### PR TITLE
Refactor runtime parameters

### DIFF
--- a/prm/benchmarks/navier_stokes-daru-tenaud-shocktube.prm
+++ b/prm/benchmarks/navier_stokes-daru-tenaud-shocktube.prm
@@ -81,12 +81,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = true
-
-  set limiter iterations = 2
-end
-
 subsection G - ParabolicModule
   set tolerance                              = 1e-10
   set tolerance linfty norm                  = false

--- a/prm/benchmarks/scalar_conservation-kpp.prm
+++ b/prm/benchmarks/scalar_conservation-kpp.prm
@@ -29,10 +29,6 @@ subsection B - Equation
   set dimension                       = 2
   set equation                        = scalar conservation
   set flux                            = kpp
-
-  set riemann solver averaged entropy = true
-  set riemann solver greedy wavespeed = true
-  set riemann solver random entropies = 0
 end
 
 
@@ -66,10 +62,11 @@ end
 
 
 subsection F - HyperbolicModule
-  set cfl with boundary dofs        = false
-
-  set limiter iterations            = 2
-  set limiter relaxation factor     = 1
+  subsection riemann solver
+    set use averaged entropy = true
+    set use greedy wavespeed = true
+    set random entropies = 0
+  end
 end
 
 

--- a/prm/benchmarks/shallow_water-G3-S2-experiment.prm
+++ b/prm/benchmarks/shallow_water-G3-S2-experiment.prm
@@ -41,7 +41,6 @@ end
 subsection B - Equation
   set dimension                    = 2
   set equation                     = shallow water
-  set limiter square velocity      = true
 
   set reference water depth        = 1
   set dry state relaxation large   = 1e4
@@ -91,11 +90,20 @@ end
 
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = false
-  set indicator evc factor          = 1
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 2
+
+  subsection indicator
+    set evc factor = 1
+  end
+
+  subsection limiter
+    set iterations               = 2
+    set newton max iterations    = 2
+    set newton tolerance         = 1e-10
+    set relaxation factor        = 2
+
+    set limit on kinetic energy  = false
+    set limit on square velocity = true
+  end
 end
 
 subsection H - TimeIntegrator

--- a/prm/verification/euler-leblanc-erk33.prm
+++ b/prm/verification/euler-leblanc-erk33.prm
@@ -63,10 +63,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 8
+  subsection limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/prm/verification/euler-rarefaction_erk33.prm
+++ b/prm/verification/euler-rarefaction_erk33.prm
@@ -68,10 +68,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 8
+  subsection limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/prm/verification/euler-shock_front_erk33.prm
+++ b/prm/verification/euler-shock_front_erk33.prm
@@ -61,10 +61,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 1
+  subsection limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/prm/verification/euler-smooth_wave-erk33.prm
+++ b/prm/verification/euler-smooth_wave-erk33.prm
@@ -60,10 +60,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 8
+  subsection limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/prm/verification/navier_stokes-becker_solution-erk33.prm
+++ b/prm/verification/navier_stokes-becker_solution-erk33.prm
@@ -69,10 +69,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 1
+  subsection limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/prm/verification/shallow_water-paraboloid_1d-erk33.prm
+++ b/prm/verification/shallow_water-paraboloid_1d-erk33.prm
@@ -35,9 +35,6 @@ subsection B - Equation
   set gravity                      = 9.81
   set manning friction coefficient = 0
 
-  set limiter kinetic energy       = true
-  set limiter square velocity      = false
-
   set reference water depth        = 10
   set dry state relaxation factor  = 1.0e-3
   set dry state relaxation small   = 1e2
@@ -68,6 +65,13 @@ subsection E - InitialValues
     set paraboloid length   = 10000
     set speed               = 2
     set water height        = 10
+  end
+end
+
+subsection F - HyperbolicModule
+  subsection limiter
+    set limit on kinetic energy  = true
+    set limit on square velocity = false
   end
 end
 

--- a/prm/verification/shallow_water-paraboloid_2d-erk33.prm
+++ b/prm/verification/shallow_water-paraboloid_2d-erk33.prm
@@ -35,9 +35,6 @@ subsection B - Equation
   set gravity                      = 9.81
   set manning friction coefficient = 0
 
-  set limiter kinetic energy       = false
-  set limiter square velocity      = true
-
   set reference water depth        = 0.1
   set dry state relaxation factor  = 0
   set dry state relaxation small   = 1e2
@@ -68,6 +65,13 @@ subsection E - InitialValues
     set eta                 = 0.5
     set free surface radius = 1
     set water height        = 0.1
+  end
+end
+
+subsection F - HyperbolicModule
+  subsection limiter
+    set limit on kinetic energy  = false
+    set limit on square velocity = true
   end
 end
 

--- a/prm/verification/shallow_water-ritter_dam_break-erk33.prm
+++ b/prm/verification/shallow_water-ritter_dam_break-erk33.prm
@@ -34,9 +34,6 @@ subsection B - Equation
   set gravity                      = 9.81
   set manning friction coefficient = 0
 
-  set limiter kinetic energy       = true
-  set limiter square velocity      = false
-
   set reference water depth        = 0.005
   set dry state relaxation factor  = 1.0e-3
   set dry state relaxation small   = 1e2
@@ -65,6 +62,13 @@ subsection E - InitialValues
   subsection ritter dam break
     set time initial = 1
     set left water depth = 0.005
+  end
+end
+
+subsection F - HyperbolicModule
+  subsection limiter
+    set limit on kinetic energy  = true
+    set limit on square velocity = false
   end
 end
 

--- a/prm/verification/shallow_water-smooth_vortex-erk33.prm
+++ b/prm/verification/shallow_water-smooth_vortex-erk33.prm
@@ -34,9 +34,6 @@ subsection B - Equation
   set gravity                      = 9.81
   set manning friction coefficient = 0
 
-  set limiter kinetic energy       = false
-  set limiter square velocity      = true
-
   set reference water depth        = 2
   set dry state relaxation factor  = 0
   set dry state relaxation small   = 1e2
@@ -67,6 +64,13 @@ subsection E - InitialValues
     set beta            = 2
     set mach number     = 1
     set reference depth = 2
+  end
+end
+
+subsection F - HyperbolicModule
+  subsection limiter
+    set limit on kinetic energy  = false
+    set limit on square velocity = true
   end
 end
 

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -23,7 +23,7 @@ namespace ryujin
     class IndicatorParameters : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection)
+      IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -27,7 +27,7 @@ namespace ryujin
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
-        add_parameter("indicator evc factor",
+        add_parameter("evc factor",
                       evc_factor_,
                       "Factor for scaling the entropy viscocity commuator");
       }

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -11,6 +11,7 @@
 #include <multicomponent_vector.h>
 #include <simd.h>
 
+#include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/vectorization.h>
 
 
@@ -18,6 +19,26 @@ namespace ryujin
 {
   namespace Euler
   {
+    template <typename ScalarNumber = double>
+    class IndicatorParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      IndicatorParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+        evc_factor_ = ScalarNumber(1.);
+        add_parameter("indicator evc factor",
+                      evc_factor_,
+                      "Factor for scaling the entropy viscocity commuator");
+      }
+
+      ACCESSOR_READ_ONLY(evc_factor);
+
+    private:
+      ScalarNumber evc_factor_;
+    };
+
+
     /**
      * This class implements an indicator strategy used to form the
      * preliminary high-order update.
@@ -100,6 +121,11 @@ namespace ryujin
       using ScalarNumber = typename HyperbolicSystemView::ScalarNumber;
 
       /**
+       * @copydoc IndicatorParameters
+       */
+      using Parameters = IndicatorParameters<ScalarNumber>;
+
+      /**
        * @name Stencil-based computation of indicators
        *
        * Intended usage:
@@ -122,12 +148,12 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
+                const Parameters &parameters,
                 const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values,
-                const ScalarNumber evc_factor)
+                    &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
-          , evc_factor(evc_factor)
       {
       }
 
@@ -159,11 +185,10 @@ namespace ryujin
       //@{
 
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
-
-      const ScalarNumber evc_factor;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;
@@ -247,7 +272,7 @@ namespace ryujin
       const auto quotient =
           std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
 
-      return std::min(Number(1.), evc_factor * quotient);
+      return std::min(Number(1.), parameters.evc_factor() * quotient);
     }
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -16,6 +16,51 @@ namespace ryujin
 {
   namespace Euler
   {
+    template <typename ScalarNumber = double>
+    class LimiterParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      LimiterParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+        iterations_ = 2;
+        add_parameter(
+            "iterations", iterations_, "Number of limiter iterations");
+
+        if constexpr (std::is_same<ScalarNumber, double>::value)
+          newton_tolerance_ = 1.e-10;
+        else
+          newton_tolerance_ = 1.e-4;
+        add_parameter("newton tolerance",
+                      newton_tolerance_,
+                      "Tolerance for the quadratic newton stopping criterion");
+
+        newton_max_iterations_ = 2;
+        add_parameter("newton max iterations",
+                      newton_max_iterations_,
+                      "Maximal number of quadratic newton iterations performed "
+                      "during limiting");
+
+        relaxation_factor_ = ScalarNumber(1.);
+        add_parameter("relaxation factor",
+                      relaxation_factor_,
+                      "Factor for scaling the relaxation window with r_i = "
+                      "factor * (m_i/|Omega|)^(1.5/d).");
+      }
+
+      ACCESSOR_READ_ONLY(iterations);
+      ACCESSOR_READ_ONLY(newton_tolerance);
+      ACCESSOR_READ_ONLY(newton_max_iterations);
+      ACCESSOR_READ_ONLY(relaxation_factor);
+
+    private:
+      unsigned int iterations_;
+      ScalarNumber newton_tolerance_;
+      unsigned int newton_max_iterations_;
+      ScalarNumber relaxation_factor_;
+    };
+
+
     /**
      * The convex limiter.
      *
@@ -90,6 +135,11 @@ namespace ryujin
       using ScalarNumber = typename HyperbolicSystemView::ScalarNumber;
 
       /**
+       * @copydoc LimiterParameters
+       */
+      using Parameters = LimiterParameters<ScalarNumber>;
+
+      /**
        * @name Stencil-based computation of bounds
        *
        * Intended usage:
@@ -122,16 +172,12 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
+              const Parameters &parameters,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values,
-              const ScalarNumber relaxation_factor,
-              const ScalarNumber newton_tolerance,
-              const unsigned int newton_max_iter)
+                  &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
-          , relaxation_factor(relaxation_factor)
-          , newton_tolerance(newton_tolerance)
-          , newton_max_iter(newton_max_iter)
       {
       }
 
@@ -203,13 +249,10 @@ namespace ryujin
       //@{
 
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
-
-      const ScalarNumber relaxation_factor;
-      const ScalarNumber newton_tolerance;
-      const unsigned int newton_max_iter;
 
       state_type U_i;
 
@@ -301,7 +344,7 @@ namespace ryujin
         r_i = dealii::Utilities::fixed_power<3>(std::sqrt(r_i)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                               //
         r_i = dealii::Utilities::fixed_power<3>(r_i);            // in 1D: ^ 3/2
-      r_i *= relaxation_factor;
+      r_i *= parameters.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       const Number rho_relaxation =

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -20,7 +20,7 @@ namespace ryujin
     class LimiterParameters : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection)
+      LimiterParameters(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;

--- a/source/euler/limiter.template.h
+++ b/source/euler/limiter.template.h
@@ -160,7 +160,7 @@ namespace ryujin
 
         const auto &s_min = std::get<2>(bounds);
 
-        for (unsigned int n = 0; n < newton_max_iter; ++n) {
+        for (unsigned int n = 0; n < parameters.newton_max_iterations(); ++n) {
 
           const auto U_r = U + t_r * P;
           const auto rho_r = hyperbolic_system.density(U_r);
@@ -246,7 +246,8 @@ namespace ryujin
            * Break if the window between t_l and t_r is within the prescribed
            * tolerance:
            */
-          if (std::max(Number(0.), t_r - t_l - newton_tolerance) == Number(0.))
+          const Number tolerance(parameters.newton_tolerance());
+          if (std::max(Number(0.), t_r - t_l - tolerance) == Number(0.))
             break;
 
           /* We got unlucky and have to perform a Newton step: */

--- a/source/euler/riemann_solver.h
+++ b/source/euler/riemann_solver.h
@@ -12,12 +12,21 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 
-#include <functional>
-
 namespace ryujin
 {
   namespace Euler
   {
+    template <typename ScalarNumber = double>
+    class RiemannSolverParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      RiemannSolverParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+      }
+    };
+
+
     /**
      * A fast approximative solver for the 1D Riemann problem. The solver
      * ensures that the estimate \f$\lambda_{\text{max}}\f$ that is returned
@@ -71,6 +80,11 @@ namespace ryujin
       using ScalarNumber = typename HyperbolicSystemView::ScalarNumber;
 
       /**
+       * @copydoc RiemannSolverParameters
+       */
+      using Parameters = RiemannSolverParameters<ScalarNumber>;
+
+      /**
        * @name Compute wavespeed estimates
        */
       //@{
@@ -80,9 +94,11 @@ namespace ryujin
        */
       RiemannSolver(
           const HyperbolicSystem &hyperbolic_system,
+          const Parameters &parameters,
           const MultiComponentVector<ScalarNumber, n_precomputed_values>
               &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
       {
       }
@@ -216,6 +232,7 @@ namespace ryujin
 
     private:
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;

--- a/source/euler/riemann_solver.h
+++ b/source/euler/riemann_solver.h
@@ -20,7 +20,7 @@ namespace ryujin
     class RiemannSolverParameters : public dealii::ParameterAcceptor
     {
     public:
-      RiemannSolverParameters(const std::string &subsection)
+      RiemannSolverParameters(const std::string &subsection = "/RiemannSolver")
           : ParameterAcceptor(subsection)
       {
       }

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -23,7 +23,7 @@ namespace ryujin
     class IndicatorParameters : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection)
+      IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -27,7 +27,7 @@ namespace ryujin
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
-        add_parameter("indicator evc factor",
+        add_parameter("evc factor",
                       evc_factor_,
                       "Factor for scaling the entropy viscocity commuator");
       }

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -11,6 +11,7 @@
 #include <multicomponent_vector.h>
 #include <simd.h>
 
+#include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/vectorization.h>
 
 
@@ -18,6 +19,26 @@ namespace ryujin
 {
   namespace EulerAEOS
   {
+    template <typename ScalarNumber = double>
+    class IndicatorParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      IndicatorParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+        evc_factor_ = ScalarNumber(1.);
+        add_parameter("indicator evc factor",
+                      evc_factor_,
+                      "Factor for scaling the entropy viscocity commuator");
+      }
+
+      ACCESSOR_READ_ONLY(evc_factor);
+
+    private:
+      ScalarNumber evc_factor_;
+    };
+
+
     /**
      * This class implements an indicator strategy used to form the
      * preliminary high-order update.
@@ -106,6 +127,11 @@ namespace ryujin
       using ScalarNumber = typename HyperbolicSystemView::ScalarNumber;
 
       /**
+       * @copydoc IndicatorParameters
+       */
+      using Parameters = IndicatorParameters<ScalarNumber>;
+
+      /**
        * @name Stencil-based computation of indicators
        *
        * Intended usage:
@@ -128,12 +154,12 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
+                const Parameters &parameters,
                 const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values,
-                const ScalarNumber evc_factor)
+                    &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
-          , evc_factor(evc_factor)
       {
       }
 
@@ -165,11 +191,11 @@ namespace ryujin
       //@{
 
       const HyperbolicSystem::View<dim, Number> hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
 
-      const ScalarNumber evc_factor;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;
@@ -270,7 +296,7 @@ namespace ryujin
       const auto quotient =
           std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
 
-      return std::min(Number(1.), evc_factor * quotient);
+      return std::min(Number(1.), parameters.evc_factor() * quotient);
     }
 
   } // namespace EulerAEOS

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -16,6 +16,51 @@ namespace ryujin
 {
   namespace EulerAEOS
   {
+    template <typename ScalarNumber = double>
+    class LimiterParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      LimiterParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+        iterations_ = 2;
+        add_parameter(
+            "iterations", iterations_, "Number of limiter iterations");
+
+        if constexpr (std::is_same<ScalarNumber, double>::value)
+          newton_tolerance_ = 1.e-10;
+        else
+          newton_tolerance_ = 1.e-4;
+        add_parameter("newton tolerance",
+                      newton_tolerance_,
+                      "Tolerance for the quadratic newton stopping criterion");
+
+        newton_max_iterations_ = 2;
+        add_parameter("newton max iterations",
+                      newton_max_iterations_,
+                      "Maximal number of quadratic newton iterations performed "
+                      "during limiting");
+
+        relaxation_factor_ = ScalarNumber(1.);
+        add_parameter("relaxation factor",
+                      relaxation_factor_,
+                      "Factor for scaling the relaxation window with r_i = "
+                      "factor * (m_i/|Omega|)^(1.5/d).");
+      }
+
+      ACCESSOR_READ_ONLY(iterations);
+      ACCESSOR_READ_ONLY(newton_tolerance);
+      ACCESSOR_READ_ONLY(newton_max_iterations);
+      ACCESSOR_READ_ONLY(relaxation_factor);
+
+    private:
+      unsigned int iterations_;
+      ScalarNumber newton_tolerance_;
+      unsigned int newton_max_iterations_;
+      ScalarNumber relaxation_factor_;
+    };
+
+
     /**
      * The convex limiter.
      *
@@ -92,6 +137,11 @@ namespace ryujin
       using ScalarNumber = typename HyperbolicSystemView::ScalarNumber;
 
       /**
+       * @copydoc LimiterParameters
+       */
+      using Parameters = LimiterParameters<ScalarNumber>;
+
+      /**
        * @name Stencil-based computation of bounds
        *
        * Intended usage:
@@ -124,16 +174,12 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
+              const Parameters &parameters,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values,
-              const ScalarNumber relaxation_factor,
-              const ScalarNumber newton_tolerance,
-              const unsigned int newton_max_iter)
+                  &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
-          , relaxation_factor(relaxation_factor)
-          , newton_tolerance(newton_tolerance)
-          , newton_max_iter(newton_max_iter)
       {
       }
 
@@ -205,13 +251,10 @@ namespace ryujin
       //@{
 
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
-
-      ScalarNumber relaxation_factor;
-      ScalarNumber newton_tolerance;
-      unsigned int newton_max_iter;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -356,7 +399,7 @@ namespace ryujin
         r_i = dealii::Utilities::fixed_power<3>(std::sqrt(r_i)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                               //
         r_i = dealii::Utilities::fixed_power<3>(r_i);            // in 1D: ^ 3/2
-      r_i *= relaxation_factor;
+      r_i *= parameters.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       const Number rho_relaxation =

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -20,7 +20,7 @@ namespace ryujin
     class LimiterParameters : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection)
+      LimiterParameters(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;

--- a/source/euler_aeos/limiter.template.h
+++ b/source/euler_aeos/limiter.template.h
@@ -162,7 +162,7 @@ namespace ryujin
 
         const auto &s_min = std::get<2>(bounds);
 
-        for (unsigned int n = 0; n < newton_max_iter; ++n) {
+        for (unsigned int n = 0; n < parameters.newton_max_iterations(); ++n) {
 
           const auto U_r = U + t_r * P;
           const auto rho_r = hyperbolic_system.density(U_r);
@@ -252,7 +252,8 @@ namespace ryujin
            * Break if the window between t_l and t_r is within the prescribed
            * tolerance:
            */
-          if (std::max(Number(0.), t_r - t_l - newton_tolerance) == Number(0.))
+          const Number tolerance(parameters.newton_tolerance());
+          if (std::max(Number(0.), t_r - t_l - tolerance) == Number(0.))
             break;
 
           /* We got unlucky and have to perform a Newton step: */

--- a/source/euler_aeos/riemann_solver.h
+++ b/source/euler_aeos/riemann_solver.h
@@ -12,12 +12,21 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 
-#include <functional>
-
 namespace ryujin
 {
   namespace EulerAEOS
   {
+    template <typename ScalarNumber = double>
+    class RiemannSolverParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      RiemannSolverParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+      }
+    };
+
+
     /**
      * A fast approximative solver for the 1D Riemann problem. The solver
      * ensures that the estimate \f$\lambda_{\text{max}}\f$ that is returned
@@ -77,6 +86,11 @@ namespace ryujin
       using ScalarNumber = typename HyperbolicSystemView::ScalarNumber;
 
       /**
+       * @copydoc RiemannSolverParameters
+       */
+      using Parameters = RiemannSolverParameters<ScalarNumber>;
+
+      /**
        * @name Compute wavespeed estimates
        */
       //@{
@@ -86,9 +100,11 @@ namespace ryujin
        */
       RiemannSolver(
           const HyperbolicSystem &hyperbolic_system,
+          const Parameters &parameters,
           const MultiComponentVector<ScalarNumber, n_precomputed_values>
               &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
       {
       }
@@ -254,6 +270,7 @@ namespace ryujin
 
     private:
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;

--- a/source/euler_aeos/riemann_solver.h
+++ b/source/euler_aeos/riemann_solver.h
@@ -20,7 +20,7 @@ namespace ryujin
     class RiemannSolverParameters : public dealii::ParameterAcceptor
     {
     public:
-      RiemannSolverParameters(const std::string &subsection)
+      RiemannSolverParameters(const std::string &subsection = "/RiemannSolver")
           : ParameterAcceptor(subsection)
       {
       }

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -318,10 +318,8 @@ namespace ryujin
     typename Description::template Indicator<dim, Number>::Parameters
         indicator_parameters_;
 
-    unsigned int limiter_iter_;
-    Number limiter_newton_tolerance_;
-    unsigned int limiter_newton_max_iter_;
-    Number limiter_relaxation_factor_;
+    typename Description::template Limiter<dim, Number>::Parameters
+        limiter_parameters_;
 
     bool cfl_with_boundary_dofs_;
 

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -315,7 +315,8 @@ namespace ryujin
      * @name Run time options
      */
     //@{
-    Number indicator_evc_factor_;
+    typename Description::template Indicator<dim, Number>::Parameters
+        indicator_parameters_;
 
     unsigned int limiter_iter_;
     Number limiter_newton_tolerance_;

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -321,6 +321,9 @@ namespace ryujin
     typename Description::template Limiter<dim, Number>::Parameters
         limiter_parameters_;
 
+    typename Description::template RiemannSolver<dim, Number>::Parameters
+        riemann_solver_parameters_;
+
     bool cfl_with_boundary_dofs_;
 
     //@}

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -35,8 +35,9 @@ namespace ryujin
       : ParameterAcceptor(subsection)
       , precompute_only_(false)
       , id_violation_strategy_(IDViolationStrategy::warn)
-      , indicator_parameters_(subsection + "/Indicator")
-      , limiter_parameters_(subsection + "/Limiter")
+      , indicator_parameters_(subsection + "/indicator")
+      , limiter_parameters_(subsection + "/limiter")
+      , riemann_solver_parameters_(subsection + "/riemann_solver")
       , mpi_communicator_(mpi_communicator)
       , computing_timer_(computing_timer)
       , offline_data_(&offline_data)
@@ -290,7 +291,7 @@ namespace ryujin
 
         /* Stored thread locally: */
         typename Description::template RiemannSolver<dim, T> riemann_solver(
-            *hyperbolic_system_, new_precomputed);
+            *hyperbolic_system_, riemann_solver_parameters_, new_precomputed);
         typename Description::template Indicator<dim, T> indicator(
             *hyperbolic_system_, indicator_parameters_, new_precomputed);
         bool thread_ready = false;
@@ -371,7 +372,7 @@ namespace ryujin
       /* Complete d_ij at boundary: */
 
       typename Description::template RiemannSolver<dim, Number> riemann_solver(
-          *hyperbolic_system_, new_precomputed);
+          *hyperbolic_system_, riemann_solver_parameters_, new_precomputed);
 
       Number local_tau_max = std::numeric_limits<Number>::max();
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -35,6 +35,7 @@ namespace ryujin
       : ParameterAcceptor(subsection)
       , precompute_only_(false)
       , id_violation_strategy_(IDViolationStrategy::warn)
+      , indicator_parameters_(subsection + "/Indicator")
       , mpi_communicator_(mpi_communicator)
       , computing_timer_(computing_timer)
       , offline_data_(&offline_data)
@@ -44,11 +45,6 @@ namespace ryujin
       , n_restarts_(0)
       , n_warnings_(0)
   {
-    indicator_evc_factor_ = Number(1.);
-    add_parameter("indicator evc factor",
-                  indicator_evc_factor_,
-                  "Factor for scaling the entropy viscocity commuator");
-
     limiter_iter_ = 2;
     add_parameter(
         "limiter iterations", limiter_iter_, "Number of limiter iterations");
@@ -319,7 +315,7 @@ namespace ryujin
         typename Description::template RiemannSolver<dim, T> riemann_solver(
             *hyperbolic_system_, new_precomputed);
         typename Description::template Indicator<dim, T> indicator(
-            *hyperbolic_system_, new_precomputed, indicator_evc_factor_);
+            *hyperbolic_system_, indicator_parameters_, new_precomputed);
         bool thread_ready = false;
 
         RYUJIN_OMP_FOR

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -37,7 +37,7 @@ namespace ryujin
       , id_violation_strategy_(IDViolationStrategy::warn)
       , indicator_parameters_(subsection + "/indicator")
       , limiter_parameters_(subsection + "/limiter")
-      , riemann_solver_parameters_(subsection + "/riemann_solver")
+      , riemann_solver_parameters_(subsection + "/riemann solver")
       , mpi_communicator_(mpi_communicator)
       , computing_timer_(computing_timer)
       , offline_data_(&offline_data)

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -50,10 +50,6 @@ namespace ryujin
       //@{
       std::string flux_;
 
-      bool riemann_solver_greedy_wavespeed_;
-      bool riemann_solver_averaged_entropy_;
-      unsigned int riemann_solver_random_entropies_;
-
       FluxLibrary::flux_list_type flux_list_;
       using Flux = FluxLibrary::Flux;
       std::shared_ptr<Flux> selected_flux_;
@@ -104,26 +100,8 @@ namespace ryujin
           return hyperbolic_system_.flux_;
         }
 
-        DEAL_II_ALWAYS_INLINE inline bool
-        riemann_solver_greedy_wavespeed() const
-        {
-          return hyperbolic_system_.riemann_solver_greedy_wavespeed_;
-        }
-
-        DEAL_II_ALWAYS_INLINE inline bool
-        riemann_solver_averaged_entropy() const
-        {
-          return hyperbolic_system_.riemann_solver_averaged_entropy_;
-        }
-
-        DEAL_II_ALWAYS_INLINE inline unsigned int
-        riemann_solver_random_entropies() const
-        {
-          return hyperbolic_system_.riemann_solver_random_entropies_;
-        }
-
         DEAL_II_ALWAYS_INLINE inline ScalarNumber
-        riemann_solver_approximation_delta() const
+        derivative_approximation_delta() const
         {
           const auto &flux = hyperbolic_system_.selected_flux_;
           return ScalarNumber(flux->derivative_approximation_delta());
@@ -551,29 +529,6 @@ namespace ryujin
                     flux_,
                     "The scalar flux. Valid names are given by any of the "
                     "subsections defined below");
-
-      riemann_solver_greedy_wavespeed_ = false;
-      add_parameter(
-          "riemann solver greedy wavespeed",
-          riemann_solver_greedy_wavespeed_,
-          "Use a greedy wavespeed estimate instead of a guaranteed upper bound "
-          "on the maximal wavespeed (for convex fluxes).");
-
-      riemann_solver_averaged_entropy_ = false;
-      add_parameter(
-          "riemann solver averaged entropy",
-          riemann_solver_averaged_entropy_,
-          "In addition to the wavespeed estimate based on the Roe average and "
-          "flux gradients of the left and right state also enforce an entropy "
-          "inequality on the averaged Krŭzkov entropy.");
-
-      riemann_solver_random_entropies_ = 0;
-      add_parameter(
-          "riemann solver random entropies",
-          riemann_solver_random_entropies_,
-          "In addition to the wavespeed estimate based on the Roe average and "
-          "flux gradients of the left and right state also enforce an entropy "
-          "inequality on the prescribed number of random Krŭzkov entropies.");
 
       /*
        * And finally populate the flux list with all flux configurations

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -22,7 +22,7 @@ namespace ryujin
     class IndicatorParameters : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection)
+      IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -26,7 +26,7 @@ namespace ryujin
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
-        add_parameter("indicator evc factor",
+        add_parameter("evc factor",
                       evc_factor_,
                       "Factor for scaling the entropy viscocity commuator");
       }

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -19,7 +19,7 @@ namespace ryujin
     class LimiterParameters : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection)
+      LimiterParameters(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;

--- a/source/scalar_conservation/riemann_solver.h
+++ b/source/scalar_conservation/riemann_solver.h
@@ -12,12 +12,21 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 
-#include <functional>
-
 namespace ryujin
 {
   namespace ScalarConservation
   {
+    template <typename ScalarNumber = double>
+    class RiemannSolverParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      RiemannSolverParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+      }
+    };
+
+
     /**
      * A fast estimate for a sufficient maximal wavespeed of the 1D Riemann
      * problem. The wavespeed estimate is based on a guaranteed upper bound
@@ -60,6 +69,11 @@ namespace ryujin
       using ScalarNumber = typename get_value_type<Number>::type;
 
       /**
+       * @copydoc RiemannSolverParameters
+       */
+      using Parameters = RiemannSolverParameters<ScalarNumber>;
+
+      /**
        * @name Compute wavespeed estimates
        */
       //@{
@@ -69,9 +83,11 @@ namespace ryujin
        */
       RiemannSolver(
           const HyperbolicSystem &hyperbolic_system,
+          const Parameters &parameters,
           const MultiComponentVector<ScalarNumber, n_precomputed_values>
               &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
       {
       }
@@ -97,12 +113,13 @@ namespace ryujin
                      const unsigned int *js,
                      const dealii::Tensor<1, dim, Number> &n_ij) const;
 
-      //@}
-      //
     private:
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
+
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
+      //@}
     };
 
 

--- a/source/scalar_conservation/riemann_solver.h
+++ b/source/scalar_conservation/riemann_solver.h
@@ -23,7 +23,41 @@ namespace ryujin
       RiemannSolverParameters(const std::string &subsection)
           : ParameterAcceptor(subsection)
       {
+        use_greedy_wavespeed_ = false;
+        add_parameter("use greedy wavespeed",
+                      use_greedy_wavespeed_,
+                      "Use a greedy wavespeed estimate instead of a guaranteed "
+                      "upper bound "
+                      "on the maximal wavespeed (for convex fluxes).");
+
+        use_averaged_entropy_ = false;
+        add_parameter("use averaged entropy",
+                      use_averaged_entropy_,
+                      "In addition to the wavespeed estimate based on the Roe "
+                      "average and "
+                      "flux gradients of the left and right state also enforce "
+                      "an entropy "
+                      "inequality on the averaged Krŭzkov entropy.");
+
+        random_entropies_ = 0;
+        add_parameter(
+            "random entropies",
+            random_entropies_,
+            "In addition to the wavespeed estimate based on the Roe average "
+            "and "
+            "flux gradients of the left and right state also enforce an "
+            "entropy "
+            "inequality on the prescribed number of random Krŭzkov entropies.");
       }
+
+      ACCESSOR_READ_ONLY(use_greedy_wavespeed);
+      ACCESSOR_READ_ONLY(use_averaged_entropy);
+      ACCESSOR_READ_ONLY(random_entropies);
+
+    private:
+      bool use_greedy_wavespeed_;
+      bool use_averaged_entropy_;
+      unsigned int random_entropies_;
     };
 
 

--- a/source/scalar_conservation/riemann_solver.h
+++ b/source/scalar_conservation/riemann_solver.h
@@ -20,7 +20,7 @@ namespace ryujin
     class RiemannSolverParameters : public dealii::ParameterAcceptor
     {
     public:
-      RiemannSolverParameters(const std::string &subsection)
+      RiemannSolverParameters(const std::string &subsection = "/RiemannSolver")
           : ParameterAcceptor(subsection)
       {
         use_greedy_wavespeed_ = false;

--- a/source/scalar_conservation/riemann_solver.template.h
+++ b/source/scalar_conservation/riemann_solver.template.h
@@ -35,7 +35,7 @@ namespace ryujin
       const Number df_i = view.construct_flux_gradient_tensor(prec_i) * n_ij;
       const Number df_j = view.construct_flux_gradient_tensor(prec_j) * n_ij;
 
-      const auto h2 = Number(2. * view.riemann_solver_approximation_delta());
+      const auto h2 = Number(2. * view.derivative_approximation_delta());
 
 #ifdef DEBUG_RIEMANN_SOLVER
       std::cout << "\nu_i  = " << u_i << std::endl;
@@ -68,7 +68,7 @@ namespace ryujin
 
       constexpr auto gte = dealii::SIMDComparison::greater_than_or_equal;
 
-      if (view.riemann_solver_greedy_wavespeed()) {
+      if (parameters.use_greedy_wavespeed()) {
         /*
          * In case of a greedy estimate we make sure that we always use the
          * Roe average and only fall back to the derivative approximation
@@ -173,12 +173,12 @@ namespace ryujin
       };
 
 
-      if (view.riemann_solver_averaged_entropy()) {
+      if (parameters.use_averaged_entropy()) {
         const Number k = ScalarNumber(0.5) * (u_i + u_j);
         enforce_entropy(k);
       }
 
-      const unsigned int n_entropies = view.riemann_solver_random_entropies();
+      const unsigned int n_entropies = parameters.random_entropies();
       for (unsigned int i = 0; i < n_entropies; ++i) {
         const Number factor = draw();
         const Number k = factor * u_i + (Number(1.) - factor) * u_j;

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -54,9 +54,6 @@ namespace ryujin
       double gravity_;
       double manning_friction_coefficient_;
 
-      bool limiter_kinetic_energy_;
-      bool limiter_square_velocity_;
-
       double reference_water_depth_;
       double dry_state_relaxation_factor_;
       double dry_state_relaxation_small_;
@@ -121,16 +118,6 @@ namespace ryujin
         manning_friction_coefficient() const
         {
           return hyperbolic_system_.manning_friction_coefficient_;
-        }
-
-        DEAL_II_ALWAYS_INLINE inline bool limiter_kinetic_energy() const
-        {
-          return hyperbolic_system_.limiter_kinetic_energy_;
-        }
-
-        DEAL_II_ALWAYS_INLINE inline bool limiter_square_velocity() const
-        {
-          return hyperbolic_system_.limiter_square_velocity_;
         }
 
         DEAL_II_ALWAYS_INLINE inline ScalarNumber reference_water_depth() const
@@ -676,16 +663,6 @@ namespace ryujin
       add_parameter("reference water depth",
                     reference_water_depth_,
                     "Problem specific water depth reference");
-
-      limiter_kinetic_energy_ = false;
-      add_parameter("limiter kinetic energy",
-                    limiter_kinetic_energy_,
-                    "Limit on the kinetic energy");
-
-      limiter_square_velocity_ = true;
-      add_parameter("limiter square velocity",
-                    limiter_square_velocity_,
-                    "Limit on the square velocity");
 
       dry_state_relaxation_factor_ = 2.e-1;
       add_parameter("dry state relaxation factor",

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -23,7 +23,7 @@ namespace ryujin
     class IndicatorParameters : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection)
+      IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -27,7 +27,7 @@ namespace ryujin
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
-        add_parameter("indicator evc factor",
+        add_parameter("evc factor",
                       evc_factor_,
                       "Factor for scaling the entropy viscocity commuator");
       }

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -11,6 +11,7 @@
 
 #include <multicomponent_vector.h>
 
+#include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/vectorization.h>
 
 
@@ -18,6 +19,26 @@ namespace ryujin
 {
   namespace ShallowWater
   {
+    template <typename ScalarNumber = double>
+    class IndicatorParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      IndicatorParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+        evc_factor_ = ScalarNumber(1.);
+        add_parameter("indicator evc factor",
+                      evc_factor_,
+                      "Factor for scaling the entropy viscocity commuator");
+      }
+
+      ACCESSOR_READ_ONLY(evc_factor);
+
+    private:
+      ScalarNumber evc_factor_;
+    };
+
+
     /**
      * An suitable indicator strategy that is used to form the preliminary
      * high-order update.
@@ -67,6 +88,11 @@ namespace ryujin
       using ScalarNumber = typename get_value_type<Number>::type;
 
       /**
+       * @copydoc IndicatorParameters
+       */
+      using Parameters = IndicatorParameters<ScalarNumber>;
+
+      /**
        * @name Stencil-based computation of indicators
        *
        * Intended usage:
@@ -89,12 +115,12 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
+                const Parameters &parameters,
                 const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values,
-                const ScalarNumber evc_factor)
+                    &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
-          , evc_factor(evc_factor)
       {
       }
 
@@ -125,11 +151,10 @@ namespace ryujin
        */
       //@{
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
-
-      const ScalarNumber evc_factor;
 
       Number h_i = 0.;
       Number eta_i = 0.;
@@ -214,7 +239,7 @@ namespace ryujin
            std::max(hd_i * std::abs(eta_i),
                     Number(100. * std::numeric_limits<ScalarNumber>::min())));
 
-      return std::min(Number(1.), evc_factor * quotient);
+      return std::min(Number(1.), parameters.evc_factor() * quotient);
     }
 
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -47,6 +47,16 @@ namespace ryujin
                       relaxation_factor_,
                       "Factor for scaling the relaxation window with r_i = "
                       "factor * (m_i/|Omega|)^(1.5/d).");
+
+        limit_on_kinetic_energy_ = false;
+        add_parameter("limit on kinetic energy",
+                      limit_on_kinetic_energy_,
+                      "Limit on kinetic energy");
+
+        limit_on_square_velocity_ = true;
+        add_parameter("limit on square velocity",
+                      limit_on_square_velocity_,
+                      "Limit on square velocity");
       }
 
       ACCESSOR_READ_ONLY(iterations);
@@ -54,11 +64,17 @@ namespace ryujin
       ACCESSOR_READ_ONLY(newton_max_iterations);
       ACCESSOR_READ_ONLY(relaxation_factor);
 
+      ACCESSOR_READ_ONLY(limit_on_kinetic_energy);
+      ACCESSOR_READ_ONLY(limit_on_square_velocity);
+
     private:
       unsigned int iterations_;
       ScalarNumber newton_tolerance_;
       unsigned int newton_max_iterations_;
       ScalarNumber relaxation_factor_;
+
+      bool limit_on_kinetic_energy_;
+      bool limit_on_square_velocity_;
     };
 
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -21,7 +21,7 @@ namespace ryujin
     class LimiterParameters : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection)
+      LimiterParameters(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;

--- a/source/shallow_water/limiter.template.h
+++ b/source/shallow_water/limiter.template.h
@@ -140,8 +140,8 @@ namespace ryujin
        * Return early if we neither limit on kinetic energy or on square
        * velocity.
        */
-      if (RYUJIN_UNLIKELY(!hyperbolic_system.limiter_square_velocity() &&
-                          !hyperbolic_system.limiter_kinetic_energy()))
+      if (RYUJIN_UNLIKELY(!parameters.limit_on_square_velocity() &&
+                          !parameters.limit_on_kinetic_energy()))
         return {t_l, success};
 
       /*
@@ -157,7 +157,7 @@ namespace ryujin
        *   psi = h KE_i^max - 1/2 |q|^2
        */
 
-      if (hyperbolic_system.limiter_kinetic_energy()) {
+      if (parameters.limit_on_kinetic_energy()) {
 
         /* We first check if t_r is a good state */
 
@@ -176,7 +176,7 @@ namespace ryujin
             dealii::SIMDComparison::greater_than>(psi_r, Number(0.), t_r, t_l);
 
         /* If we have set t_l = t_r everywhere we can return: */
-        if (!hyperbolic_system.limiter_square_velocity() && t_l == t_r)
+        if (!parameters.limit_on_square_velocity() && t_l == t_r)
           return {t_l, success};
 
 #ifdef DEBUG_OUTPUT_LIMITER
@@ -290,7 +290,7 @@ namespace ryujin
 #endif
 
         /* Flip bounds for the square velocity limiter: */
-        if (hyperbolic_system.limiter_square_velocity()) {
+        if (parameters.limit_on_square_velocity()) {
           t_r = t_l;
           t_l = t_min;
         }
@@ -307,7 +307,7 @@ namespace ryujin
        *   psi = h^2 (|v|^2)^max - |q|^2
        */
 
-      if (hyperbolic_system.limiter_square_velocity()) {
+      if (parameters.limit_on_square_velocity()) {
         /* We first check if t_r is a good state */
 
         const auto U_r = U + t_r * P;

--- a/source/shallow_water/limiter.template.h
+++ b/source/shallow_water/limiter.template.h
@@ -220,7 +220,8 @@ namespace ryujin
          * Skip the quadratic Newton step if the window between t_l and t_r
          * is within the prescribed tolerance:
          */
-        if (!(std::max(Number(0.), t_r - t_l - newton_tol) == Number(0.))) {
+        const Number tolerance(parameters.newton_tolerance());
+        if (!(std::max(Number(0.), t_r - t_l - tolerance) == Number(0.))) {
           /*
            * If the bound is not satisfied, we need to find the root of a
            * quadratic function:
@@ -367,7 +368,8 @@ namespace ryujin
          * Skip the quadratic Newton step if the window between t_l and t_r
          * is within the prescribed tolerance:
          */
-        if (!(std::max(Number(0.), t_r - t_l - newton_tol) == Number(0.))) {
+        const Number tolerance(parameters.newton_tolerance());
+        if (!(std::max(Number(0.), t_r - t_l - tolerance) == Number(0.))) {
           /*
            * If the bound is not satisfied, we need to find the root of a
            * quadratic function:

--- a/source/shallow_water/riemann_solver.h
+++ b/source/shallow_water/riemann_solver.h
@@ -9,10 +9,26 @@
 
 #include "hyperbolic_system.h"
 
+#include <simd.h>
+
+#include <deal.II/base/point.h>
+#include <deal.II/base/tensor.h>
+
 namespace ryujin
 {
   namespace ShallowWater
   {
+    template <typename ScalarNumber = double>
+    class RiemannSolverParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      RiemannSolverParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+      }
+    };
+
+
     /**
      * A fast approximative solver for the associated 1D Riemann problem.
      * The solver has to ensure that the estimate
@@ -65,6 +81,11 @@ namespace ryujin
       using ScalarNumber = typename HyperbolicSystemView::ScalarNumber;
 
       /**
+       * @copydoc RiemannSolverParameters
+       */
+      using Parameters = RiemannSolverParameters<ScalarNumber>;
+
+      /**
        * @name Compute wavespeed estimates
        */
       //@{
@@ -74,13 +95,14 @@ namespace ryujin
        */
       RiemannSolver(
           const HyperbolicSystem &hyperbolic_system,
+          const Parameters &parameters,
           const MultiComponentVector<ScalarNumber, n_precomputed_values>
               &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
       {
       }
-
 
       /**
        * For two given 1D primitive states riemann_data_i and riemann_data_j,
@@ -89,7 +111,6 @@ namespace ryujin
        */
       Number compute(const primitive_type &riemann_data_i,
                      const primitive_type &riemann_data_j) const;
-
 
       /**
        * For two given states U_i a U_j and a (normalized) "direction" n_ij
@@ -135,16 +156,11 @@ namespace ryujin
                               const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      //@}
-      /**
-       * @name Internal functions used in the Riemann solver
-       */
-      //@{
-
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
+
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
-
       //@}
     };
 

--- a/source/shallow_water/riemann_solver.h
+++ b/source/shallow_water/riemann_solver.h
@@ -22,7 +22,7 @@ namespace ryujin
     class RiemannSolverParameters : public dealii::ParameterAcceptor
     {
     public:
-      RiemannSolverParameters(const std::string &subsection)
+      RiemannSolverParameters(const std::string &subsection = "/RiemannSolver")
           : ParameterAcceptor(subsection)
       {
       }

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -10,6 +10,7 @@
 #include <multicomponent_vector.h>
 #include <simd.h>
 
+#include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/vectorization.h>
 
 
@@ -17,6 +18,17 @@ namespace ryujin
 {
   namespace Skeleton
   {
+    template <typename ScalarNumber = double>
+    class IndicatorParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      IndicatorParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+      }
+    };
+
+
     /**
      * An suitable indicator strategy that is used to form the preliminary
      * high-order update.
@@ -54,6 +66,11 @@ namespace ryujin
       using ScalarNumber = typename get_value_type<Number>::type;
 
       /**
+       * @copydoc IndicatorParameters
+       */
+      using Parameters = IndicatorParameters<ScalarNumber>;
+
+      /**
        * @name Stencil-based computation of indicators
        *
        * Intended usage:
@@ -76,12 +93,12 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
+                const Parameters &parameters,
                 const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values,
-                const ScalarNumber evc_factor)
+                    &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
-          , evc_factor(evc_factor)
       {
       }
 
@@ -121,11 +138,10 @@ namespace ryujin
        */
       //@{
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
-
-      const ScalarNumber evc_factor;
       //@}
     };
   } // namespace Skeleton

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -22,7 +22,7 @@ namespace ryujin
     class IndicatorParameters : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection)
+      IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
       }

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -16,6 +16,25 @@ namespace ryujin
 {
   namespace Skeleton
   {
+    template <typename ScalarNumber = double>
+    class LimiterParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      LimiterParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+        iterations_ = 2;
+        add_parameter(
+            "iterations", iterations_, "Number of limiter iterations");
+      }
+
+      ACCESSOR_READ_ONLY(iterations);
+
+    private:
+      unsigned int iterations_;
+    };
+
+
     /**
      * The convex limiter.
      *
@@ -53,6 +72,11 @@ namespace ryujin
       using ScalarNumber = typename get_value_type<Number>::type;
 
       /**
+       * @copydoc LimiterParameters
+       */
+      using Parameters = LimiterParameters<ScalarNumber>;
+
+      /**
        * @name Stencil-based computation of bounds
        *
        * Intended usage:
@@ -85,16 +109,12 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
+              const Parameters &parameters,
               const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values,
-              const ScalarNumber relaxation_factor,
-              const ScalarNumber newton_tolerance,
-              const unsigned int newton_max_iter)
+                  &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
-          , relaxation_factor(relaxation_factor)
-          , newton_tolerance(newton_tolerance)
-          , newton_max_iter(newton_max_iter)
       {
       }
 
@@ -175,13 +195,10 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
 
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
-
-      ScalarNumber relaxation_factor;
-      ScalarNumber newton_tolerance;
-      unsigned int newton_max_iter;
 
       Bounds bounds_;
       //@}

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -20,7 +20,7 @@ namespace ryujin
     class LimiterParameters : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection)
+      LimiterParameters(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;

--- a/source/skeleton/riemann_solver.h
+++ b/source/skeleton/riemann_solver.h
@@ -12,12 +12,21 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/tensor.h>
 
-#include <functional>
-
 namespace ryujin
 {
   namespace Skeleton
   {
+    template <typename ScalarNumber = double>
+    class RiemannSolverParameters : public dealii::ParameterAcceptor
+    {
+    public:
+      RiemannSolverParameters(const std::string &subsection)
+          : ParameterAcceptor(subsection)
+      {
+      }
+    };
+
+
     /**
      * A fast approximative solver for the associated 1D Riemann problem.
      * The solver has to ensure that the estimate
@@ -52,6 +61,11 @@ namespace ryujin
       using ScalarNumber = typename get_value_type<Number>::type;
 
       /**
+       * @copydoc RiemannSolverParameters
+       */
+      using Parameters = RiemannSolverParameters<ScalarNumber>;
+
+      /**
        * @name Compute wavespeed estimates
        */
       //@{
@@ -61,9 +75,11 @@ namespace ryujin
        */
       RiemannSolver(
           const HyperbolicSystem &hyperbolic_system,
+          const Parameters &parameters,
           const MultiComponentVector<ScalarNumber, n_precomputed_values>
               &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
+          , parameters(parameters)
           , precomputed_values(precomputed_values)
       {
       }
@@ -80,12 +96,14 @@ namespace ryujin
       {
         return Number(0.);
       }
-      //@}
-      //
+
     private:
       const HyperbolicSystemView hyperbolic_system;
+      const Parameters &parameters;
+
       const MultiComponentVector<ScalarNumber, n_precomputed_values>
           &precomputed_values;
+      //@}
     };
   } // namespace Skeleton
 } // namespace ryujin

--- a/source/skeleton/riemann_solver.h
+++ b/source/skeleton/riemann_solver.h
@@ -20,7 +20,7 @@ namespace ryujin
     class RiemannSolverParameters : public dealii::ParameterAcceptor
     {
     public:
-      RiemannSolverParameters(const std::string &subsection)
+      RiemannSolverParameters(const std::string &subsection = "/RiemannSolver")
           : ParameterAcceptor(subsection)
       {
       }

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -33,9 +33,7 @@ int main()
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  Limiter<dim, double> limiter(hyperbolic_system,
-                               limiter_parameters,
-                               dummy);
+  Limiter<dim, double> limiter(hyperbolic_system, limiter_parameters, dummy);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  Limiter<dim, double>::Parameters limiter_parameters("/limiter");
+  Limiter<dim, double>::Parameters limiter_parameters;
 
   using state_type = HyperbolicSystem::View<dim, double>::state_type;
 

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -21,10 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-
-  const double relaxation_factor = 1.;
-  const double newton_tolerance = 1.e-10;
-  const unsigned int newton_max_iter = 2;
+  Limiter<dim, double>::Parameters limiter_parameters("/limiter");
 
   using state_type = HyperbolicSystem::View<dim, double>::state_type;
 
@@ -37,10 +34,8 @@ int main()
   precomputed_type dummy;
 
   Limiter<dim, double> limiter(hyperbolic_system,
-                               dummy,
-                               relaxation_factor,
-                               newton_tolerance,
-                               newton_max_iter);
+                               limiter_parameters,
+                               dummy);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler/riemann_solver-simd.cc
+++ b/tests/euler/riemann_solver-simd.cc
@@ -19,6 +19,9 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
+  RiemannSolver<dim, Number>::Parameters riemann_solver_parameters(
+      "/riemann_solver");
+
   const double gamma = hyperbolic_system.view<dim, double>().gamma();
 
   static constexpr unsigned int n_precomputed_values =
@@ -26,7 +29,8 @@ int main()
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  RiemannSolver<dim, Number> riemann_solver(hyperbolic_system, dummy);
+  RiemannSolver<dim, Number> riemann_solver(
+      hyperbolic_system, riemann_solver_parameters, dummy);
 
   const auto riemann_data = [&](const auto &state) {
     const Number rho = state[0];

--- a/tests/euler/riemann_solver-simd.cc
+++ b/tests/euler/riemann_solver-simd.cc
@@ -19,8 +19,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  RiemannSolver<dim, Number>::Parameters riemann_solver_parameters(
-      "/riemann_solver");
+  RiemannSolver<dim, Number>::Parameters riemann_solver_parameters;
 
   const double gamma = hyperbolic_system.view<dim, double>().gamma();
 

--- a/tests/euler/riemann_solver.cc
+++ b/tests/euler/riemann_solver.cc
@@ -17,6 +17,8 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
+  RiemannSolver<dim, double>::Parameters riemann_solver_parameters(
+      "/riemann_solver");
 
   const double gamma = hyperbolic_system.view<dim, double>().gamma();
 
@@ -25,7 +27,8 @@ int main()
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  RiemannSolver<dim> riemann_solver(hyperbolic_system, dummy);
+  RiemannSolver<dim> riemann_solver(
+      hyperbolic_system, riemann_solver_parameters, dummy);
 
   const auto riemann_data = [&](const auto &state) {
     const double rho = state[0];

--- a/tests/euler/riemann_solver.cc
+++ b/tests/euler/riemann_solver.cc
@@ -17,8 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  RiemannSolver<dim, double>::Parameters riemann_solver_parameters(
-      "/riemann_solver");
+  RiemannSolver<dim, double>::Parameters riemann_solver_parameters;
 
   const double gamma = hyperbolic_system.view<dim, double>().gamma();
 

--- a/tests/euler/verification-isentropic_vortex-2d-erk33-l5.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-erk33-l5.prm
@@ -44,11 +44,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler/verification-isentropic_vortex-2d-erk33-l6.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-erk33-l6.prm
@@ -44,11 +44,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler/verification-isentropic_vortex-2d-erk33-l7.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-erk33-l7.prm
@@ -44,11 +44,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler/verification-isentropic_vortex-2d-ssprk33-l5.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-ssprk33-l5.prm
@@ -44,11 +44,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler/verification-isentropic_vortex-2d-ssprk33-l6.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-ssprk33-l6.prm
@@ -44,11 +44,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler/verification-isentropic_vortex-2d-ssprk33-l7.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-ssprk33-l7.prm
@@ -44,11 +44,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler/verification-leblanc-1d-erk33-l6.prm
+++ b/tests/euler/verification-leblanc-1d-erk33-l6.prm
@@ -45,7 +45,7 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  subsection Limiter
+  subsection limiter
     set iterations            = 2
     set newton max iterations = 2
     set newton tolerance      = 1e-10

--- a/tests/euler/verification-leblanc-1d-erk33-l6.prm
+++ b/tests/euler/verification-leblanc-1d-erk33-l6.prm
@@ -45,10 +45,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 8
+  subsection Limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/tests/euler/verification-rarefaction-1d-erk33-l6.prm
+++ b/tests/euler/verification-rarefaction-1d-erk33-l6.prm
@@ -44,10 +44,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 8
+  subsection Limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/tests/euler/verification-rarefaction-1d-erk33-l6.prm
+++ b/tests/euler/verification-rarefaction-1d-erk33-l6.prm
@@ -44,7 +44,7 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  subsection Limiter
+  subsection limiter
     set iterations            = 2
     set newton max iterations = 2
     set newton tolerance      = 1e-10

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -21,10 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-
-  const double relaxation_factor = 1.;
-  const double newton_tolerance = 1.e-10;
-  const unsigned int newton_max_iter = 2;
+  Limiter<dim, double>::Parameters limiter_parameters("/limiter");
 
   const auto set_covolume = [&](const double covolume) {
     /*
@@ -53,10 +50,8 @@ int main()
   precomputed_type dummy;
 
   Limiter<dim, double> limiter(hyperbolic_system,
-                               dummy,
-                               relaxation_factor,
-                               newton_tolerance,
-                               newton_max_iter);
+                               limiter_parameters,
+                               dummy);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -49,9 +49,7 @@ int main()
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  Limiter<dim, double> limiter(hyperbolic_system,
-                               limiter_parameters,
-                               dummy);
+  Limiter<dim, double> limiter(hyperbolic_system, limiter_parameters, dummy);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  Limiter<dim, double>::Parameters limiter_parameters("/limiter");
+  Limiter<dim, double>::Parameters limiter_parameters;
 
   const auto set_covolume = [&](const double covolume) {
     /*

--- a/tests/euler_aeos/riemann_solver-strict.cc
+++ b/tests/euler_aeos/riemann_solver-strict.cc
@@ -17,8 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  RiemannSolver<dim, double>::Parameters riemann_solver_parameters(
-      "/riemann_solver");
+  RiemannSolver<dim, double>::Parameters riemann_solver_parameters;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystem::View<dim, double>::n_precomputed_values;

--- a/tests/euler_aeos/riemann_solver-strict.cc
+++ b/tests/euler_aeos/riemann_solver-strict.cc
@@ -17,13 +17,16 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
+  RiemannSolver<dim, double>::Parameters riemann_solver_parameters(
+      "/riemann_solver");
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystem::View<dim, double>::n_precomputed_values;
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  RiemannSolver<dim> riemann_solver(hyperbolic_system, dummy);
+  RiemannSolver<dim> riemann_solver(
+      hyperbolic_system, riemann_solver_parameters, dummy);
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"

--- a/tests/euler_aeos/riemann_solver.cc
+++ b/tests/euler_aeos/riemann_solver.cc
@@ -17,8 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  RiemannSolver<dim, double>::Parameters riemann_solver_parameters(
-      "/riemann_solver");
+  RiemannSolver<dim, double>::Parameters riemann_solver_parameters;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystem::View<dim, double>::n_precomputed_values;

--- a/tests/euler_aeos/riemann_solver.cc
+++ b/tests/euler_aeos/riemann_solver.cc
@@ -17,13 +17,16 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
+  RiemannSolver<dim, double>::Parameters riemann_solver_parameters(
+      "/riemann_solver");
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystem::View<dim, double>::n_precomputed_values;
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  RiemannSolver<dim> riemann_solver(hyperbolic_system, dummy);
+  RiemannSolver<dim> riemann_solver(
+      hyperbolic_system, riemann_solver_parameters, dummy);
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l5.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l5.prm
@@ -48,11 +48,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l6.prm
@@ -48,11 +48,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l7.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l7.prm
@@ -48,11 +48,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l5.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l5.prm
@@ -48,11 +48,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l6.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l6.prm
@@ -48,11 +48,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l7.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l7.prm
@@ -48,11 +48,6 @@ subsection E - InitialValues
   end
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl min            = 0.2
   set cfl max            = 0.2

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.prm
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.prm
@@ -49,7 +49,7 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  subsection Limiter
+  subsection limiter
     set iterations            = 2
     set newton max iterations = 2
     set newton tolerance      = 1e-10

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.prm
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.prm
@@ -49,10 +49,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 8
+  subsection Limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
@@ -49,7 +49,7 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  subsection Limiter
+  subsection limiter
     set iterations            = 2
     set newton max iterations = 2
     set newton tolerance      = 1e-10

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
@@ -49,10 +49,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 8
+  subsection Limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
@@ -48,7 +48,7 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  subsection Limiter
+  subsection limiter
     set iterations            = 2
     set newton max iterations = 2
     set newton tolerance      = 1e-10

--- a/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
@@ -48,10 +48,12 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 8
+  subsection Limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 8
+  end
 end
 
 

--- a/tests/navier_stokes/gmg_energy.prm
+++ b/tests/navier_stokes/gmg_energy.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/gmg_velocity.prm
+++ b/tests/navier_stokes/gmg_velocity.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/gmg_velocity_energy.prm
+++ b/tests/navier_stokes/gmg_velocity_energy.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l5-2d.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l5-2d.prm
@@ -54,12 +54,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l5.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l5.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l6.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l6.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l7.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l7.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l5-2d.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l5-2d.prm
@@ -54,12 +54,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l5.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l5.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l6.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l6.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l7.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l7.prm
@@ -53,12 +53,6 @@ subsection E - InitialValues
 end
 
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs = false
-  set limiter iterations     = 2
-end
-
-
 subsection G - ParabolicModule
   set tolerance             = 1e-16
   set tolerance linfty norm = false

--- a/tests/scalar_conservation/riemann_solver.cc
+++ b/tests/scalar_conservation/riemann_solver.cc
@@ -22,6 +22,9 @@ void test(const std::string &expression)
   std::cout << std::scientific;
 
   HyperbolicSystem hyperbolic_system;
+  typename RiemannSolver<dim, Number>::Parameters riemann_solver_parameters(
+      "/riemann_solver");
+
   const auto view = hyperbolic_system.view<dim, Number>();
 
   {
@@ -45,7 +48,8 @@ void test(const std::string &expression)
 
   precomputed_type dummy;
 
-  RiemannSolver<dim, Number> riemann_solver(hyperbolic_system, dummy);
+  RiemannSolver<dim> riemann_solver(
+      hyperbolic_system, riemann_solver_parameters, dummy);
 
   std::cout << "\n\ndim = " << dim << std::endl;
   std::cout << "f(u)={" + expression + "}" << std::endl;

--- a/tests/scalar_conservation/riemann_solver.cc
+++ b/tests/scalar_conservation/riemann_solver.cc
@@ -23,7 +23,7 @@ void test(const std::string &expression)
 
   HyperbolicSystem hyperbolic_system;
   typename RiemannSolver<dim, Number>::Parameters riemann_solver_parameters(
-      "/riemann_solver");
+      "/RiemannSolver");
 
   const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -31,8 +31,10 @@ void test(const std::string &expression)
     std::stringstream parameters;
     parameters << "subsection HyperbolicSystem\n"
                << "set flux = " << expression << "\n"
-               << "set riemann solver greedy wavespeed = true\n"
-               << "set riemann solver averaged entropy = true\n"
+               << "end\n"
+               << "subsection RiemannSolver\n"
+               << "set use greedy wavespeed = true\n"
+               << "set use averaged entropy = true\n"
                << "end\n"
                << std::endl;
     ParameterAcceptor::initialize(parameters);

--- a/tests/scalar_conservation/riemann_solver.cc
+++ b/tests/scalar_conservation/riemann_solver.cc
@@ -22,8 +22,7 @@ void test(const std::string &expression)
   std::cout << std::scientific;
 
   HyperbolicSystem hyperbolic_system;
-  typename RiemannSolver<dim, Number>::Parameters riemann_solver_parameters(
-      "/RiemannSolver");
+  typename RiemannSolver<dim, Number>::Parameters riemann_solver_parameters;
 
   const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/tests/shallow_water/riemann_solver.cc
+++ b/tests/shallow_water/riemann_solver.cc
@@ -19,8 +19,7 @@ int main()
   HyperbolicSystem hyperbolic_system;
   const double gravity = hyperbolic_system.view<dim, double>().gravity();
 
-  RiemannSolver<dim, double>::Parameters riemann_solver_parameters(
-      "/riemann_solver");
+  RiemannSolver<dim, double>::Parameters riemann_solver_parameters;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystem::View<dim, double>::n_precomputed_values;

--- a/tests/shallow_water/riemann_solver.cc
+++ b/tests/shallow_water/riemann_solver.cc
@@ -19,12 +19,16 @@ int main()
   HyperbolicSystem hyperbolic_system;
   const double gravity = hyperbolic_system.view<dim, double>().gravity();
 
+  RiemannSolver<dim, double>::Parameters riemann_solver_parameters(
+      "/riemann_solver");
+
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystem::View<dim, double>::n_precomputed_values;
   using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  RiemannSolver<dim> riemann_solver(hyperbolic_system, dummy);
+  RiemannSolver<dim> riemann_solver(
+      hyperbolic_system, riemann_solver_parameters, dummy);
 
   const auto riemann_data = [&](const auto &state) {
     const auto h = hyperbolic_system.view<dim, double>().water_depth_sharp(

--- a/tests/shallow_water/verification-paraboloid_1d-erk33-l7.prm
+++ b/tests/shallow_water/verification-paraboloid_1d-erk33-l7.prm
@@ -37,9 +37,6 @@ subsection B - Equation
   set gravity                      = 9.81
   set manning friction coefficient = 0
 
-  set limiter kinetic energy       = true
-  set limiter square velocity      = false
-
   set reference water depth        = 10
   set dry state relaxation factor  = 1.0e-3
   set dry state relaxation small   = 1e2
@@ -70,6 +67,13 @@ subsection E - InitialValues
     set paraboloid length   = 10000
     set speed               = 2
     set water height        = 10
+  end
+end
+
+subsection F - HyperbolicModule
+  subsection Limiter
+    set limit on kinetic energy  = true
+    set limit on square velocity = false
   end
 end
 

--- a/tests/shallow_water/verification-paraboloid_1d-erk33-l7.prm
+++ b/tests/shallow_water/verification-paraboloid_1d-erk33-l7.prm
@@ -71,7 +71,7 @@ subsection E - InitialValues
 end
 
 subsection F - HyperbolicModule
-  subsection Limiter
+  subsection limiter
     set limit on kinetic energy  = true
     set limit on square velocity = false
   end

--- a/tests/shallow_water/verification-ritter_dam_break-erk33-l7.prm
+++ b/tests/shallow_water/verification-ritter_dam_break-erk33-l7.prm
@@ -36,9 +36,6 @@ subsection B - Equation
   set gravity                      = 9.81
   set manning friction coefficient = 0
 
-  set limiter kinetic energy       = true
-  set limiter square velocity      = false
-
   set reference water depth        = 0.005
   set dry state relaxation factor  = 1.0e-3
   set dry state relaxation small   = 1e2
@@ -67,6 +64,13 @@ subsection E - InitialValues
   subsection ritter dam break
     set time initial = 1
     set left water depth = 0.005
+  end
+end
+
+subsection F - HyperbolicModule
+  subsection Limiter
+    set limit on kinetic energy  = true
+    set limit on square velocity = false
   end
 end
 

--- a/tests/shallow_water/verification-ritter_dam_break-erk33-l7.prm
+++ b/tests/shallow_water/verification-ritter_dam_break-erk33-l7.prm
@@ -68,7 +68,7 @@ subsection E - InitialValues
 end
 
 subsection F - HyperbolicModule
-  subsection Limiter
+  subsection limiter
     set limit on kinetic energy  = true
     set limit on square velocity = false
   end

--- a/tests/shallow_water/verification-smooth_vortex-erk33-l6.prm
+++ b/tests/shallow_water/verification-smooth_vortex-erk33-l6.prm
@@ -70,7 +70,7 @@ subsection E - InitialValues
 end
 
 subsection F - HyperbolicModule
-  subsection Limiter
+  subsection limiter
     set limit on kinetic energy  = false
     set limit on square velocity = true
   end

--- a/tests/shallow_water/verification-smooth_vortex-erk33-l6.prm
+++ b/tests/shallow_water/verification-smooth_vortex-erk33-l6.prm
@@ -36,9 +36,6 @@ subsection B - Equation
   set gravity                      = 9.81
   set manning friction coefficient = 0
 
-  set limiter kinetic energy       = false
-  set limiter square velocity      = true
-
   set reference water depth        = 2
   set dry state relaxation factor  = 0
   set dry state relaxation small   = 1e2
@@ -69,6 +66,13 @@ subsection E - InitialValues
     set beta            = 2
     set mach number     = 1
     set reference depth = 2
+  end
+end
+
+subsection F - HyperbolicModule
+  subsection Limiter
+    set limit on kinetic energy  = false
+    set limit on square velocity = true
   end
 end
 

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.prm
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.prm
@@ -64,7 +64,7 @@ subsection E - InitialValues
 end
 
 subsection F - HyperbolicModule
-  subsection Limiter
+  subsection limiter
     set limit on kinetic energy  = false
     set limit on square velocity = true
   end

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.prm
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.prm
@@ -36,9 +36,6 @@ subsection B - Equation
   set gravity                      = 9.81
   set manning friction coefficient = 1.e-2
 
-  set limiter kinetic energy       = false
-  set limiter square velocity      = true
-  
   set reference water depth        = 1
   set dry state relaxation large   = 1e4
   set dry state relaxation small   = 1e4
@@ -57,7 +54,6 @@ subsection C - Discretization
 end
 
 subsection E - InitialValues
-
   set configuration = sloping friction
   set position      = 0
 
@@ -65,7 +61,13 @@ subsection E - InitialValues
    set ramp slope        = 1.e-2
    set initial discharge = 1.e-1
   end
+end
 
+subsection F - HyperbolicModule
+  subsection Limiter
+    set limit on kinetic energy  = false
+    set limit on square velocity = true
+  end
 end
 
 subsection H - TimeIntegrator

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.prm
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.prm
@@ -68,15 +68,6 @@ subsection E - InitialValues
 
 end
 
-subsection F - HyperbolicModule
-  set cfl with boundary dofs        = false
-  set indicator evc factor          = 1
-  set limiter iterations            = 2
-  set limiter newton max iterations = 2
-  set limiter newton tolerance      = 1e-10
-  set limiter relaxation factor     = 2
-end
-
 subsection H - TimeIntegrator
   set cfl max               = 0.50
   set cfl min               = 0.50


### PR DESCRIPTION
This changeset creates small parameter classes for all of our indicators, limiters, and riemann solvers. This moves most of these parameters out of the `HyperbolicSystem` and to a subsection under `HyperbolicModule`.