### PR TITLE
`OfflineData`: collect coupling boundary pairs over full locally relevant index set

### DIFF
--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -312,6 +312,16 @@ namespace ryujin
         const ITERATOR1 &begin,
         const ITERATOR2 &end,
         const dealii::Utilities::MPI::Partitioner &partitioner) const;
+
+    /**
+     * Collect coupling pairs of locally owned (and locally relevant)
+     * boundary degrees of freedom.
+     */
+    template <typename ITERATOR1, typename ITERATOR2>
+    coupling_boundary_pairs_type collect_coupling_boundary_pairs(
+        const ITERATOR1 &begin,
+        const ITERATOR2 &end,
+        const dealii::Utilities::MPI::Partitioner &partitioner) const;
   };
 
 } /* namespace ryujin */


### PR DESCRIPTION
In reference to #40 and #41. This modification ensures that we always symmetrize the `d_ij` matrix appropriately.

Note this has probably been wrong for a long time: we forgot to symmetrize `d_ij` and `d_ji` components at the boundary when i is a locally owned but j is only a locally relevant degree of freedom. This seems to work by accident for structured, uniform meshes - we thus never saw this issue in any of our test configurations.

Part of #44 