### PR TITLE
`HyperbolicSystem`: Simplify nodal source interface

### DIFF
--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -583,13 +583,11 @@ namespace ryujin
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int i,
                               const state_type &U_i,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const = delete;
 
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int *js,
                               const state_type &U_j,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const = delete;
 
       //@}

--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -580,29 +580,17 @@ namespace ryujin
       /** We do not have source terms: */
       static constexpr bool have_source_terms = false;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int i,
-                                  const state_type &U_i,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const = delete;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int i,
+                              const state_type &U_i,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const = delete;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int *js,
-                                  const state_type &U_j,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const = delete;
-
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int i,
-                                   const state_type &U_i,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const = delete;
-
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int *js,
-                                   const state_type &U_j,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const = delete;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int *js,
+                              const state_type &U_j,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const = delete;
 
       //@}
       /**

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -664,13 +664,11 @@ namespace ryujin
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int i,
                               const state_type &U_i,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const = delete;
 
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int *js,
                               const state_type &U_j,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const = delete;
 
       //@}

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -661,29 +661,17 @@ namespace ryujin
       /** We do not have source terms */
       static constexpr bool have_source_terms = false;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int i,
-                                  const state_type &U_i,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const = delete;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int i,
+                              const state_type &U_i,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const = delete;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int *js,
-                                  const state_type &U_j,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const = delete;
-
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int i,
-                                   const state_type &U_i,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const = delete;
-
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int *js,
-                                   const state_type &U_j,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const = delete;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int *js,
+                              const state_type &U_j,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const = delete;
 
       //@}
       /**

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -701,24 +701,24 @@ namespace ryujin
             if constexpr (View::have_source_terms) {
               // FIXME: Chain through correct time
               constexpr Number t = 0.;
-              const auto contribution =
+              const auto S_j =
                   view.nodal_source(new_precomputed, js, U_j, t, tau);
-              F_iH += weight * m_ij * contribution;
-              P_ij += weight * m_ij * contribution;
+              F_iH += weight * m_ij * S_j;
+              P_ij += weight * m_ij * S_j;
             }
 
             for (int s = 0; s < stages; ++s) {
               const auto U_jH = stage_U[s].get().template get_tensor<T>(js);
-              const auto p = view.flux_contribution(
+              const auto flux_jHs = view.flux_contribution(
                   stage_precomputed[s].get(), precomputed_initial_, js, U_jH);
 
               if constexpr (View::have_high_order_flux) {
                 const auto high_order_flux_ij =
-                    view.high_order_flux(flux_iHs[s], p);
+                    view.high_order_flux(flux_iHs[s], flux_jHs);
                 F_iH += stage_weights[s] * contract(high_order_flux_ij, c_ij);
                 P_ij += stage_weights[s] * contract(high_order_flux_ij, c_ij);
               } else {
-                const auto flux_ij = view.flux(flux_iHs[s], p);
+                const auto flux_ij = view.flux(flux_iHs[s], flux_jHs);
                 F_iH += stage_weights[s] * contract(flux_ij, c_ij);
                 P_ij += stage_weights[s] * contract(flux_ij, c_ij);
               }
@@ -726,10 +726,10 @@ namespace ryujin
               if constexpr (View::have_source_terms) {
                 // FIXME: Chain through correct time
                 constexpr Number t = 0.;
-                const auto contribution = view.nodal_source(
+                const auto S_js = view.nodal_source(
                     stage_precomputed[s].get(), js, U_jH, t, tau);
-                F_iH += stage_weights[s] * m_ij * contribution;
-                P_ij += stage_weights[s] * m_ij * contribution;
+                F_iH += stage_weights[s] * m_ij * S_js;
+                P_ij += stage_weights[s] * m_ij * S_js;
               }
             }
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -558,10 +558,8 @@ namespace ryujin
                 stage_precomputed[s].get(), precomputed_initial_, i, temp);
 
             if constexpr (View::have_source_terms) {
-              // FIXME: Chain through correct time
-              constexpr Number t = 0.;
               S_iH += stage_weights[s] *
-                      view.nodal_source(new_precomputed, i, temp, t, tau);
+                      view.nodal_source(new_precomputed, i, temp, tau);
             }
           }
 
@@ -569,12 +567,8 @@ namespace ryujin
           state_type F_iH;
 
           if constexpr (View::have_source_terms) {
-            // FIXME: Chain through correct time
-            constexpr Number t = 0.;
-
-            S_i = view.nodal_source(new_precomputed, i, U_i, t, tau);
+            S_i = view.nodal_source(new_precomputed, i, U_i, tau);
             S_iH += weight * S_i;
-
             U_i_new += tau * /* m_i_inv * m_i */ S_i;
             F_iH += m_i * S_iH;
           }
@@ -699,10 +693,7 @@ namespace ryujin
             }
 
             if constexpr (View::have_source_terms) {
-              // FIXME: Chain through correct time
-              constexpr Number t = 0.;
-              const auto S_j =
-                  view.nodal_source(new_precomputed, js, U_j, t, tau);
+              const auto S_j = view.nodal_source(new_precomputed, js, U_j, tau);
               F_iH += weight * m_ij * S_j;
               P_ij += weight * m_ij * S_j;
             }
@@ -724,10 +715,8 @@ namespace ryujin
               }
 
               if constexpr (View::have_source_terms) {
-                // FIXME: Chain through correct time
-                constexpr Number t = 0.;
                 const auto S_js = view.nodal_source(
-                    stage_precomputed[s].get(), js, U_jH, t, tau);
+                    stage_precomputed[s].get(), js, U_jH, tau);
                 F_iH += stage_weights[s] * m_ij * S_js;
                 P_ij += stage_weights[s] * m_ij * S_js;
               }

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -561,22 +561,21 @@ namespace ryujin
               // FIXME: Chain through correct time
               constexpr Number t = 0.;
               S_iH += stage_weights[s] *
-                      view.high_order_source(new_precomputed, i, temp, t, tau);
+                      view.nodal_source(new_precomputed, i, temp, t, tau);
             }
           }
 
-          state_type F_iH;
           [[maybe_unused]] state_type S_i;
+          state_type F_iH;
 
           if constexpr (View::have_source_terms) {
             // FIXME: Chain through correct time
             constexpr Number t = 0.;
 
-            S_i = view.low_order_source(new_precomputed, i, U_i, t, tau);
-            U_i_new += tau * /* m_i_inv * m_i */ S_i;
+            S_i = view.nodal_source(new_precomputed, i, U_i, t, tau);
+            S_iH += weight * S_i;
 
-            S_iH += weight *
-                    view.high_order_source(new_precomputed, i, U_i, t, tau);
+            U_i_new += tau * /* m_i_inv * m_i */ S_i;
             F_iH += m_i * S_iH;
           }
 
@@ -703,7 +702,7 @@ namespace ryujin
               // FIXME: Chain through correct time
               constexpr Number t = 0.;
               const auto contribution =
-                  view.high_order_source(new_precomputed, js, U_j, t, tau);
+                  view.nodal_source(new_precomputed, js, U_j, t, tau);
               F_iH += weight * m_ij * contribution;
               P_ij += weight * m_ij * contribution;
             }
@@ -727,7 +726,7 @@ namespace ryujin
               if constexpr (View::have_source_terms) {
                 // FIXME: Chain through correct time
                 constexpr Number t = 0.;
-                const auto contribution = view.high_order_source(
+                const auto contribution = view.nodal_source(
                     stage_precomputed[s].get(), js, U_jH, t, tau);
                 F_iH += stage_weights[s] * m_ij * contribution;
                 P_ij += stage_weights[s] * m_ij * contribution;

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -433,13 +433,11 @@ namespace ryujin
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int i,
                               const state_type &U_i,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const = delete;
 
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int *js,
                               const state_type &U_j,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const = delete;
 
       //@}

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -430,29 +430,17 @@ namespace ryujin
       /** We do not have source terms */
       static constexpr bool have_source_terms = false;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int i,
-                                  const state_type &U_i,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const = delete;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int i,
+                              const state_type &U_i,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const = delete;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int *js,
-                                  const state_type &U_j,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const = delete;
-
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int i,
-                                   const state_type &U_i,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const = delete;
-
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int *js,
-                                   const state_type &U_j,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const = delete;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int *js,
+                              const state_type &U_j,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const = delete;
 
       //@}
       /**

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -560,29 +560,17 @@ namespace ryujin
                                   const Number &h_star,
                                   const ScalarNumber tau) const;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int i,
-                                  const state_type &U_i,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int i,
+                              const state_type &U_i,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int *js,
-                                  const state_type &U_j,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const;
-
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int i,
-                                   const state_type &U_i,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const;
-
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int *js,
-                                   const state_type &U_j,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int *js,
+                              const state_type &U_j,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const;
 
       //@}
       /**
@@ -1224,7 +1212,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    HyperbolicSystemView<dim, Number>::low_order_source(
+    HyperbolicSystemView<dim, Number>::nodal_source(
         const precomputed_vector_type &pv,
         const unsigned int i,
         const state_type &U_i,
@@ -1240,39 +1228,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    HyperbolicSystemView<dim, Number>::low_order_source(
-        const precomputed_vector_type &pv,
-        const unsigned int *js,
-        const state_type &U_j,
-        const ScalarNumber /*t*/,
-        const ScalarNumber tau) const -> state_type
-    {
-      const auto &[eta_m, h_star] =
-          pv.template get_tensor<Number, precomputed_state_type>(js);
-
-      return manning_friction(U_j, h_star, tau);
-    }
-
-
-    template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto
-    HyperbolicSystemView<dim, Number>::high_order_source(
-        const precomputed_vector_type &pv,
-        const unsigned int i,
-        const state_type &U_i,
-        const ScalarNumber /*t*/,
-        const ScalarNumber tau) const -> state_type
-    {
-      const auto &[eta_m, h_star] =
-          pv.template get_tensor<Number, precomputed_state_type>(i);
-
-      return manning_friction(U_i, h_star, tau);
-    }
-
-
-    template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto
-    HyperbolicSystemView<dim, Number>::high_order_source(
+    HyperbolicSystemView<dim, Number>::nodal_source(
         const precomputed_vector_type &pv,
         const unsigned int *js,
         const state_type &U_j,

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -563,13 +563,11 @@ namespace ryujin
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int i,
                               const state_type &U_i,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const;
 
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int *js,
                               const state_type &U_j,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const;
 
       //@}
@@ -1216,7 +1214,6 @@ namespace ryujin
         const precomputed_vector_type &pv,
         const unsigned int i,
         const state_type &U_i,
-        const ScalarNumber /*t*/,
         const ScalarNumber tau) const -> state_type
     {
       const auto &[eta_m, h_star] =
@@ -1232,7 +1229,6 @@ namespace ryujin
         const precomputed_vector_type &pv,
         const unsigned int *js,
         const state_type &U_j,
-        const ScalarNumber /*t*/,
         const ScalarNumber tau) const -> state_type
     {
       const auto &[eta_m, h_star] =

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -339,13 +339,11 @@ namespace ryujin
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int i,
                               const state_type &U_i,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const = delete;
 
       state_type nodal_source(const precomputed_vector_type &pv,
                               const unsigned int *js,
                               const state_type &U_j,
-                              const ScalarNumber t,
                               const ScalarNumber tau) const = delete;
 
       //@}

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -336,17 +336,17 @@ namespace ryujin
       /** We do not have source terms */
       static constexpr bool have_source_terms = false;
 
-      state_type low_order_source(const precomputed_vector_type &pv,
-                                  const unsigned int i,
-                                  const state_type &U_i,
-                                  const ScalarNumber t,
-                                  const ScalarNumber tau) const = delete;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int i,
+                              const state_type &U_i,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const = delete;
 
-      state_type high_order_source(const precomputed_vector_type &pv,
-                                   const unsigned int i,
-                                   const state_type &U_i,
-                                   const ScalarNumber t,
-                                   const ScalarNumber tau) const = delete;
+      state_type nodal_source(const precomputed_vector_type &pv,
+                              const unsigned int *js,
+                              const state_type &U_j,
+                              const ScalarNumber t,
+                              const ScalarNumber tau) const = delete;
 
       //@}
       /**


### PR DESCRIPTION
Let's get rid of some unused interface for nodal sources:
 - We do not need a  high-order and low-order split for nodal sources: the only candidate for PDEs that I can see might need one are equations with well balancing, and we have exactly one such equation (the `shallow_water` module) where we don't need it.
 - Let's remove the time parameter `t` as well - if this is ever needed then we should make it part of the precomputation loop. Maybe for entertainment I will simply add such sources with a function parser to the scalar conservation equation module.
 - Reword some variables and simplify some code in the `HyperbolicModule`.