### PR TITLE
Limiter: Harmonize interface

### DIFF
--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -146,7 +146,7 @@ namespace ryujin
       /**
        * Return the computed alpha_i value.
        */
-      Number alpha(const Number h_i);
+      Number alpha(const Number h_i) const;
 
       //@}
 
@@ -229,7 +229,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i)
+    Indicator<dim, Number>::alpha(const Number hd_i) const
     {
       using ScalarNumber = typename get_value_type<Number>::type;
 

--- a/source/euler/limiter.cc
+++ b/source/euler/limiter.cc
@@ -13,64 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template std::tuple<NUMBER, bool>
-    Limiter<1, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 3> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
-    template std::tuple<NUMBER, bool>
-    Limiter<2, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 3> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
-    template std::tuple<NUMBER, bool>
-    Limiter<3, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 3> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
+    template class Limiter<1, NUMBER>;
+    template class Limiter<2, NUMBER>;
+    template class Limiter<3, NUMBER>;
 
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<1, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 3> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<2, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 3> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<3, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 3> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-
+    template class Limiter<1, dealii::VectorizedArray<NUMBER>>;
+    template class Limiter<2, dealii::VectorizedArray<NUMBER>>;
+    template class Limiter<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -102,7 +102,7 @@ namespace ryujin
        *     // ...
        *     limiter.accumulate(js, U_j, pre_j, scaled_c_ij, beta_ij);
        *   }
-       *   limiter.apply_relaxation(hd_i, limiter_relaxation_factor_);
+       *   limiter.apply_relaxation(hd_i);
        *   limiter.bounds();
        * }
        * ```
@@ -124,9 +124,15 @@ namespace ryujin
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values)
+                  &precomputed_values,
+            const ScalarNumber relaxation_factor,
+            const ScalarNumber newton_tolerance,
+            const unsigned int newton_max_iter)
           : hyperbolic_system(hyperbolic_system)
           , precomputed_values(precomputed_values)
+          , relaxation_factor(relaxation_factor)
+          , newton_tolerance(newton_tolerance)
+          , newton_max_iter(newton_max_iter)
       {
       }
 
@@ -150,8 +156,7 @@ namespace ryujin
       /**
        * Apply relaxation.
        */
-      void apply_relaxation(const Number hd_i,
-                            const ScalarNumber factor = ScalarNumber(2.));
+      void apply_relaxation(const Number hd_i);
 
       /**
        * Return the computed bounds.
@@ -177,12 +182,9 @@ namespace ryujin
        * due to round-off errors when computing the limiter bounds.
        */
       std::tuple<Number, bool>
-      limit(const HyperbolicSystemView &hyperbolic_system,
-            const Bounds &bounds,
+      limit(const Bounds &bounds,
             const state_type &U,
             const state_type &P,
-            const ScalarNumber newton_tolerance,
-            const unsigned int newton_max_iter,
             const Number t_min = Number(0.),
             const Number t_max = Number(1.));
       //*}
@@ -203,14 +205,18 @@ namespace ryujin
                              const state_type &U);
 
     private:
-      //*}
-      /** @name */
+      //@}
+      /** @name Arguments and internal fields */
       //@{
 
       const HyperbolicSystemView hyperbolic_system;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
+
+      ScalarNumber relaxation_factor;
+      ScalarNumber newton_tolerance;
+      unsigned int newton_max_iter;
 
       state_type U_i;
 
@@ -290,7 +296,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Limiter<dim, Number>::apply_relaxation(Number hd_i, ScalarNumber factor)
+    Limiter<dim, Number>::apply_relaxation(Number hd_i)
     {
       auto &[rho_min, rho_max, s_min] = bounds_;
 
@@ -301,7 +307,7 @@ namespace ryujin
         r_i = dealii::Utilities::fixed_power<3>(std::sqrt(r_i)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                               //
         r_i = dealii::Utilities::fixed_power<3>(r_i);            // in 1D: ^ 3/2
-      r_i *= factor;
+      r_i *= relaxation_factor;
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       const Number rho_relaxation =

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -97,11 +97,10 @@ namespace ryujin
        * Limiter<dim, Number> limiter;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i);
+       *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_i, U_j, pre_i, pre_j, scaled_c_ij,
-       * beta_ij);
+       *     limiter.accumulate(js, U_j, pre_j, scaled_c_ij, beta_ij);
        *   }
        *   limiter.apply_relaxation(hd_i, limiter_relaxation_factor_);
        *   limiter.bounds();
@@ -134,16 +133,16 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int i, const state_type &U_i);
+      void reset(const unsigned int i,
+                 const state_type &U_i,
+                 const flux_contribution_type &flux_i);
 
       /**
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
       void accumulate(const unsigned int *js,
-                      const state_type &U_i,
                       const state_type &U_j,
-                      const flux_contribution_type &flux_i,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
                       const Number beta_ij);
@@ -213,6 +212,8 @@ namespace ryujin
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
 
+      state_type U_i;
+
       Bounds bounds_;
 
       Number rho_relaxation_numerator;
@@ -229,8 +230,11 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
     Limiter<dim, Number>::reset(const unsigned int /*i*/,
-                                const state_type & /*U_i*/)
+                                const state_type &new_U_i,
+                                const flux_contribution_type & /*new_flux_i*/)
     {
+      U_i = new_U_i;
+
       /* Bounds: */
 
       auto &[rho_min, rho_max, s_min] = bounds_;
@@ -250,9 +254,7 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void Limiter<dim, Number>::accumulate(
         const unsigned int *js,
-        const state_type &U_i,
         const state_type &U_j,
-        const flux_contribution_type & /*flux_i*/,
         const flux_contribution_type & /*flux_j*/,
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
         const Number beta_ij)

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -176,7 +176,7 @@ namespace ryujin
        * high-order update are within bounds. The latter might be violated
        * due to round-off errors when computing the limiter bounds.
        */
-      static std::tuple<Number, bool>
+      std::tuple<Number, bool>
       limit(const HyperbolicSystemView &hyperbolic_system,
             const Bounds &bounds,
             const state_type &U,

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -102,8 +102,7 @@ namespace ryujin
        *     // ...
        *     limiter.accumulate(js, U_j, pre_j, scaled_c_ij, beta_ij);
        *   }
-       *   limiter.apply_relaxation(hd_i);
-       *   limiter.bounds();
+       *   limiter.bounds(hd_i);
        * }
        * ```
        */
@@ -125,9 +124,9 @@ namespace ryujin
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
                   &precomputed_values,
-            const ScalarNumber relaxation_factor,
-            const ScalarNumber newton_tolerance,
-            const unsigned int newton_max_iter)
+              const ScalarNumber relaxation_factor,
+              const ScalarNumber newton_tolerance,
+              const unsigned int newton_max_iter)
           : hyperbolic_system(hyperbolic_system)
           , precomputed_values(precomputed_values)
           , relaxation_factor(relaxation_factor)
@@ -154,14 +153,9 @@ namespace ryujin
                       const Number beta_ij);
 
       /**
-       * Apply relaxation.
+       * Return the computed bounds (with relaxation applied).
        */
-      void apply_relaxation(const Number hd_i);
-
-      /**
-       * Return the computed bounds.
-       */
-      const Bounds &bounds() const;
+      Bounds bounds(const Number hd_i) const;
 
       //*}
       /** @name Convex limiter */
@@ -181,12 +175,11 @@ namespace ryujin
        * high-order update are within bounds. The latter might be violated
        * due to round-off errors when computing the limiter bounds.
        */
-      std::tuple<Number, bool>
-      limit(const Bounds &bounds,
-            const state_type &U,
-            const state_type &P,
-            const Number t_min = Number(0.),
-            const Number t_max = Number(1.));
+      std::tuple<Number, bool> limit(const Bounds &bounds,
+                                     const state_type &U,
+                                     const state_type &P,
+                                     const Number t_min = Number(0.),
+                                     const Number t_max = Number(1.));
       //*}
       /**
        * @name Verify invariant domain property
@@ -295,10 +288,11 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void
-    Limiter<dim, Number>::apply_relaxation(Number hd_i)
+    DEAL_II_ALWAYS_INLINE inline auto
+    Limiter<dim, Number>::bounds(const Number hd_i) const -> Bounds
     {
-      auto &[rho_min, rho_max, s_min] = bounds_;
+      auto relaxed_bounds = bounds_;
+      auto &[rho_min, rho_max, s_min] = relaxed_bounds;
 
       /* Use r_i = factor * (m_i / |Omega|) ^ (1.5 / d): */
 
@@ -321,14 +315,8 @@ namespace ryujin
 
       s_min = std::max((Number(1.) - r_i) * s_min,
                        Number(2.) * s_min - s_interp_max);
-    }
 
-
-    template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline const typename Limiter<dim, Number>::Bounds &
-    Limiter<dim, Number>::bounds() const
-    {
-      return bounds_;
+      return relaxed_bounds;
     }
 
 

--- a/source/euler/limiter.template.h
+++ b/source/euler/limiter.template.h
@@ -13,12 +13,9 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const HyperbolicSystemView &hyperbolic_system,
-                                const Bounds &bounds,
+    Limiter<dim, Number>::limit(const Bounds &bounds,
                                 const state_type &U,
                                 const state_type &P,
-                                const ScalarNumber newton_tolerance,
-                                const unsigned int newton_max_iter,
                                 const Number t_min /* = Number(0.) */,
                                 const Number t_max /* = Number(1.) */)
     {

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -152,7 +152,7 @@ namespace ryujin
       /**
        * Return the computed alpha_i value.
        */
-      Number alpha(const Number h_i);
+      Number alpha(const Number h_i) const;
 
       //@}
 
@@ -251,7 +251,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i)
+    Indicator<dim, Number>::alpha(const Number hd_i) const
     {
       if (!hyperbolic_system.compute_strict_bounds())
         return Number(0.);

--- a/source/euler_aeos/limiter.cc
+++ b/source/euler_aeos/limiter.cc
@@ -13,64 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template std::tuple<NUMBER, bool>
-    Limiter<1, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 4> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
-    template std::tuple<NUMBER, bool>
-    Limiter<2, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 4> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
-    template std::tuple<NUMBER, bool>
-    Limiter<3, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 4> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
+    template class Limiter<1, NUMBER>;
+    template class Limiter<2, NUMBER>;
+    template class Limiter<3, NUMBER>;
 
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<1, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 4> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<2, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 4> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<3, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 4> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-
+    template class Limiter<1, dealii::VectorizedArray<NUMBER>>;
+    template class Limiter<2, dealii::VectorizedArray<NUMBER>>;
+    template class Limiter<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -178,7 +178,7 @@ namespace ryujin
        * high-order update are within bounds. The latter might be violated
        * due to round-off errors when computing the limiter bounds.
        */
-      static std::tuple<Number, bool>
+      std::tuple<Number, bool>
       limit(const HyperbolicSystemView &hyperbolic_system,
             const Bounds &bounds,
             const state_type &U,

--- a/source/euler_aeos/limiter.template.h
+++ b/source/euler_aeos/limiter.template.h
@@ -13,12 +13,9 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const HyperbolicSystemView &hyperbolic_system,
-                                const Bounds &bounds,
+    Limiter<dim, Number>::limit(const Bounds &bounds,
                                 const state_type &U,
                                 const state_type &P,
-                                const ScalarNumber newton_tolerance,
-                                const unsigned int newton_max_iter,
                                 const Number t_min /* = Number(0.) */,
                                 const Number t_max /* = Number(1.) */)
     {

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -684,8 +684,8 @@ namespace ryujin
           }
 
           const auto hd_i = m_i * measure_of_omega_inverse;
-          limiter.apply_relaxation(hd_i);
-          bounds_.template write_tensor<T>(limiter.bounds(), i);
+          const auto relaxed_bounds = limiter.bounds(hd_i);
+          bounds_.template write_tensor<T>(relaxed_bounds, i);
         }
       };
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -547,7 +547,7 @@ namespace ryujin
           const auto m_i = load_value<T>(lumped_mass_matrix, i);
           const auto m_i_inv = load_value<T>(lumped_mass_matrix_inverse, i);
 
-          limiter.reset(i, U_i);
+          limiter.reset(i, U_i, flux_i);
 
           /* Sources: */
           state_type S_i_new;
@@ -613,8 +613,7 @@ namespace ryujin
               P_ij += (d_ijH - d_ij) * (U_j - U_i);
             }
 
-            limiter.accumulate(
-                js, U_i, U_j, flux_i, flux_j, d_ij_inv * c_ij, beta_ij);
+            limiter.accumulate(js, U_j, flux_j, d_ij_inv * c_ij, beta_ij);
 
             /*
              * Compute high-order fluxes:
@@ -781,7 +780,7 @@ namespace ryujin
             }
 
             /*
-             * Compute limiter bounds:
+             * Compute limiter coefficients:
              */
 
             const auto &[l_ij, success] =

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -718,6 +718,8 @@ namespace ryujin
         using View = typename HyperbolicSystem::template View<dim, T>;
 
         /* Stored thread locally: */
+        using Limiter = typename Description::template Limiter<dim, T>;
+        Limiter limiter(*hyperbolic_system_, new_precomputed);
         bool thread_ready = false;
 
         RYUJIN_OMP_FOR
@@ -784,13 +786,12 @@ namespace ryujin
              */
 
             const auto &[l_ij, success] =
-                Description::template Limiter<dim, T>::limit(
-                    *hyperbolic_system_,
-                    bounds,
-                    U_i_new,
-                    P_ij,
-                    limiter_newton_tolerance_,
-                    limiter_newton_max_iter_);
+                limiter.limit(*hyperbolic_system_,
+                              bounds,
+                              U_i_new,
+                              P_ij,
+                              limiter_newton_tolerance_,
+                              limiter_newton_max_iter_);
             lij_matrix_.template write_entry<T>(l_ij, i, col_idx, true);
 
             /*
@@ -857,6 +858,8 @@ namespace ryujin
 
         /* Stored thread locally: */
         AlignedVector<T> lij_row;
+        using Limiter = typename Description::template Limiter<dim, T>;
+        Limiter limiter(*hyperbolic_system_, new_precomputed);
         bool thread_ready = false;
 
         RYUJIN_OMP_FOR
@@ -928,13 +931,12 @@ namespace ryujin
                 pij_matrix_.template get_tensor<T>(i, col_idx);
 
             const auto &[new_l_ij, success] =
-                Description::template Limiter<dim, T>::limit(
-                    *hyperbolic_system_,
-                    bounds,
-                    U_i_new,
-                    new_p_ij,
-                    limiter_newton_tolerance_,
-                    limiter_newton_max_iter_);
+                limiter.limit(*hyperbolic_system_,
+                              bounds,
+                              U_i_new,
+                              new_p_ij,
+                              limiter_newton_tolerance_,
+                              limiter_newton_max_iter_);
 
             /*
              * This is the second pass of the limiter. Under rare

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -101,7 +101,7 @@ namespace ryujin
       /**
        * Return the computed alpha_i value.
        */
-      Number alpha(const Number h_i);
+      Number alpha(const Number h_i) const;
 
       //@}
 
@@ -174,7 +174,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i)
+    Indicator<dim, Number>::alpha(const Number hd_i) const
     {
       Number numerator = left - right;
       Number denominator = std::abs(left) + std::abs(right);

--- a/source/scalar_conservation/limiter.cc
+++ b/source/scalar_conservation/limiter.cc
@@ -13,64 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template std::tuple<NUMBER, bool>
-    Limiter<1, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 2> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
-    template std::tuple<NUMBER, bool>
-    Limiter<2, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 2> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
-    template std::tuple<NUMBER, bool>
-    Limiter<3, NUMBER>::limit(const HyperbolicSystemView &,
-                              const std::array<NUMBER, 2> &,
-                              const state_type &,
-                              const state_type &,
-                              const NUMBER,
-                              const unsigned int,
-                              const NUMBER,
-                              const NUMBER);
+    template class Limiter<1, NUMBER>;
+    template class Limiter<2, NUMBER>;
+    template class Limiter<3, NUMBER>;
 
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<1, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 2> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<2, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 2> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-    template std::tuple<VectorizedArray<NUMBER>, bool>
-    Limiter<3, VectorizedArray<NUMBER>>::limit(
-        const HyperbolicSystemView &,
-        const std::array<VectorizedArray<NUMBER>, 2> &,
-        const state_type &,
-        const state_type &,
-        const NUMBER,
-        const unsigned int,
-        const VectorizedArray<NUMBER>,
-        const VectorizedArray<NUMBER>);
-
+    template class Limiter<1, dealii::VectorizedArray<NUMBER>>;
+    template class Limiter<2, dealii::VectorizedArray<NUMBER>>;
+    template class Limiter<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace ScalarConservation
 } // namespace ryujin

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -131,7 +131,7 @@ namespace ryujin
        * obeying \f$t_{\text{min}} < t < t_{\text{max}}\f$, such that the
        * selected local minimum principles are obeyed.
        */
-      static std::tuple<Number, bool>
+      std::tuple<Number, bool>
       limit(const HyperbolicSystemView &hyperbolic_system,
             const Bounds &bounds,
             const state_type &U,

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -60,11 +60,10 @@ namespace ryujin
        * Limiter<dim, Number> limiter;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i);
+       *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_i, U_j, pre_i, pre_j, scaled_c_ij,
-       * beta_ij);
+       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, beta_ij);
        *   }
        *   limiter.apply_relaxation(hd_i, limiter_relaxation_factor_);
        *   limiter.bounds();
@@ -97,16 +96,16 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int /*i*/, const state_type & /*U_i*/);
+      void reset(const unsigned int i,
+                 const state_type &U_i,
+                 const flux_contribution_type &flux_i);
 
       /**
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
       void accumulate(const unsigned int *js,
-                      const state_type &U_i,
                       const state_type &U_j,
-                      const flux_contribution_type &flux_i,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
                       const Number beta_ij);
@@ -168,6 +167,9 @@ namespace ryujin
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
 
+      state_type U_i;
+      flux_contribution_type flux_i;
+
       Bounds bounds_;
 
       Number u_relaxation_numerator;
@@ -186,8 +188,12 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
     Limiter<dim, Number>::reset(const unsigned int /*i*/,
-                                const state_type & /*U_i*/)
+                                const state_type &new_U_i,
+                                const flux_contribution_type &new_flux_i)
     {
+      U_i = new_U_i;
+      flux_i = new_flux_i;
+
       /* Bounds: */
 
       auto &[u_min, u_max] = bounds_;
@@ -205,9 +211,7 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void Limiter<dim, Number>::accumulate(
         const unsigned int * /*js*/,
-        const state_type &U_i,
         const state_type &U_j,
-        const flux_contribution_type &flux_i,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
         const Number beta_ij)

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -65,7 +65,7 @@ namespace ryujin
        *     // ...
        *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, beta_ij);
        *   }
-       *   limiter.apply_relaxation(hd_i, limiter_relaxation_factor_);
+       *   limiter.apply_relaxation(hd_i);
        *   limiter.bounds();
        * }
        * ```
@@ -87,9 +87,15 @@ namespace ryujin
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values)
+                  &precomputed_values,
+            const ScalarNumber relaxation_factor,
+            const ScalarNumber newton_tolerance,
+            const unsigned int newton_max_iter)
           : hyperbolic_system(hyperbolic_system)
           , precomputed_values(precomputed_values)
+          , relaxation_factor(relaxation_factor)
+          , newton_tolerance(newton_tolerance)
+          , newton_max_iter(newton_max_iter)
       {
       }
 
@@ -113,8 +119,7 @@ namespace ryujin
       /**
        * Apply relaxation.
        */
-      void apply_relaxation(const Number hd_i,
-                            const ScalarNumber factor = ScalarNumber(2.));
+      void apply_relaxation(const Number hd_i);
 
       /**
        * Return the computed bounds.
@@ -132,12 +137,9 @@ namespace ryujin
        * selected local minimum principles are obeyed.
        */
       std::tuple<Number, bool>
-      limit(const HyperbolicSystemView &hyperbolic_system,
-            const Bounds &bounds,
+      limit(const Bounds &bounds,
             const state_type &U,
             const state_type &P,
-            const ScalarNumber newton_tolerance,
-            const unsigned int newton_max_iter,
             const Number t_min = Number(0.),
             const Number t_max = Number(1.));
 
@@ -159,13 +161,17 @@ namespace ryujin
                              const state_type & /*U*/);
 
     private:
-      //*}
-      /** @name */
+      //@}
+      /** @name Arguments and internal fields */
       //@{
       const HyperbolicSystemView hyperbolic_system;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
+
+      ScalarNumber relaxation_factor;
+      ScalarNumber newton_tolerance;
+      unsigned int newton_max_iter;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -243,7 +249,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Limiter<dim, Number>::apply_relaxation(Number hd_i, ScalarNumber factor)
+    Limiter<dim, Number>::apply_relaxation(Number hd_i)
     {
       auto &[u_min, u_max] = bounds_;
 
@@ -254,7 +260,7 @@ namespace ryujin
         r_i = dealii::Utilities::fixed_power<3>(std::sqrt(r_i)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                               //
         r_i = dealii::Utilities::fixed_power<3>(r_i);            // in 1D: ^ 3/2
-      r_i *= factor;
+      r_i *= relaxation_factor;
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       const Number u_relaxation =

--- a/source/scalar_conservation/limiter.template.h
+++ b/source/scalar_conservation/limiter.template.h
@@ -13,12 +13,9 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const HyperbolicSystemView &hyperbolic_system,
-                                const Bounds &bounds,
+    Limiter<dim, Number>::limit(const Bounds &bounds,
                                 const state_type &U,
                                 const state_type &P,
-                                const ScalarNumber /*newton_tolerance*/,
-                                const unsigned int /*newton_max_iter*/,
                                 const Number t_min /* = Number(0.) */,
                                 const Number t_max /* = Number(1.) */)
     {

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -107,7 +107,7 @@ namespace ryujin
       /**
        * Return the computed alpha_i value.
        */
-      Number alpha(const Number h_i);
+      Number alpha(const Number h_i) const;
 
       //@}
 
@@ -184,7 +184,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i)
+    Indicator<dim, Number>::alpha(const Number hd_i) const
     {
       using ScalarNumber = typename get_value_type<Number>::type;
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -138,7 +138,7 @@ namespace ryujin
        * obeying \f$t_{\text{min}} < t < t_{\text{max}}\f$, such that the
        * selected local minimum principles are obeyed.
        */
-      static std::tuple<Number, bool>
+      std::tuple<Number, bool>
       limit(const HyperbolicSystem &hyperbolic_system,
             const Bounds &bounds,
             const state_type &U,

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -72,8 +72,7 @@ namespace ryujin
        *     limiter.accumulate(js, U_i, U_j, pre_i, pre_j, scaled_c_ij,
        * beta_ij);
        *   }
-       *   limiter.apply_relaxation(hd_i);
-       *   limiter.bounds();
+       *   limiter.bounds(hd_i);
        * }
        * ```
        */
@@ -95,9 +94,9 @@ namespace ryujin
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
                   &precomputed_values,
-            const ScalarNumber relaxation_factor,
-            const ScalarNumber newton_tolerance,
-            const unsigned int newton_max_iter)
+              const ScalarNumber relaxation_factor,
+              const ScalarNumber newton_tolerance,
+              const unsigned int newton_max_iter)
           : hyperbolic_system(hyperbolic_system)
           , precomputed_values(precomputed_values)
           , relaxation_factor(relaxation_factor)
@@ -129,9 +128,9 @@ namespace ryujin
       void apply_relaxation(const Number hd_i);
 
       /**
-       * Return the computed bounds.
+       * Return the computed bounds (with relaxation applied).
        */
-      const Bounds &bounds() const;
+      const Bounds bounds(const Number hd_i) const;
 
       //*}
       /** @name Convex limiter */
@@ -143,12 +142,11 @@ namespace ryujin
        * obeying \f$t_{\text{min}} < t < t_{\text{max}}\f$, such that the
        * selected local minimum principles are obeyed.
        */
-      std::tuple<Number, bool>
-      limit(const Bounds &bounds,
-            const state_type &U,
-            const state_type &P,
-            const Number t_min = Number(0.),
-            const Number t_max = Number(1.));
+      std::tuple<Number, bool> limit(const Bounds &bounds,
+                                     const state_type &U,
+                                     const state_type &P,
+                                     const Number t_min = Number(0.),
+                                     const Number t_max = Number(1.));
       //*}
       /**
        * @name Verify invariant domain property

--- a/source/shallow_water/limiter.template.h
+++ b/source/shallow_water/limiter.template.h
@@ -13,12 +13,9 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const HyperbolicSystem &hyperbolic_system,
-                                const Bounds &bounds,
+    Limiter<dim, Number>::limit(const Bounds &bounds,
                                 const state_type &U,
                                 const state_type &P,
-                                const ScalarNumber newton_tolerance,
-                                const unsigned int /* newton_max_iter */,
                                 const Number t_min /* = Number(0.) */,
                                 const Number t_max /* = Number(1.) */)
     {

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -106,7 +106,7 @@ namespace ryujin
       /**
        * Return the computed alpha_i value.
        */
-      Number alpha(const Number /*h_i*/)
+      Number alpha(const Number /*h_i*/) const
       {
         return Number(0.);
       }

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -65,8 +65,7 @@ namespace ryujin
        *     // ...
        *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, beta_ij);
        *   }
-       *   limiter.apply_relaxation(hd_i);
-       *   limiter.bounds();
+       *   limiter.bounds(hd_i);
        * }
        * ```
        */
@@ -88,9 +87,9 @@ namespace ryujin
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
                   &precomputed_values,
-            const ScalarNumber relaxation_factor,
-            const ScalarNumber newton_tolerance,
-            const unsigned int newton_max_iter)
+              const ScalarNumber relaxation_factor,
+              const ScalarNumber newton_tolerance,
+              const unsigned int newton_max_iter)
           : hyperbolic_system(hyperbolic_system)
           , precomputed_values(precomputed_values)
           , relaxation_factor(relaxation_factor)
@@ -123,19 +122,13 @@ namespace ryujin
       }
 
       /**
-       * Apply relaxation.
+       * Return the computed bounds (with relaxation applied).
        */
-      void apply_relaxation(const Number /*hd_i*/)
+      Bounds bounds(const Number /*hd_i*/) const
       {
-        // empty
-      }
+        auto relaxed_bounds = bounds_;
 
-      /**
-       * Return the computed bounds.
-       */
-      const Bounds &bounds() const
-      {
-        return bounds_;
+        return relaxed_bounds;
       }
 
       //*}
@@ -148,12 +141,11 @@ namespace ryujin
        * obeying \f$t_{\text{min}} < t < t_{\text{max}}\f$, such that the
        * selected local minimum principles are obeyed.
        */
-      std::tuple<Number, bool>
-      limit(const Bounds & /*bounds*/,
-            const state_type & /*U*/,
-            const state_type & /*P*/,
-            const Number /*t_min*/ = Number(0.),
-            const Number t_max = Number(1.))
+      std::tuple<Number, bool> limit(const Bounds & /*bounds*/,
+                                     const state_type & /*U*/,
+                                     const state_type & /*P*/,
+                                     const Number /*t_min*/ = Number(0.),
+                                     const Number t_max = Number(1.))
       {
         return {t_max, true};
       }

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -143,7 +143,7 @@ namespace ryujin
        * obeying \f$t_{\text{min}} < t < t_{\text{max}}\f$, such that the
        * selected local minimum principles are obeyed.
        */
-      static std::tuple<Number, bool>
+      std::tuple<Number, bool>
       limit(const HyperbolicSystemView & /*hyperbolic_system*/,
             const Bounds & /*bounds*/,
             const state_type & /*U*/,

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -65,7 +65,7 @@ namespace ryujin
        *     // ...
        *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, beta_ij);
        *   }
-       *   limiter.apply_relaxation(hd_i, limiter_relaxation_factor_);
+       *   limiter.apply_relaxation(hd_i);
        *   limiter.bounds();
        * }
        * ```
@@ -87,9 +87,15 @@ namespace ryujin
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values)
+                  &precomputed_values,
+            const ScalarNumber relaxation_factor,
+            const ScalarNumber newton_tolerance,
+            const unsigned int newton_max_iter)
           : hyperbolic_system(hyperbolic_system)
           , precomputed_values(precomputed_values)
+          , relaxation_factor(relaxation_factor)
+          , newton_tolerance(newton_tolerance)
+          , newton_max_iter(newton_max_iter)
       {
       }
 
@@ -119,8 +125,7 @@ namespace ryujin
       /**
        * Apply relaxation.
        */
-      void apply_relaxation(const Number /*hd_i*/,
-                            const ScalarNumber /*factor*/)
+      void apply_relaxation(const Number /*hd_i*/)
       {
         // empty
       }
@@ -144,12 +149,9 @@ namespace ryujin
        * selected local minimum principles are obeyed.
        */
       std::tuple<Number, bool>
-      limit(const HyperbolicSystemView & /*hyperbolic_system*/,
-            const Bounds & /*bounds*/,
+      limit(const Bounds & /*bounds*/,
             const state_type & /*U*/,
             const state_type & /*P*/,
-            const ScalarNumber /*newton_tolerance*/,
-            const unsigned int /*newton_max_iter*/,
             const Number /*t_min*/ = Number(0.),
             const Number t_max = Number(1.))
       {
@@ -177,13 +179,17 @@ namespace ryujin
       }
 
     private:
-      //*}
-      /** @name */
+      //@}
+      /** @name Arguments and internal fields */
       //@{
       const HyperbolicSystemView hyperbolic_system;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
+
+      ScalarNumber relaxation_factor;
+      ScalarNumber newton_tolerance;
+      unsigned int newton_max_iter;
 
       Bounds bounds_;
       //@}

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -60,11 +60,10 @@ namespace ryujin
        * Limiter<dim, Number> limiter;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i);
+       *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_i, U_j, pre_i, pre_j, scaled_c_ij,
-       * beta_ij);
+       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, beta_ij);
        *   }
        *   limiter.apply_relaxation(hd_i, limiter_relaxation_factor_);
        *   limiter.bounds();
@@ -97,7 +96,9 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int /*i*/, const state_type & /*U_i*/)
+      void reset(const unsigned int /*i*/,
+                 const state_type & /*new_U_i*/,
+                 const flux_contribution_type & /*new_flux_i*/)
       {
         // empty
       }
@@ -107,9 +108,7 @@ namespace ryujin
        * with the neighboring state U_j.
        */
       void accumulate(const unsigned int * /*js*/,
-                      const state_type & /*U_i*/,
                       const state_type & /*U_j*/,
-                      const flux_contribution_type & /*flux_i*/,
                       const flux_contribution_type & /*flux_j*/,
                       const dealii::Tensor<1, dim, Number> & /*scaled_c_ij*/,
                       const Number & /*beta_ij*/)

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -46,7 +46,7 @@ int main()
               << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
               << bounds[2] << std::endl;
 
-    const auto &[l, success] = Limiter<dim, double>::limit(
+    const auto &[l, success] = limiter.limit(
         hyperbolic_system, bounds, U, P, newton_tolerance, newton_max_iter);
 
     std::cout << "l: " << l;

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -22,6 +22,10 @@ int main()
 
   HyperbolicSystem hyperbolic_system;
 
+  const double relaxation_factor = 1.;
+  const double newton_tolerance = 1.e-10;
+  const unsigned int newton_max_iter = 2;
+
   using state_type = HyperbolicSystem::View<dim, double>::state_type;
 
   using bounds_type = Limiter<dim, double>::Bounds;
@@ -32,30 +36,30 @@ int main()
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  Limiter<dim, double> limiter(hyperbolic_system, dummy);
+  Limiter<dim, double> limiter(hyperbolic_system,
+                               dummy,
+                               relaxation_factor,
+                               newton_tolerance,
+                               newton_max_iter);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 
-  const auto test = [&](const state_type &U,
-                        const state_type &P,
-                        const bounds_type &bounds,
-                        const double newton_tolerance,
-                        const unsigned int newton_max_iter) {
-    std::cout << "State: " << U
-              << "\nSpecific entropy: " << view.specific_entropy(U)
-              << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
-              << bounds[2] << std::endl;
+  const auto test =
+      [&](const state_type &U, const state_type &P, const bounds_type &bounds) {
+        std::cout << "State: " << U
+                  << "\nSpecific entropy: " << view.specific_entropy(U)
+                  << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
+                  << bounds[2] << std::endl;
 
-    const auto &[l, success] = limiter.limit(
-        hyperbolic_system, bounds, U, P, newton_tolerance, newton_max_iter);
+        const auto &[l, success] = limiter.limit(bounds, U, P);
 
-    std::cout << "l: " << l;
-    if (success)
-      std::cout << "\nSuccess!";
-    else
-      std::cout << "\nFailure!";
-    std::cout << std::endl;
-  };
+        std::cout << "l: " << l;
+        if (success)
+          std::cout << "\nSuccess!";
+        else
+          std::cout << "\nFailure!";
+        std::cout << std::endl;
+      };
 
   std::cout << std::setprecision(16);
   std::cout << std::scientific;
@@ -67,37 +71,37 @@ int main()
     auto U = state_type{{0.8, 1.4, 3.0}};
     auto P = state_type{{-0.1, 0.1, 0.1}};
     auto bounds = bounds_type{0.9, 1.1, 2.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum density violation (eps):" << std::endl;
     U = state_type{{0.9 - 1.0e-10, 1.4, 3.0}};
     P = state_type{{-1.0e-20, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density violation:" << std::endl;
     U = state_type{{1.2, 1.4, 3.0}};
     P = state_type{{0.1, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density violation (eps):" << std::endl;
     U = state_type{{1.1 + 1.0e-10, 1.4, 3.0}};
     P = state_type{{1.0e-20, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy violation:" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy violation (eps):" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -1.0e-20}};
     bounds = bounds_type{0.9, 1.1, 1.82 + 1.e-10};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
   }
 
   {
@@ -107,37 +111,37 @@ int main()
     auto U = state_type{{1.0, 1.4, 3.0}};
     auto P = state_type{{-0.2, 0.1, 0.1}};
     auto bounds = bounds_type{0.9, 1.1, 2.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum density bound (eps):" << std::endl;
     U = state_type{{0.9 + 1.0e-10, 1.4, 3.0}};
     P = state_type{{-5.0e-10, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density bound" << std::endl;
     U = state_type{{1.0, 1.4, 3.0}};
     P = state_type{{0.2, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 1.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density bound (eps):" << std::endl;
     U = state_type{{1.1 - 1.0e-10, 1.4, 3.0}};
     P = state_type{{5.0e-10, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 1.0};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy bound" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -0.3}};
     bounds = bounds_type{0.9, 1.1, 1.8};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy bound (eps):" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -4.0e-10}};
     bounds = bounds_type{0.9, 1.1, 1.82 - 1.e-10};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
   }
 
   return 0;

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -62,23 +62,22 @@ int main()
 
   constexpr double gamma = 1.4;
 
-  const auto test = [&](const state_type &U,
-                        const state_type &P,
-                        const bounds_type &bounds) {
-    std::cout << "State: " << U << "\nSpecific entropy: "
-              << view.surrogate_specific_entropy(U, gamma)
-              << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
-              << bounds[2] << std::endl;
+  const auto test =
+      [&](const state_type &U, const state_type &P, const bounds_type &bounds) {
+        std::cout << "State: " << U << "\nSpecific entropy: "
+                  << view.surrogate_specific_entropy(U, gamma)
+                  << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
+                  << bounds[2] << std::endl;
 
-    const auto &[l, success] = limiter.limit(bounds, U, P);
+        const auto &[l, success] = limiter.limit(bounds, U, P);
 
-    std::cout << "l: " << l;
-    if (success)
-      std::cout << "\nSuccess!";
-    else
-      std::cout << "\nFailure!";
-    std::cout << std::endl;
-  };
+        std::cout << "l: " << l;
+        if (success)
+          std::cout << "\nSuccess!";
+        else
+          std::cout << "\nFailure!";
+        std::cout << std::endl;
+      };
 
   std::cout << std::setprecision(16);
   std::cout << std::scientific;

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -64,7 +64,7 @@ int main()
               << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
               << bounds[2] << std::endl;
 
-    const auto &[l, success] = Limiter<dim, double>::limit(
+    const auto &[l, success] = limiter.limit(
         hyperbolic_system, bounds, U, P, newton_tolerance, newton_max_iter);
 
     std::cout << "l: " << l;

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -22,6 +22,10 @@ int main()
 
   HyperbolicSystem hyperbolic_system;
 
+  const double relaxation_factor = 1.;
+  const double newton_tolerance = 1.e-10;
+  const unsigned int newton_max_iter = 2;
+
   const auto set_covolume = [&](const double covolume) {
     /*
      * Set the interpolatory covolume by selecting an equation of state
@@ -48,7 +52,11 @@ int main()
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  Limiter<dim, double> limiter(hyperbolic_system, dummy);
+  Limiter<dim, double> limiter(hyperbolic_system,
+                               dummy,
+                               relaxation_factor,
+                               newton_tolerance,
+                               newton_max_iter);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 
@@ -56,16 +64,13 @@ int main()
 
   const auto test = [&](const state_type &U,
                         const state_type &P,
-                        const bounds_type &bounds,
-                        const double newton_tolerance,
-                        const unsigned int newton_max_iter) {
+                        const bounds_type &bounds) {
     std::cout << "State: " << U << "\nSpecific entropy: "
               << view.surrogate_specific_entropy(U, gamma)
               << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
               << bounds[2] << std::endl;
 
-    const auto &[l, success] = limiter.limit(
-        hyperbolic_system, bounds, U, P, newton_tolerance, newton_max_iter);
+    const auto &[l, success] = limiter.limit(bounds, U, P);
 
     std::cout << "l: " << l;
     if (success)
@@ -85,37 +90,37 @@ int main()
     auto U = state_type{{0.8, 1.4, 3.0}};
     auto P = state_type{{-0.1, 0.1, 0.1}};
     auto bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum density violation (eps):" << std::endl;
     U = state_type{{0.9 - 1.0e-10, 1.4, 3.0}};
     P = state_type{{-1.0e-20, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density violation:" << std::endl;
     U = state_type{{1.2, 1.4, 3.0}};
     P = state_type{{0.1, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density violation (eps):" << std::endl;
     U = state_type{{1.1 + 1.0e-10, 1.4, 3.0}};
     P = state_type{{1.0e-20, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy violation:" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy violation (eps):" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -1.0e-20}};
     bounds = bounds_type{0.9, 1.1, 1.82 + 1.e-10, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
   }
 
   {
@@ -125,37 +130,37 @@ int main()
     auto U = state_type{{1.0, 1.4, 3.0}};
     auto P = state_type{{-0.2, 0.1, 0.1}};
     auto bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum density bound (eps):" << std::endl;
     U = state_type{{0.9 + 1.0e-10, 1.4, 3.0}};
     P = state_type{{-5.0e-10, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density bound" << std::endl;
     U = state_type{{1.0, 1.4, 3.0}};
     P = state_type{{0.2, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 1.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density bound (eps):" << std::endl;
     U = state_type{{1.1 - 1.0e-10, 1.4, 3.0}};
     P = state_type{{5.0e-10, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 1.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy bound" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -0.3}};
     bounds = bounds_type{0.9, 1.1, 1.8, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy bound (eps):" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -4.0e-10}};
     bounds = bounds_type{0.9, 1.1, 1.82 - 1.e-10, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
   }
 
   {
@@ -169,37 +174,37 @@ int main()
     auto U = state_type{{1.0, 1.4, 3.0}};
     auto P = state_type{{-0.2, 0.1, 0.1}};
     auto bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum density bound (eps):" << std::endl;
     U = state_type{{0.9 + 1.0e-10, 1.4, 3.0}};
     P = state_type{{-5.0e-10, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 2.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density bound" << std::endl;
     U = state_type{{1.0, 1.4, 3.0}};
     P = state_type{{0.2, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 1.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMaximum density bound (eps):" << std::endl;
     U = state_type{{1.1 - 1.0e-10, 1.4, 3.0}};
     P = state_type{{5.0e-10, 0.1, 0.1}};
     bounds = bounds_type{0.9, 1.1, 1.0, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy bound" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -0.3}};
     bounds = bounds_type{0.9, 1.1, 1.7, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     std::cout << "\nMinimum entropy bound (eps):" << std::endl;
     U = state_type{{1.0, 1.4, 2.8}};
     P = state_type{{0.1, 0.1, -4.0e-10}};
     bounds = bounds_type{0.9, 1.1, 1.7448913582358123 - 1.e-10, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
   }
 
   {
@@ -215,7 +220,7 @@ int main()
     auto U = state_type{{4.5, 1.4, 100000.0}};
     auto P = state_type{{1.0, 0.1, 0.1}};
     auto bounds = bounds_type{0.9, rho_limit, 1.6, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
 
     rho_max = 1 / b - 1.0e-3;
     rho_limit = (gamma + 1) * rho_max / (gamma - 1 + 2 * b * rho_max);
@@ -223,7 +228,7 @@ int main()
     U = state_type{{4.5, 1.4, 500.0}};
     P = state_type{{1.0, 0.1, 0.1}};
     bounds = bounds_type{0.9, rho_limit, 1.6, gamma};
-    test(U, P, bounds, 1.e-10, 2);
+    test(U, P, bounds);
   }
 
   return 0;


### PR DESCRIPTION
This pull request tries to bring the `Limiter::reset()`, `Limiter::accumulate()`, `Limiter::bounds()` functions closer to the other ones (for indicator and Riemann solver). Passes the testsuite and I don't see a change in performance.