### PR TITLE
Reorganize flux construction

### DIFF
--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -95,7 +95,7 @@ namespace ryujin
      * const auto view = hyperbolic_system.template view<dim, Number>();
      * const auto flux_i = view.flux_contribution(...);
      * const auto flux_j = view.flux_contribution(...);
-     * const auto flux_ij = view.flux(flux_i, flux_j, c_ij);
+     * const auto flux_ij = view.flux_divergence(flux_i, flux_j, c_ij);
      * // etc.
      * ```
      */
@@ -538,7 +538,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
+       *     const auto flux_ij = flux_divergence(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -561,14 +561,15 @@ namespace ryujin
        * Given flux contributions @p flux_i and @p flux_j compute the flux
        * <code>(-f(U_i) - f(U_j)</code>
        */
-      state_type flux(const flux_contribution_type &flux_i,
+      state_type
+      flux_divergence(const flux_contribution_type &flux_i,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &c_ij) const;
 
       /** The low-order and high-order fluxes are the same */
       static constexpr bool have_high_order_flux = false;
 
-      state_type high_order_flux(
+      state_type high_order_flux_divergence(
           const flux_contribution_type &flux_i,
           const flux_contribution_type &flux_j,
           const dealii::Tensor<1, dim, Number> &c_ij) const = delete;
@@ -1201,7 +1202,8 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto HyperbolicSystemView<dim, Number>::flux(
+    DEAL_II_ALWAYS_INLINE inline auto
+    HyperbolicSystemView<dim, Number>::flux_divergence(
         const flux_contribution_type &flux_i,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &c_ij) const -> state_type

--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -95,7 +95,7 @@ namespace ryujin
      * const auto view = hyperbolic_system.template view<dim, Number>();
      * const auto flux_i = view.flux_contribution(...);
      * const auto flux_j = view.flux_contribution(...);
-     * const auto flux_ij = view.flux(flux_i, flux_j);
+     * const auto flux_ij = view.flux(flux_i, flux_j, c_ij);
      * // etc.
      * ```
      */
@@ -538,7 +538,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j);
+       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -561,15 +561,17 @@ namespace ryujin
        * Given flux contributions @p flux_i and @p flux_j compute the flux
        * <code>(-f(U_i) - f(U_j)</code>
        */
-      flux_type flux(const flux_contribution_type &flux_i,
-                     const flux_contribution_type &flux_j) const;
+      state_type flux(const flux_contribution_type &flux_i,
+                      const flux_contribution_type &flux_j,
+                      const dealii::Tensor<1, dim, Number> &c_ij) const;
 
       /** The low-order and high-order fluxes are the same */
       static constexpr bool have_high_order_flux = false;
 
-      flux_type
-      high_order_flux(const flux_contribution_type &flux_i,
-                      const flux_contribution_type &flux_j) const = delete;
+      state_type high_order_flux(
+          const flux_contribution_type &flux_i,
+          const flux_contribution_type &flux_j,
+          const dealii::Tensor<1, dim, Number> &c_ij) const = delete;
 
       //@}
       /**
@@ -1201,9 +1203,10 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto HyperbolicSystemView<dim, Number>::flux(
         const flux_contribution_type &flux_i,
-        const flux_contribution_type &flux_j) const -> flux_type
+        const flux_contribution_type &flux_j,
+        const dealii::Tensor<1, dim, Number> &c_ij) const -> state_type
     {
-      return -add(flux_i, flux_j);
+      return -contract(add(flux_i, flux_j), c_ij);
     }
 
 

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -100,7 +100,7 @@ namespace ryujin
      * const auto view = hyperbolic_system.template view<dim, Number>();
      * const auto flux_i = view.flux_contribution(...);
      * const auto flux_j = view.flux_contribution(...);
-     * const auto flux_ij = view.flux(flux_i, flux_j);
+     * const auto flux_ij = view.flux(flux_i, flux_j, c_ij);
      * // etc.
      * ```
      */
@@ -618,7 +618,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j);
+       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -641,17 +641,19 @@ namespace ryujin
        * Given flux contributions @p flux_i and @p flux_j compute the flux
        * <code>(-f(U_i) - f(U_j)</code>
        */
-      flux_type flux(const flux_contribution_type &flux_i,
-                     const flux_contribution_type &flux_j) const;
+      state_type flux(const flux_contribution_type &flux_i,
+                      const flux_contribution_type &flux_j,
+                      const dealii::Tensor<1, dim, Number> &c_ij) const;
 
       /**
        * The low-order and high-order fluxes are the same:
        */
       static constexpr bool have_high_order_flux = false;
 
-      flux_type
-      high_order_flux(const flux_contribution_type &flux_i,
-                      const flux_contribution_type &flux_j) const = delete;
+      state_type high_order_flux(
+          const flux_contribution_type &flux_i,
+          const flux_contribution_type &flux_j,
+          const dealii::Tensor<1, dim, Number> &c_ij) const = delete;
 
       /**
        * @name Computing stencil source terms
@@ -1358,9 +1360,10 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto HyperbolicSystemView<dim, Number>::flux(
         const flux_contribution_type &flux_i,
-        const flux_contribution_type &flux_j) const -> flux_type
+        const flux_contribution_type &flux_j,
+        const dealii::Tensor<1, dim, Number> &c_ij) const -> state_type
     {
-      return -add(flux_i, flux_j);
+      return -contract(add(flux_i, flux_j), c_ij);
     }
 
 

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -100,7 +100,7 @@ namespace ryujin
      * const auto view = hyperbolic_system.template view<dim, Number>();
      * const auto flux_i = view.flux_contribution(...);
      * const auto flux_j = view.flux_contribution(...);
-     * const auto flux_ij = view.flux(flux_i, flux_j, c_ij);
+     * const auto flux_ij = view.flux_divergence(flux_i, flux_j, c_ij);
      * // etc.
      * ```
      */
@@ -618,7 +618,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
+       *     const auto flux_ij = flux_divergence(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -641,7 +641,8 @@ namespace ryujin
        * Given flux contributions @p flux_i and @p flux_j compute the flux
        * <code>(-f(U_i) - f(U_j)</code>
        */
-      state_type flux(const flux_contribution_type &flux_i,
+      state_type
+      flux_divergence(const flux_contribution_type &flux_i,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &c_ij) const;
 
@@ -650,7 +651,7 @@ namespace ryujin
        */
       static constexpr bool have_high_order_flux = false;
 
-      state_type high_order_flux(
+      state_type high_order_flux_divergence(
           const flux_contribution_type &flux_i,
           const flux_contribution_type &flux_j,
           const dealii::Tensor<1, dim, Number> &c_ij) const = delete;
@@ -1358,7 +1359,8 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto HyperbolicSystemView<dim, Number>::flux(
+    DEAL_II_ALWAYS_INLINE inline auto
+    HyperbolicSystemView<dim, Number>::flux_divergence(
         const flux_contribution_type &flux_i,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &c_ij) const -> state_type

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -641,9 +641,9 @@ namespace ryujin
              * Compute low-order flux and limiter bounds:
              */
 
-            const auto flux_ij = view.flux(flux_i, flux_j);
-            U_i_new += tau * m_i_inv * contract(flux_ij, c_ij);
-            auto P_ij = -contract(flux_ij, c_ij);
+            const auto flux_ij = view.flux(flux_i, flux_j, c_ij);
+            U_i_new += tau * m_i_inv * flux_ij;
+            auto P_ij = -flux_ij;
 
             if constexpr (shallow_water) {
               /*
@@ -684,12 +684,12 @@ namespace ryujin
 
             if constexpr (View::have_high_order_flux) {
               const auto high_order_flux_ij =
-                  view.high_order_flux(flux_i, flux_j);
-              F_iH += weight * contract(high_order_flux_ij, c_ij);
-              P_ij += weight * contract(high_order_flux_ij, c_ij);
+                  view.high_order_flux(flux_i, flux_j, c_ij);
+              F_iH += weight * high_order_flux_ij;
+              P_ij += weight * high_order_flux_ij;
             } else {
-              F_iH += weight * contract(flux_ij, c_ij);
-              P_ij += weight * contract(flux_ij, c_ij);
+              F_iH += weight * flux_ij;
+              P_ij += weight * flux_ij;
             }
 
             if constexpr (View::have_source_terms) {
@@ -705,13 +705,13 @@ namespace ryujin
 
               if constexpr (View::have_high_order_flux) {
                 const auto high_order_flux_ij =
-                    view.high_order_flux(flux_iHs[s], flux_jHs);
-                F_iH += stage_weights[s] * contract(high_order_flux_ij, c_ij);
-                P_ij += stage_weights[s] * contract(high_order_flux_ij, c_ij);
+                    view.high_order_flux(flux_iHs[s], flux_jHs, c_ij);
+                F_iH += stage_weights[s] * high_order_flux_ij;
+                P_ij += stage_weights[s] * high_order_flux_ij;
               } else {
-                const auto flux_ij = view.flux(flux_iHs[s], flux_jHs);
-                F_iH += stage_weights[s] * contract(flux_ij, c_ij);
-                P_ij += stage_weights[s] * contract(flux_ij, c_ij);
+                const auto flux_ij = view.flux(flux_iHs[s], flux_jHs, c_ij);
+                F_iH += stage_weights[s] * flux_ij;
+                P_ij += stage_weights[s] * flux_ij;
               }
 
               if constexpr (View::have_source_terms) {

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -641,7 +641,7 @@ namespace ryujin
              * Compute low-order flux and limiter bounds:
              */
 
-            const auto flux_ij = view.flux(flux_i, flux_j, c_ij);
+            const auto flux_ij = view.flux_divergence(flux_i, flux_j, c_ij);
             U_i_new += tau * m_i_inv * flux_ij;
             auto P_ij = -flux_ij;
 
@@ -684,7 +684,7 @@ namespace ryujin
 
             if constexpr (View::have_high_order_flux) {
               const auto high_order_flux_ij =
-                  view.high_order_flux(flux_i, flux_j, c_ij);
+                  view.high_order_flux_divergence(flux_i, flux_j, c_ij);
               F_iH += weight * high_order_flux_ij;
               P_ij += weight * high_order_flux_ij;
             } else {
@@ -704,12 +704,13 @@ namespace ryujin
                   stage_precomputed[s].get(), precomputed_initial_, js, U_jH);
 
               if constexpr (View::have_high_order_flux) {
-                const auto high_order_flux_ij =
-                    view.high_order_flux(flux_iHs[s], flux_jHs, c_ij);
+                const auto high_order_flux_ij = view.high_order_flux_divergence(
+                    flux_iHs[s], flux_jHs, c_ij);
                 F_iH += stage_weights[s] * high_order_flux_ij;
                 P_ij += stage_weights[s] * high_order_flux_ij;
               } else {
-                const auto flux_ij = view.flux(flux_iHs[s], flux_jHs, c_ij);
+                const auto flux_ij =
+                    view.flux_divergence(flux_iHs[s], flux_jHs, c_ij);
                 F_iH += stage_weights[s] * flux_ij;
                 P_ij += stage_weights[s] * flux_ij;
               }

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -389,7 +389,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j);
+       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -412,14 +412,17 @@ namespace ryujin
        * Given flux contributions @p flux_i and @p flux_j compute the flux
        * <code>(-f(U_i) - f(U_j)</code>
        */
-      flux_type flux(const flux_contribution_type &flux_i,
-                     const flux_contribution_type &flux_j) const;
+      state_type flux(const flux_contribution_type &flux_i,
+                      const flux_contribution_type &flux_j,
+                      const dealii::Tensor<1, dim, Number> &c_ij) const;
 
       /** The low-order and high-order fluxes are the same */
       static constexpr bool have_high_order_flux = false;
 
-      flux_type high_order_flux(const flux_contribution_type &,
-                                const flux_contribution_type &) const = delete;
+      state_type high_order_flux(
+          const flux_contribution_type &,
+          const flux_contribution_type &,
+          const dealii::Tensor<1, dim, Number> &c_ij) const = delete;
 
       //@}
       /**
@@ -811,9 +814,10 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto HyperbolicSystemView<dim, Number>::flux(
         const flux_contribution_type &flux_i,
-        const flux_contribution_type &flux_j) const -> flux_type
+        const flux_contribution_type &flux_j,
+        const dealii::Tensor<1, dim, Number> &c_ij) const -> state_type
     {
-      return -add(flux_i, flux_j);
+      return -contract(add(flux_i, flux_j), c_ij);
     }
 
   } // namespace ScalarConservation

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -389,7 +389,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
+       *     const auto flux_ij = flux_divergence(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -412,14 +412,15 @@ namespace ryujin
        * Given flux contributions @p flux_i and @p flux_j compute the flux
        * <code>(-f(U_i) - f(U_j)</code>
        */
-      state_type flux(const flux_contribution_type &flux_i,
+      state_type
+      flux_divergence(const flux_contribution_type &flux_i,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &c_ij) const;
 
       /** The low-order and high-order fluxes are the same */
       static constexpr bool have_high_order_flux = false;
 
-      state_type high_order_flux(
+      state_type high_order_flux_divergence(
           const flux_contribution_type &,
           const flux_contribution_type &,
           const dealii::Tensor<1, dim, Number> &c_ij) const = delete;
@@ -812,7 +813,8 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto HyperbolicSystemView<dim, Number>::flux(
+    DEAL_II_ALWAYS_INLINE inline auto
+    HyperbolicSystemView<dim, Number>::flux_divergence(
         const flux_contribution_type &flux_i,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &c_ij) const -> state_type

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -92,7 +92,7 @@ namespace ryujin
      * const auto view = hyperbolic_system.template view<dim, Number>();
      * const auto flux_i = view.flux_contribution(...);
      * const auto flux_j = view.flux_contribution(...);
-     * const auto flux_ij = view.flux(flux_i, flux_j, c_ij);
+     * const auto flux_ij = view.flux_divergence(flux_i, flux_j, c_ij);
      * // etc.
      * ```
      */
@@ -491,7 +491,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
+       *     const auto flux_ij = flux_divergence(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -516,7 +516,8 @@ namespace ryujin
        * compute the equilibrated, low-order flux \f$(f(U_i^{\ast,j}) +
        * f(U_j^{\ast,i})\f$
        */
-      state_type flux(const flux_contribution_type &flux_i,
+      state_type
+      flux_divergence(const flux_contribution_type &flux_i,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &c_ij) const;
 
@@ -530,10 +531,10 @@ namespace ryujin
        * compute the high-order flux \f$(f(U_i^{\ast,j}) +
        * f(U_j^{\ast,i})\f$
        */
-      state_type
-      high_order_flux(const flux_contribution_type &flux_i,
-                      const flux_contribution_type &flux_j,
-                      const dealii::Tensor<1, dim, Number> &c_ij) const;
+      state_type high_order_flux_divergence(
+          const flux_contribution_type &flux_i,
+          const flux_contribution_type &flux_j,
+          const dealii::Tensor<1, dim, Number> &c_ij) const;
 
       /**
        * Given precomputed flux contributions @p prec_i and @p prec_j compute
@@ -1109,7 +1110,8 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto HyperbolicSystemView<dim, Number>::flux(
+    DEAL_II_ALWAYS_INLINE inline auto
+    HyperbolicSystemView<dim, Number>::flux_divergence(
         const flux_contribution_type &flux_i,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &c_ij) const -> state_type
@@ -1141,7 +1143,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    HyperbolicSystemView<dim, Number>::high_order_flux(
+    HyperbolicSystemView<dim, Number>::high_order_flux_divergence(
         const flux_contribution_type &flux_i,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &c_ij) const -> state_type

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -284,7 +284,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j);
+       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -313,10 +313,11 @@ namespace ryujin
        * Given flux contributions @p flux_i and @p flux_j compute the flux
        * <code>(-f(U_i) - f(U_j)</code>
        */
-      flux_type flux(const flux_contribution_type & /*flux_i*/,
-                     const flux_contribution_type & /*flux_j*/) const
+      state_type flux(const flux_contribution_type & /*flux_i*/,
+                      const flux_contribution_type & /*flux_j*/,
+                      const dealii::Tensor<1, dim, Number> & /*c_ij*/) const
       {
-        return flux_type{};
+        return state_type{};
       }
 
       /**
@@ -324,8 +325,10 @@ namespace ryujin
        */
       static constexpr bool have_high_order_flux = false;
 
-      flux_type high_order_flux(const flux_contribution_type &,
-                                const flux_contribution_type &) const = delete;
+      state_type
+      high_order_flux(const flux_contribution_type &,
+                      const flux_contribution_type &,
+                      const dealii::Tensor<1, dim, Number> &) const = delete;
 
       //@}
       /**

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -284,7 +284,7 @@ namespace ryujin
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
        *     const auto flux_j = flux_contribution(precomputed..., js, U_j);
-       *     const auto flux_ij = flux(flux_i, flux_j, c_ij);
+       *     const auto flux_ij = flux_divergence(flux_i, flux_j, c_ij);
        *   }
        * }
        * ```
@@ -313,7 +313,8 @@ namespace ryujin
        * Given flux contributions @p flux_i and @p flux_j compute the flux
        * <code>(-f(U_i) - f(U_j)</code>
        */
-      state_type flux(const flux_contribution_type & /*flux_i*/,
+      state_type
+      flux_divergence(const flux_contribution_type & /*flux_i*/,
                       const flux_contribution_type & /*flux_j*/,
                       const dealii::Tensor<1, dim, Number> & /*c_ij*/) const
       {
@@ -325,10 +326,10 @@ namespace ryujin
        */
       static constexpr bool have_high_order_flux = false;
 
-      state_type
-      high_order_flux(const flux_contribution_type &,
-                      const flux_contribution_type &,
-                      const dealii::Tensor<1, dim, Number> &) const = delete;
+      state_type high_order_flux_divergence(
+          const flux_contribution_type &,
+          const flux_contribution_type &,
+          const dealii::Tensor<1, dim, Number> &) const = delete;
 
       //@}
       /**


### PR DESCRIPTION
This moves the contraction with `c_ij` into the `flux()` functions (that I have also renamed to `flux_divergence()` to signify that fact. This small change allows us to further (micro-)optimize the contraction loops.