### PR TITLE
Modify loop for indicator.accumulate()

### DIFF
--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -337,7 +337,6 @@ namespace ryujin
 
           indicator.reset(i, U_i);
 
-          /* Don't skip diagonal for indicator */
           const unsigned int *js = sparsity_simd.columns(i);
           for (unsigned int col_idx = 0; col_idx < row_length;
                ++col_idx, js += stride_size) {
@@ -348,7 +347,10 @@ namespace ryujin
 
             indicator.accumulate(js, U_j, c_ij);
 
-            /* Then skip diagonal. If col_idx == 0, we continue. */
+            /* Skip diagonal. */
+            if (col_idx == 0)
+              continue;
+
             /* Only iterate over the upper triangular portion of d_ij */
             if (all_below_diagonal<T>(i, js))
               continue;

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -337,9 +337,9 @@ namespace ryujin
 
           indicator.reset(i, U_i);
 
-          /* Skip diagonal. */
-          const unsigned int *js = sparsity_simd.columns(i) + stride_size;
-          for (unsigned int col_idx = 1; col_idx < row_length;
+          /* Don't skip diagonal for indicator */
+          const unsigned int *js = sparsity_simd.columns(i);
+          for (unsigned int col_idx = 0; col_idx < row_length;
                ++col_idx, js += stride_size) {
 
             const auto U_j = old_U.template get_tensor<T>(js);
@@ -348,6 +348,7 @@ namespace ryujin
 
             indicator.accumulate(js, U_j, c_ij);
 
+            /* Then skip diagonal. If col_idx == 0, we continue. */
             /* Only iterate over the upper triangular portion of d_ij */
             if (all_below_diagonal<T>(i, js))
               continue;

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.output
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.output
@@ -8,9 +8,9 @@
 [INFO] scheduling output
 [INFO] scheduling output
 [INFO] scheduling output
-Normalized consolidated Linf, L1, and L2 errors at final time 
-#dofs = 4225
-t     = 2.002751001291742
-Linf  = 0.03574448813100288
-L1    = 0.0006330576515184822
-L2    = 0.003423352366914714
+Normalized consolidated Linf, L1, and L2 errors at final time
+#dofs = 513
+t     = 1.000593578808362
+Linf  = 2.073541977120867e-14
+L1    = 3.827527652098191e-15
+L2    = 4.904868710241667e-15

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.prm
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.prm
@@ -1,0 +1,94 @@
+##
+#
+# Shallow water benchmark
+#
+# A 1D benchmark configuration consisting of a steady flow over an inclined 
+# plane with Manning's friction. See section 4.1 of [1] for details.
+#
+# This configuration uses an explicit ERK(3, 3, 1) timestepping. Expected
+# results are reported in shallow_water-steady_inclinde_1d-erk33-l9.baseline
+#
+# [1] Chertock, Alina, et al. "Well‐balanced positivity preserving 
+#     central‐upwind scheme for the shallow water system with friction terms." 
+#     International Journal for numerical methods in fluids 
+#     78.6 (2015): 355-383.
+##
+
+subsection A - TimeLoop
+  set basename                      = steady_incline_1d-erk33-l9
+
+  set final time                    = 1
+  set enable output full            = true
+  set output granularity            = 1
+
+  set enable compute error          = true
+  set error quantities              = h, m
+  set error normalize               = true
+
+  set terminal update interval      = 0
+
+end
+
+subsection B - Equation
+  set dimension                    = 1
+  set equation                     = shallow water
+
+  set gravity                      = 9.81
+  set manning friction coefficient = 1.e-2
+
+  set limiter kinetic energy       = false
+  set limiter square velocity      = true
+  
+  set reference water depth        = 1
+  set dry state relaxation large   = 1e4
+  set dry state relaxation small   = 1e4
+end
+
+subsection C - Discretization
+  set geometry            = rectangular domain
+  set mesh refinement     = 9
+
+  subsection rectangular domain
+    set boundary condition left   = dynamic
+    set boundary condition right  = dynamic
+    set position bottom left      = 0
+    set position top right        = 20
+  end
+end
+
+subsection E - InitialValues
+
+  set configuration = sloping friction
+  set position      = 0
+
+  subsection sloping friction
+   set ramp slope        = 1.e-2
+   set initial discharge = 1.e-1
+  end
+
+end
+
+subsection F - HyperbolicModule
+  set cfl with boundary dofs        = false
+  set indicator evc factor          = 1
+  set limiter iterations            = 2
+  set limiter newton max iterations = 2
+  set limiter newton tolerance      = 1e-10
+  set limiter relaxation factor     = 2
+end
+
+subsection H - TimeIntegrator
+  set cfl max               = 0.50
+  set cfl min               = 0.50
+  set cfl recovery strategy = none
+  set time stepping scheme  = erk 33
+end
+
+subsection I - VTUOutput
+  set manifolds                  = 
+  set schlieren beta             = 10
+  set schlieren quantities       = h
+  set schlieren recompute bounds = true
+  set use mpi io                 = true
+  set vtu output quantities      = h, m, bathymetry, alpha, eta_m
+end

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.prm
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.prm
@@ -6,7 +6,7 @@
 # plane with Manning's friction. See section 4.1 of [1] for details.
 #
 # This configuration uses an explicit ERK(3, 3, 1) timestepping. Expected
-# results are reported in shallow_water-steady_inclinde_1d-erk33-l9.baseline
+# results are reported in shallow_water-steady_incline_1d-erk33-l9.baseline
 #
 # [1] Chertock, Alina, et al. "Well‐balanced positivity preserving 
 #     central‐upwind scheme for the shallow water system with friction terms." 


### PR DESCRIPTION
Modify loop where indicator.accumulate() happens to compute correct values at the boundary. Had to modify a previous shallow water test. Also added a new test for this bug.