### PR TITLE
Shallow water: Add support for geotiff image files for reading in a bathymetry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,11 @@ if("${WITH_EOSPAC}" STREQUAL "")
 endif()
 option(WITH_EOSPAC "Add support for the EOSPAC suite" ${EOSPAC_FOUND})
 
+if("${WITH_GDAL}" STREQUAL "")
+  find_package(GDAL QUIET)
+endif()
+option(WITH_GDAL "Compile and link against the gdal library" ${GDAL_FOUND})
+
 #
 # Set up compiler flags:
 #
@@ -132,19 +137,24 @@ set(CMAKE_EXE_LINKER_FLAGS "")
 
 set(EXTERNAL_TARGETS)
 
-if(WITH_OPENMP)
-  find_package(OpenMP REQUIRED)
-  list(APPEND EXTERNAL_TARGETS "OpenMP::OpenMP_CXX")
-endif()
-
 if(WITH_EOSPAC)
   find_package(EOSPAC REQUIRED)
   list(APPEND EXTERNAL_TARGETS "Eospac::Eospac6")
 endif()
 
+if(WITH_GDAL)
+  find_package(GDAL REQUIRED)
+  list(APPEND EXTERNAL_TARGETS "GDAL::GDAL")
+endif()
+
 if(WITH_LIKWID)
   find_package(LIKWID REQUIRED)
   list(APPEND EXTERNAL_TARGETS "Likwid::Likwid")
+endif()
+
+if(WITH_OPENMP)
+  find_package(OpenMP REQUIRED)
+  list(APPEND EXTERNAL_TARGETS "OpenMP::OpenMP_CXX")
 endif()
 
 if(WITH_VALGRIND)

--- a/source/compile_time_options.h.in
+++ b/source/compile_time_options.h.in
@@ -22,6 +22,7 @@
 /* External packages: */
 
 #cmakedefine WITH_EOSPAC
+#cmakedefine WITH_GDAL
 #cmakedefine WITH_LIKWID
 #cmakedefine WITH_OPENMP
 #cmakedefine WITH_VALGRIND

--- a/source/initial_state_library.h
+++ b/source/initial_state_library.h
@@ -43,7 +43,7 @@ namespace ryujin
     using precomputed_state_type = typename View::precomputed_state_type;
 
     /**
-     * Constructor taking geometry name @p name and a subsection @p
+     * Constructor taking initial state name @p name and a subsection @p
      * subsection as an argument. The dealii::ParameterAcceptor is
      * initialized with the subsubsection `subsection + "/" + name`.
      */
@@ -78,7 +78,7 @@ namespace ryujin
     }
 
     /**
-     * Return the name of the geometry as (const reference) std::string
+     * Return the name of the initial state as (const reference) std::string
      */
     ACCESSOR_READ_ONLY(name)
 

--- a/source/lazy.h
+++ b/source/lazy.h
@@ -10,7 +10,12 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>
+
+#if DEAL_II_VERSION_GTE(9, 5, 0)
 #include <deal.II/base/mutex.h>
+#else
+#include <deal.II/base/thread_management.h>
+#endif
 
 #include <atomic>
 #include <mutex>

--- a/source/lazy.h
+++ b/source/lazy.h
@@ -1,0 +1,178 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2023 - 2024 by Matthias Maier
+// Copyright (C) 2024 - 2024 by the ryujin authors
+//
+
+#pragma once
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/exceptions.h>
+#include <deal.II/base/memory_consumption.h>
+#include <deal.II/base/mutex.h>
+
+#include <atomic>
+#include <mutex>
+#include <optional>
+
+
+namespace ryujin
+{
+  /**
+   * This is a slightly minimized variant of the Lazy<T> initialization class
+   * shipped with the current development version of deal.II.
+   */
+  template <typename T>
+  class Lazy
+  {
+  public:
+    Lazy();
+    Lazy(const Lazy &other);
+    Lazy(Lazy &&other) noexcept;
+
+    Lazy &operator=(const Lazy &other);
+    Lazy &operator=(Lazy &&other) noexcept;
+
+    void reset() noexcept;
+
+    template <typename Callable>
+    void ensure_initialized(const Callable &creator) const;
+
+    bool has_value() const;
+
+    const T &value() const;
+    T &value();
+
+  private:
+    mutable std::optional<T> object;
+    mutable std::atomic<bool> object_is_initialized;
+    mutable dealii::Threads::Mutex initialization_mutex;
+  };
+
+
+  // ------------------------------- inline functions --------------------------
+
+
+  template <typename T>
+  inline Lazy<T>::Lazy()
+      : object_is_initialized(false)
+  {
+  }
+
+
+  template <typename T>
+  inline Lazy<T>::Lazy(const Lazy &other)
+      : object(other.object)
+  {
+    object_is_initialized.store(other.object_is_initialized.load());
+  }
+
+
+  template <typename T>
+  inline Lazy<T>::Lazy(Lazy &&other) noexcept
+      : object(std::move(other.object))
+  {
+    object_is_initialized.store(other.object_is_initialized.load());
+
+    other.object_is_initialized.store(false);
+    other.object.reset();
+  }
+
+
+  template <typename T>
+  inline Lazy<T> &Lazy<T>::operator=(const Lazy &other)
+  {
+    object = other.object;
+    object_is_initialized.store(other.object_is_initialized.load());
+
+    return *this;
+  }
+
+
+  template <typename T>
+  inline Lazy<T> &Lazy<T>::operator=(Lazy &&other) noexcept
+  {
+    object = std::move(other.object);
+    object_is_initialized.store(other.object_is_initialized.load());
+
+    other.object_is_initialized.store(false);
+    other.object.reset();
+
+    return *this;
+  }
+
+
+  template <typename T>
+  inline void Lazy<T>::reset() noexcept
+  {
+    object_is_initialized.store(false);
+    object.reset();
+  }
+
+
+  template <typename T>
+  template <typename Callable>
+  inline DEAL_II_ALWAYS_INLINE void
+  Lazy<T>::ensure_initialized(const Callable &creator) const
+  {
+    // Check the object_is_initialized atomic with "acquire" semantics.
+    if (!object_is_initialized.load(std::memory_order_acquire))
+#ifdef DEAL_II_HAVE_CXX20
+        [[unlikely]]
+#endif
+    {
+      std::lock_guard<std::mutex> lock(initialization_mutex);
+
+      //
+      // Check again. If this thread won the race to the lock then we
+      // initialize the object. Otherwise another thread has already
+      // initialized the object and flipped the object_is_initialized
+      // bit. (Here, the initialization_mutex ensures consistent ordering
+      // with a memory fence, so we will observe the updated bool without
+      // acquire semantics.)
+      //
+      if (!object_is_initialized.load(std::memory_order_relaxed)) {
+        Assert(object.has_value() == false, dealii::ExcInternalError());
+        object.emplace(std::move(creator()));
+
+        // Flip the object_is_initialized boolean with "release" semantics.
+        object_is_initialized.store(true, std::memory_order_release);
+      }
+    }
+  }
+
+
+  template <typename T>
+  inline DEAL_II_ALWAYS_INLINE bool Lazy<T>::has_value() const
+  {
+    return (object_is_initialized && object.has_value());
+  }
+
+
+  template <typename T>
+  inline DEAL_II_ALWAYS_INLINE const T &Lazy<T>::value() const
+  {
+    Assert(object_is_initialized && object.has_value(),
+           dealii::ExcMessage(
+               "value() has been called but the contained object has not been "
+               "initialized. Did you forget to call 'ensure_initialized()' "
+               "first?"));
+
+    return object.value();
+  }
+
+
+  template <typename T>
+  inline DEAL_II_ALWAYS_INLINE T &Lazy<T>::value()
+  {
+    Assert(object_is_initialized && object.has_value(),
+           dealii::ExcMessage(
+               "value() has been called but the contained object has not been "
+               "initialized. Did you forget to call 'ensure_initialized()' "
+               "first?"));
+
+    return object.value();
+  }
+
+} // namespace ryujin

--- a/source/shallow_water/initial_state_geotiff.h
+++ b/source/shallow_water/initial_state_geotiff.h
@@ -1,0 +1,256 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 - 2024 by the ryujin authors
+//
+
+#pragma once
+
+#include <initial_state_library.h>
+#include <lazy.h>
+
+#include <deal.II/base/function_parser.h>
+
+
+#ifdef WITH_GDAL
+#include <cpl_conv.h>
+#include <gdal.h>
+#include <gdal_priv.h>
+#endif
+
+namespace ryujin
+{
+  namespace ShallowWaterInitialStates
+  {
+    /**
+     * Returns an initial state defined by a set of user specified functions
+     * based on the primitive variables.
+     *
+     * @ingroup ShallowWaterEquations
+     */
+    template <typename Description, int dim, typename Number>
+    class GeoTIFF : public InitialState<Description, dim, Number>
+    {
+    public:
+      using HyperbolicSystem = typename Description::HyperbolicSystem;
+      using View =
+          typename Description::template HyperbolicSystemView<dim, Number>;
+      using state_type = typename View::state_type;
+
+
+      GeoTIFF(const HyperbolicSystem &hyperbolic_system,
+              const std::string subsection)
+          : InitialState<Description, dim, Number>("geotiff", subsection)
+          , hyperbolic_system_(hyperbolic_system)
+      {
+        filename_ = "ryujin.tif";
+        this->add_parameter(
+            "filename", filename_, "GeoTIFF image file to load");
+
+        height_expression_ = "1.4";
+        this->add_parameter(
+            "water height expression",
+            height_expression_,
+            "A function expression describing the water height");
+
+        velocity_expression_ = "0.0";
+        this->add_parameter("velocity expression",
+                            velocity_expression_,
+                            "A function expression describing the velocity");
+
+        const auto set_up = [this] {
+#ifdef WITH_GDAL
+          /* Initial GDAL and reset all data: */
+          GDALAllRegister();
+          driver_name = "";
+          driver_projection = "";
+          affine_transformation = {0, 0, 0, 0, 0, 0};
+          raster_offset = {0, 0};
+          raster_size = {0, 0};
+          raster.clear();
+#endif
+
+          using FP = dealii::FunctionParser<dim>;
+          /*
+           * This variant of the constructor initializes the function
+           * parser with support for a time-dependent description involving
+           * a variable »t«:
+           */
+          height_function_ = std::make_unique<FP>(height_expression_);
+          velocity_function_ = std::make_unique<FP>(velocity_expression_);
+        };
+
+        set_up();
+        this->parse_parameters_call_back.connect(set_up);
+      }
+
+      state_type compute(const dealii::Point<dim> &point, Number t) final
+      {
+        const auto z = compute_bathymetry(point);
+
+        dealii::Tensor<1, 2, Number> primitive;
+
+        height_function_->set_time(t);
+        primitive[0] = std::max(Number(0.), height_function_->value(point) - z);
+
+        velocity_function_->set_time(t);
+        primitive[1] = velocity_function_->value(point);
+
+        const auto view = hyperbolic_system_.template view<dim, Number>();
+        return view.from_initial_state(primitive);
+      }
+
+      typename InitialState<Description, dim, Number>::precomputed_state_type
+      initial_precomputations(const dealii::Point<dim> &point) final
+      {
+        /* Compute bathymetry: */
+        return {compute_bathymetry(point)};
+      }
+
+    private:
+      const HyperbolicSystem &hyperbolic_system_;
+
+
+      void read_in_raster() const
+      {
+#ifdef WITH_GDAL
+        auto dataset_handle = GDALOpen(filename_.c_str(), GA_ReadOnly);
+        AssertThrow(dataset_handle,
+                    dealii::ExcMessage("GDAL error: file not found"));
+
+        auto dataset = GDALDataset::FromHandle(dataset_handle);
+        Assert(dataset, dealii::ExcInternalError());
+
+        const auto driver = dataset->GetDriver();
+
+        driver_name = driver->GetMetadataItem(GDAL_DMD_LONGNAME);
+        if (dataset->GetProjectionRef() != nullptr)
+          driver_projection = dataset->GetProjectionRef();
+
+        /* For now we support one raster in the dataset: */
+
+        AssertThrow(
+            dataset->GetRasterCount() == 1,
+            dealii::ExcMessage(
+                "GDAL driver error: currently we only support one raster"));
+
+        const auto raster_band = dataset->GetRasterBand(1);
+
+        AssertThrow(dataset->GetRasterXSize() == raster_band->GetXSize() &&
+                        dataset->GetRasterYSize() == raster_band->GetYSize(),
+                    dealii::ExcMessage(
+                        "GDAL driver error: the raster band has a different "
+                        "dimension than the (global) raster dimension of the "
+                        "geotiff image. This is not supported."));
+
+        /*
+         * Construct the affine transformation from information in the geotiff
+         * image, or from the parameter file:
+         */
+
+        const auto tiff_with_geotransform =
+            dataset->GetGeoTransform(affine_transformation.data()) == CE_None;
+
+//         printf("Origin = (%.6f,%.6f)\n",
+//                affine_transformation[0],
+//                affine_transformation[3]);
+//         printf("Pixel Size = (%.6f,%.6f)\n",
+//                affine_transformation[1],
+//                affine_transformation[5]);
+//         printf("Pixel Rota = (%.6f,%.6f)\n",
+//                affine_transformation[2],
+//                affine_transformation[4]);
+
+        /*
+         * FIXME: For now, we simply read in the entire geotiff file on
+         * each rank. In order to save memory for very large files it would
+         * be possible to create a bounding box for the all active cells of
+         * the triangulation and then only read in a small region for which
+         * we actually need data.
+         */
+
+        raster_offset = {0, 0};
+        raster_size = {dataset->GetRasterXSize(), dataset->GetRasterYSize()};
+
+        raster.resize(raster_size[0] * raster_size[1]);
+        const auto error_code = raster_band->RasterIO(
+            GF_Read,
+            raster_offset[0], /* x-offset of image region */
+            raster_offset[1], /* y-offset of image region */
+            raster_size[0],   /* x-size of image region */
+            raster_size[1],   /* y-size of image region */
+            raster.data(),
+            raster_size[0], /* x-size of target buffer */
+            raster_size[1], /* y-size of target buffer */
+            GDT_Float32,
+            0,
+            0);
+
+        AssertThrow(error_code == 0,
+                    dealii::ExcMessage(
+                        "GDAL driver error: error reading in geotiff file"));
+
+        GDALClose(dataset_handle);
+
+#ifdef DEBUG_OUTPUT
+        std::cout << "GDAL: driver name    = " << driver_name;
+        std::cout << "\nGDAL: projection     = " << driver_projection;
+        std::cout << "\nGDAL: transformation =";
+        for (const auto &it : affine_transformation)
+          std::cout << " " << it;
+        std::cout << "\nGDAL: raster offset  =";
+        for (const auto &it : raster_offset)
+          std::cout << " " << it;
+        std::cout << "\nGDAL: raster size    =";
+        for (const auto &it : raster_size)
+          std::cout << " " << it;
+        std::cout << std::endl;
+#endif
+
+#else
+        static constexpr auto message =
+            "ryujin has to be configured with GDAL support in order to read in "
+            "GeoTIFF images";
+        AssertThrow(false, dealii::ExcMessage(message));
+        __builtin_trap();
+#endif
+      }
+
+
+      DEAL_II_ALWAYS_INLINE inline Number
+      compute_bathymetry(const dealii::Point<dim> & /*point*/) const
+      {
+        geotiff.ensure_initialized([&]() { read_in_raster(); return true; });
+
+        return 0.;
+      }
+
+
+      /* Runtime parameters: */
+
+      std::string filename_;
+
+      std::string height_expression_;
+      std::string velocity_expression_;
+
+      /* GDAL data structures: */
+
+      //
+      // We use a Lazy<t> wrapper for lazy initialization with efficient
+      // Schmidt's double checking. We simply ignore the bool type here.
+      //
+      Lazy<bool> geotiff;
+
+      mutable std::string driver_name;
+      mutable std::string driver_projection;
+      mutable std::array<double, 6> affine_transformation;
+      mutable std::array<int, 2> raster_offset;
+      mutable std::array<int, 2> raster_size;
+      mutable std::vector<float> raster;
+
+      /* Fields for muparser support for water height and velocity: */
+
+      std::unique_ptr<dealii::FunctionParser<dim>> height_function_;
+      std::unique_ptr<dealii::FunctionParser<dim>> velocity_function_;
+    };
+  } // namespace ShallowWaterInitialStates
+} // namespace ryujin

--- a/source/shallow_water/initial_state_geotiff.h
+++ b/source/shallow_water/initial_state_geotiff.h
@@ -22,8 +22,9 @@ namespace ryujin
   namespace ShallowWaterInitialStates
   {
     /**
-     * Returns an initial state defined by a set of user specified functions
-     * based on the primitive variables.
+     * Returns an initial state by reading a bathymetry from a geotiff
+     * file. For this we link against GDAL, see https://gdal.org/index.html
+     * for details on GDAL and what image formats it supports.
      *
      * @ingroup ShallowWaterEquations
      */

--- a/source/shallow_water/initial_state_library_shallow_water.h
+++ b/source/shallow_water/initial_state_library_shallow_water.h
@@ -12,6 +12,7 @@
 #include "initial_state_contrast.h"
 #include "initial_state_flow_over_bump.h"
 #include "initial_state_function.h"
+#include "initial_state_geotiff.h"
 #include "initial_state_hou_test.h"
 #include "initial_state_paraboloid.h"
 #include "initial_state_ritter_dam_break.h"
@@ -40,6 +41,7 @@ namespace ryujin
       add(std::make_unique<Contrast<Description, dim, Number>>(h, s));
       add(std::make_unique<FlowOverBump<Description, dim, Number>>(h, s));
       add(std::make_unique<Function<Description, dim, Number>>(h, s));
+      add(std::make_unique<GeoTIFF<Description, dim, Number>>(h, s));
       add(std::make_unique<HouTest<Description, dim, Number>>(h, s));
       add(std::make_unique<Paraboloid<Description, dim, Number>>(h, s));
       add(std::make_unique<RitterDamBreak<Description, dim, Number>>(h, s));


### PR DESCRIPTION
This is a quick hack to add rudimentary support for geotiff files. We could add support for geotiff (and other raster elevation formats supported by gdal) much more comprehensively, I'll open an issue for that.