### PR TITLE
`EquationDispatch`: isolate equation implementation by using opaque signals/slot mechanism

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -14,6 +14,7 @@ configure_file(
 
 set(COMMON_SOURCE_FILES
   discretization.cc
+  equation_dispatch.cc
   multicomponent_vector.cc
   offline_data.cc
   simd.cc

--- a/source/equation_dispatch.cc
+++ b/source/equation_dispatch.cc
@@ -1,0 +1,8 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 by the ryujin authors
+//
+
+#include "equation_dispatch.h"
+
+ryujin::EquationDispatch::Signals *ryujin::EquationDispatch::signals;

--- a/source/equation_dispatch.h
+++ b/source/equation_dispatch.h
@@ -1,76 +1,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// Copyright (C) 2023 by the ryujin authors
+// Copyright (C) 2023 - 2024 by the ryujin authors
 //
 
 #pragma once
 
-#include "patterns_conversion.h"
 #include "time_loop.h"
 
-#include "euler/description.h"
-#include "euler_aeos/description.h"
-#include "navier_stokes/description.h"
-#include "scalar_conservation/description.h"
-#include "shallow_water/description.h"
-
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/parameter_acceptor.h>
 
-#include <filesystem>
+#include <boost/signals2.hpp>
 
-namespace ryujin
-{
-  /**
-   * An enum class that controls what problem description to use.
-   */
-  enum class Equation {
-    /**
-     * The compressible Euler equations of gas dynamics with a polytropic
-     * gas equation of state
-     */
-    euler,
-
-    /**
-     * The compressible Euler equations of gas dynamics with arbitrary
-     * equation of state
-     */
-    euler_aeos,
-
-    /**
-     * The compressible Navier-Stokes equations of gas dynamics with a
-     * polytropic gas equation of state, Newtonian fluid viscosity model,
-     * and a heat flux governed by  Fourier's law.
-     */
-    navier_stokes,
-
-    /**
-     * A scalar conservation equation with a user-specified flux depending
-     * on the state.
-     */
-    scalar_conservation,
-
-    /**
-     * The shallow water equations
-     */
-    shallow_water,
-  };
-} // namespace ryujin
-
-#ifndef DOXYGEN
-DECLARE_ENUM(ryujin::Equation,
-             LIST({ryujin::Equation::euler, "euler"},
-                  {ryujin::Equation::euler_aeos, "euler aeos"},
-                  {ryujin::Equation::navier_stokes, "navier stokes"},
-                  {ryujin::Equation::scalar_conservation,
-                   "scalar conservation"},
-                  {ryujin::Equation::shallow_water, "shallow water"}, ));
-#endif
+#include <string>
 
 namespace ryujin
 {
   /**
-   * Dispatcher class that calls into the right TimeLoop depending on
-   * what equation has been selected.
+   * Dispatcher class that calls into the right TimeLoop for a configured
+   * equation depending on what has been set in the parameter file.
    */
   class EquationDispatch : dealii::ParameterAcceptor
   {
@@ -78,14 +26,41 @@ namespace ryujin
     EquationDispatch()
         : ParameterAcceptor("B - Equation")
     {
-      dimension_ = 2;
+      dimension_ = 0;
       add_parameter("dimension", dimension_, "The spatial dimension");
-
-      equation_ = Equation::euler;
       add_parameter("equation", equation_, "The PDE system");
     }
 
-    void run(const std::string &parameter_file, const MPI_Comm &mpi_comm)
+
+    /**
+     * Call create_parameter_files() for all registered equations.
+     */
+    static void create_parameter_files()
+    {
+      AssertThrow(signals != nullptr,
+                  dealii::ExcMessage("No equation has been registered"));
+
+      signals->create_parameter_files();
+    }
+
+
+    /**
+     * Register a create_parameter_files() callback.
+     */
+    template <typename Callable>
+    static void register_create_parameter_files(const Callable &callable)
+    {
+      if (signals == nullptr)
+        signals = new Signals;
+
+      signals->create_parameter_files.connect(callable);
+    }
+
+
+    /**
+     * Call dispatch() for all registered equations.
+     */
+    void dispatch(const std::string &parameter_file, const MPI_Comm &mpi_comm)
     {
       ParameterAcceptor::prm.parse_input(parameter_file,
                                          "",
@@ -98,183 +73,152 @@ namespace ryujin
                              "anymore. Goodbye.\nThe dimension parameter needs "
                              "to be either 1, 2, or 3."));
 
-      switch (equation_) {
-      case Equation::euler:
-        if (dimension_ == 1) {
-          TimeLoop<Euler::Description, 1, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 2) {
-          TimeLoop<Euler::Description, 2, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 3) {
-          TimeLoop<Euler::Description, 3, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else
-          __builtin_unreachable();
-        break;
-      case Equation::euler_aeos:
-        if (dimension_ == 1) {
-          TimeLoop<EulerAEOS::Description, 1, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 2) {
-          TimeLoop<EulerAEOS::Description, 2, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 3) {
-          TimeLoop<EulerAEOS::Description, 3, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else
-          __builtin_unreachable();
-        break;
-      case Equation::navier_stokes:
-        if (dimension_ == 1) {
-          TimeLoop<NavierStokes::Description, 1, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 2) {
-          TimeLoop<NavierStokes::Description, 2, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 3) {
-          TimeLoop<NavierStokes::Description, 3, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else
-          __builtin_unreachable();
-        break;
-      case Equation::scalar_conservation:
-        if (dimension_ == 1) {
-          TimeLoop<ScalarConservation::Description, 1, NUMBER> time_loop(
-              mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 2) {
-          TimeLoop<ScalarConservation::Description, 2, NUMBER> time_loop(
-              mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 3) {
-          TimeLoop<ScalarConservation::Description, 3, NUMBER> time_loop(
-              mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else
-          __builtin_unreachable();
-        break;
-      case Equation::shallow_water:
-        if (dimension_ == 1) {
-          TimeLoop<ShallowWater::Description, 1, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 2) {
-          TimeLoop<ShallowWater::Description, 2, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else if (dimension_ == 3) {
-          TimeLoop<ShallowWater::Description, 3, NUMBER> time_loop(mpi_comm);
-          ParameterAcceptor::initialize(parameter_file);
-          time_loop.run();
-        } else
-          __builtin_unreachable();
-        break;
-      default:
-        __builtin_trap();
-      }
+      AssertThrow(signals != nullptr,
+                  dealii::ExcMessage("No equation has been registered"));
+
+      signals->dispatch(dimension_, equation_, parameter_file, mpi_comm);
     }
 
+
+    /**
+     * Register a create_parameter_files() callback.
+     */
+    template <typename Callable>
+    static void register_dispatch(const Callable &callable)
+    {
+      if (signals == nullptr)
+        signals = new Signals;
+
+      signals->dispatch.connect(callable);
+    }
+
+
+  protected:
+    /**
+     * @name Internal data structures:
+     */
+    //@{
+
+    /**
+     * A structure that holds two Signals for equations:
+     *  - one for creating and running the appropriate timeloop
+     *  - the other signal is used to create default parameter files.
+     */
+    struct Signals {
+      boost::signals2::signal<void()> create_parameter_files;
+
+      boost::signals2::signal<void(int /*dimension*/,
+                                   const std::string & /*equation*/,
+                                   const std::string & /*parameter file*/,
+                                   const MPI_Comm & /*MPI communicator*/)>
+          dispatch;
+    };
+
+    /*
+     * Note: as a static field the pointer is zero initialized before any
+     * static/global constructor is run.
+     */
+    static Signals *signals;
+
   private:
+    //@}
+    /**
+     * @name Runtime parameters:
+     */
+    //@{
+
     int dimension_;
-    Equation equation_;
+    std::string equation_;
+
+    //@}
   };
 
 
-  namespace internal
+  /**
+   * Create default parameter files for the specified equation Description,
+   * dimension and number type. This function is called form the respective
+   * equation driver.
+   */
+  template <typename Description, int dim, typename Number>
+  void create_prm_files(const std::string &name,
+                        bool write_detailed_description)
   {
-    template <int dim, typename description>
-    void create_prm_files(const std::string &name,
-                          const MPI_Comm &mpi_communicator,
-                          bool write_detailed_description)
     {
-      {
-        /*
-         * Create temporary objects for the sole purpose of populating the
-         * ParameterAcceptor::prm object.
-         */
-        ryujin::EquationDispatch equation_dispatch;
-        ryujin::TimeLoop<description, dim, NUMBER> time_loop(mpi_communicator);
+      /*
+       * Create temporary objects for the sole purpose of populating the
+       * ParameterAcceptor::prm object.
+       */
+      ryujin::EquationDispatch equation_dispatch;
+      ryujin::TimeLoop<Description, dim, Number> time_loop(MPI_COMM_SELF);
 
-        /* Fix up "equation" entry: */
-        auto &prm = dealii::ParameterAcceptor::prm;
-        prm.enter_subsection("B - Equation");
-        prm.set("dimension", std::to_string(dim));
-        prm.set("equation", name);
-        prm.leave_subsection();
+      /* Fix up "equation" entry: */
+      auto &prm = dealii::ParameterAcceptor::prm;
+      prm.enter_subsection("B - Equation");
+      prm.set("dimension", std::to_string(dim));
+      prm.set("equation", name);
+      prm.leave_subsection();
 
-        std::string base_name = name;
-        std::replace(base_name.begin(), base_name.end(), ' ', '_');
-        base_name += "-" + std::to_string(dim) + "d";
+      std::string base_name = name;
+      std::replace(base_name.begin(), base_name.end(), ' ', '_');
+      base_name += "-" + std::to_string(dim) + "d";
 
-        if (dealii::Utilities::MPI::this_mpi_process(mpi_communicator) == 0) {
-          const auto full_name =
-              "default_parameters-" + base_name + "-description.prm";
-          if (write_detailed_description)
-            prm.print_parameters(full_name,
-                                 dealii::ParameterHandler::OutputStyle::PRM);
+      if (dealii::Utilities::MPI::this_mpi_process(MPI_COMM_SELF) == 0) {
+        const auto full_name =
+            "default_parameters-" + base_name + "-description.prm";
+        if (write_detailed_description)
+          prm.print_parameters(full_name,
+                               dealii::ParameterHandler::OutputStyle::PRM);
 
-          const auto short_name = "default_parameters-" + base_name + ".prm";
-          prm.print_parameters(short_name,
-                               dealii::ParameterHandler::OutputStyle::Short);
-        }
-        // all objects have to go out of scope, see
-        // https://github.com/dealii/dealii/issues/15111
+        const auto short_name = "default_parameters-" + base_name + ".prm";
+        prm.print_parameters(short_name,
+                             dealii::ParameterHandler::OutputStyle::Short);
       }
-      dealii::ParameterAcceptor::clear();
+      // all objects have to go out of scope, see
+      // https://github.com/dealii/dealii/issues/15111
     }
-  } // namespace internal
 
-
-  void create_parameter_templates(const std::string &parameter_file,
-                                  const MPI_Comm &mpi_communicator)
-  {
-    internal::create_prm_files<1, Euler::Description>(
-        "euler", mpi_communicator, false);
-    internal::create_prm_files<2, Euler::Description>(
-        "euler", mpi_communicator, true);
-    internal::create_prm_files<3, Euler::Description>(
-        "euler", mpi_communicator, false);
-    std::filesystem::copy("default_parameters-euler-2d.prm", parameter_file);
-
-    internal::create_prm_files<1, EulerAEOS::Description>(
-        "euler aeos", mpi_communicator, false);
-    internal::create_prm_files<2, EulerAEOS::Description>(
-        "euler aeos", mpi_communicator, true);
-    internal::create_prm_files<3, EulerAEOS::Description>(
-        "euler aeos", mpi_communicator, false);
-
-    internal::create_prm_files<1, NavierStokes::Description>(
-        "navier stokes", mpi_communicator, false);
-    internal::create_prm_files<2, NavierStokes::Description>(
-        "navier stokes", mpi_communicator, true);
-    internal::create_prm_files<3, NavierStokes::Description>(
-        "navier stokes", mpi_communicator, false);
-
-    internal::create_prm_files<1, ScalarConservation::Description>(
-        "scalar conservation", mpi_communicator, false);
-    internal::create_prm_files<2, ScalarConservation::Description>(
-        "scalar conservation", mpi_communicator, true);
-    internal::create_prm_files<3, ScalarConservation::Description>(
-        "scalar conservation", mpi_communicator, false);
-
-    internal::create_prm_files<1, ShallowWater::Description>(
-        "shallow water", mpi_communicator, false);
-    internal::create_prm_files<2, ShallowWater::Description>(
-        "shallow water", mpi_communicator, true);
-    internal::create_prm_files<3, ShallowWater::Description>(
-        "shallow water", mpi_communicator, false);
+    dealii::ParameterAcceptor::clear();
   }
+
+
+  /**
+   * A small Dispatch struct templated by an equation descriptions that
+   * registers the call backs.
+   */
+  template <typename Description, typename Number>
+  struct Dispatch {
+    Dispatch(const std::string &name)
+    {
+      EquationDispatch::register_create_parameter_files([name]() {
+        create_prm_files<Description, 1, Number>(name, false);
+        create_prm_files<Description, 2, Number>(name, true);
+        create_prm_files<Description, 3, Number>(name, false);
+      });
+
+      EquationDispatch::register_dispatch(
+          [name](const int dimension,
+                 const std::string &equation,
+                 const std::string &parameter_file,
+                 const MPI_Comm &mpi_comm) {
+            if (equation != name)
+              return;
+
+            if (dimension == 1) {
+              TimeLoop<Description, 1, Number> time_loop(mpi_comm);
+              dealii::ParameterAcceptor::initialize(parameter_file);
+              time_loop.run();
+            } else if (dimension == 2) {
+              TimeLoop<Description, 2, Number> time_loop(mpi_comm);
+              dealii::ParameterAcceptor::initialize(parameter_file);
+              time_loop.run();
+            } else if (dimension == 3) {
+              TimeLoop<Description, 3, Number> time_loop(mpi_comm);
+              dealii::ParameterAcceptor::initialize(parameter_file);
+              time_loop.run();
+            } else
+              __builtin_unreachable();
+          });
+    }
+  };
+
 } // namespace ryujin

--- a/source/euler/CMakeLists.txt
+++ b/source/euler/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(obj_euler OBJECT
+  equation_dispatch.cc
   initial_state_library.cc
   limiter.cc
   riemann_solver.cc

--- a/source/euler/equation_dispatch.cc
+++ b/source/euler/equation_dispatch.cc
@@ -1,0 +1,17 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 by the ryujin authors
+//
+
+#include "description.h"
+
+#include <compile_time_options.h>
+#include <equation_dispatch.h>
+
+namespace ryujin
+{
+  namespace Euler
+  {
+    Dispatch<Description, NUMBER> dispatch_instance("euler");
+  } // namespace Euler
+} // namespace ryujin

--- a/source/euler_aeos/CMakeLists.txt
+++ b/source/euler_aeos/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(obj_euler_aeos OBJECT
+  equation_dispatch.cc
   equation_of_state_library.cc
   initial_state_library.cc
   limiter.cc

--- a/source/euler_aeos/equation_dispatch.cc
+++ b/source/euler_aeos/equation_dispatch.cc
@@ -1,0 +1,17 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 by the ryujin authors
+//
+
+#include "description.h"
+
+#include <compile_time_options.h>
+#include <equation_dispatch.h>
+
+namespace ryujin
+{
+  namespace EulerAEOS
+  {
+    Dispatch<Description, NUMBER> dispatch_instance("euler aeos");
+  } // namespace EulerAEOS
+} // namespace ryujin

--- a/source/main.cc
+++ b/source/main.cc
@@ -106,9 +106,11 @@ int main(int argc, char *argv[])
       std::cout << "[INFO] Default parameter file »" << parameter_file
                 << "« not found.\n[INFO] Creating template parameter files..."
                 << std::endl;
+      ryujin::EquationDispatch::create_parameter_files();
+      std::filesystem::copy("default_parameters-euler-2d.prm", parameter_file);
     }
 
-    ryujin::create_parameter_templates(parameter_file, mpi_communicator);
+    MPI_Barrier(mpi_communicator);
 
     LIKWID_CLOSE;
     LSAN_DISABLE;
@@ -117,7 +119,7 @@ int main(int argc, char *argv[])
 
   {
     ryujin::EquationDispatch equation_dispatch;
-    equation_dispatch.run(parameter_file, mpi_communicator);
+    equation_dispatch.dispatch(parameter_file, mpi_communicator);
   }
 
   LIKWID_CLOSE;

--- a/source/navier_stokes/CMakeLists.txt
+++ b/source/navier_stokes/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(obj_navier_stokes OBJECT
+  equation_dispatch.cc
   initial_state_library.cc
   parabolic_solver.cc
   )

--- a/source/navier_stokes/equation_dispatch.cc
+++ b/source/navier_stokes/equation_dispatch.cc
@@ -1,0 +1,17 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 by the ryujin authors
+//
+
+#include "description.h"
+
+#include <compile_time_options.h>
+#include <equation_dispatch.h>
+
+namespace ryujin
+{
+  namespace NavierStokes
+  {
+    Dispatch<Description, NUMBER> dispatch_instance("navier stokes");
+  } // namespace NavierStokes
+} // namespace ryujin

--- a/source/scalar_conservation/CMakeLists.txt
+++ b/source/scalar_conservation/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(obj_scalar_conservation OBJECT
+  equation_dispatch.cc
   flux_library.cc
   initial_state_library.cc
   limiter.cc

--- a/source/scalar_conservation/equation_dispatch.cc
+++ b/source/scalar_conservation/equation_dispatch.cc
@@ -1,0 +1,17 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 by the ryujin authors
+//
+
+#include "description.h"
+
+#include <compile_time_options.h>
+#include <equation_dispatch.h>
+
+namespace ryujin
+{
+  namespace ScalarConservation
+  {
+    Dispatch<Description, NUMBER> dispatch_instance("scalar conservation");
+  } // namespace ScalarConservation
+} // namespace ryujin

--- a/source/shallow_water/CMakeLists.txt
+++ b/source/shallow_water/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(obj_shallow_water OBJECT
+  equation_dispatch.cc
   initial_state_library.cc
   limiter.cc
   riemann_solver.cc

--- a/source/shallow_water/equation_dispatch.cc
+++ b/source/shallow_water/equation_dispatch.cc
@@ -1,0 +1,17 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 by the ryujin authors
+//
+
+#include "description.h"
+
+#include <compile_time_options.h>
+#include <equation_dispatch.h>
+
+namespace ryujin
+{
+  namespace ShallowWater
+  {
+    Dispatch<Description, NUMBER> dispatch_instance("shallow water");
+  } // namespace ShallowWater
+} // namespace ryujin

--- a/source/skeleton/CMakeLists.txt
+++ b/source/skeleton/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##
 
 add_library(obj_skeleton OBJECT
+  equation_dispatch.cc
   initial_state_library.cc
   )
 set_target_properties(obj_skeleton PROPERTIES LINKER_LANGUAGE CXX)

--- a/source/skeleton/equation_dispatch.cc
+++ b/source/skeleton/equation_dispatch.cc
@@ -1,0 +1,17 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 by the ryujin authors
+//
+
+#include "description.h"
+
+#include <compile_time_options.h>
+#include <equation_dispatch.h>
+
+namespace ryujin
+{
+  namespace Skeleton
+  {
+    Dispatch<Description, NUMBER> dispatch_instance("skeleton");
+  } // namespace Skeleton
+} // namespace ryujin

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -1048,18 +1048,17 @@ namespace ryujin
       bool final_time)
   {
     static const std::string vectorization_name = [] {
-      using T = NUMBER;
-      constexpr auto width = VectorizedArray<NUMBER>::size();
+      constexpr auto width = VectorizedArray<Number>::size();
 
       std::string result;
       if (width == 1)
         result = "scalar ";
       else
-        result = std::to_string(width * 8 * sizeof(T)) + " bit packed ";
+        result = std::to_string(width * 8 * sizeof(Number)) + " bit packed ";
 
-      if constexpr (std::is_same_v<T, double>)
+      if constexpr (std::is_same_v<Number, double>)
         return result + "double";
-      else if constexpr (std::is_same_v<T, float>)
+      else if constexpr (std::is_same_v<Number, float>)
         return result + "float";
       else
         __builtin_trap();

--- a/tests/euler/CMakeLists.txt
+++ b/tests/euler/CMakeLists.txt
@@ -12,7 +12,8 @@ include_directories(
   )
 
 set(TEST_LIBRARIES obj_common obj_${EQUATION} obj_${EQUATION}_dependent)
-
 set(TEST_TARGET ryujin)
 
-deal_ii_pickup_tests()
+if(TARGET obj_${EQUATION})
+  deal_ii_pickup_tests()
+endif()

--- a/tests/euler_aeos/CMakeLists.txt
+++ b/tests/euler_aeos/CMakeLists.txt
@@ -12,7 +12,8 @@ include_directories(
   )
 
 set(TEST_LIBRARIES obj_common obj_${EQUATION} obj_${EQUATION}_dependent)
-
 set(TEST_TARGET ryujin)
 
-deal_ii_pickup_tests()
+if(TARGET obj_${EQUATION})
+  deal_ii_pickup_tests()
+endif()

--- a/tests/navier_stokes/CMakeLists.txt
+++ b/tests/navier_stokes/CMakeLists.txt
@@ -12,7 +12,8 @@ include_directories(
   )
 
 set(TEST_LIBRARIES obj_common obj_${EQUATION} obj_${EQUATION}_dependent)
-
 set(TEST_TARGET ryujin)
 
-deal_ii_pickup_tests()
+if(TARGET obj_${EQUATION})
+  deal_ii_pickup_tests()
+endif()

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l5-2d.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l5-2d.prm
@@ -11,6 +11,7 @@ end
 
 
 subsection B - Equation
+  set dimension = 2
   set equation = navier stokes
   set gamma    = 1.4
   set mu       = 0.01

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l5-2d.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l5-2d.prm
@@ -11,6 +11,7 @@ end
 
 
 subsection B - Equation
+  set dimension = 2
   set equation = navier stokes
   set gamma       = 1.4
   set mu          = 0.01

--- a/tests/scalar_conservation/CMakeLists.txt
+++ b/tests/scalar_conservation/CMakeLists.txt
@@ -12,7 +12,8 @@ include_directories(
   )
 
 set(TEST_LIBRARIES obj_common obj_${EQUATION} obj_${EQUATION}_dependent)
-
 set(TEST_TARGET ryujin)
 
-deal_ii_pickup_tests()
+if(TARGET obj_${EQUATION})
+  deal_ii_pickup_tests()
+endif()

--- a/tests/shallow_water/CMakeLists.txt
+++ b/tests/shallow_water/CMakeLists.txt
@@ -12,7 +12,8 @@ include_directories(
   )
 
 set(TEST_LIBRARIES obj_common obj_${EQUATION} obj_${EQUATION}_dependent)
-
 set(TEST_TARGET ryujin)
 
-deal_ii_pickup_tests()
+if(TARGET obj_${EQUATION})
+  deal_ii_pickup_tests()
+endif()


### PR DESCRIPTION
This is some long overdue code refactoring to make the handling of various equations easier. It removes all equation-dependent includes and code from `equation_dispatch.h` and instead relies on a signal/slot mechanism to start up the correct `TimeLoop`.