### PR TITLE
SIMD: Bugfix: remove debug code;  use SIMD variants when available

### DIFF
--- a/source/simd.template.h
+++ b/source/simd.template.h
@@ -193,7 +193,7 @@ namespace ryujin
    *                           pow() implementation:                           *
    ****************************************************************************/
 
-#if 0
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
   template <>
   // DEAL_II_ALWAYS_INLINE inline
   float pow(const float x, const float b)
@@ -276,7 +276,7 @@ namespace ryujin
    *                         Fast pow() implementation:                        *
    ****************************************************************************/
 
-#if 0
+#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
   template <>
   // DEAL_II_ALWAYS_INLINE inline
   float fast_pow(const float x, const float b, const Bias bias)


### PR DESCRIPTION
The `#if 0` statement was used to produce the output and should have never made it into the commit.

This partially reverts 30e0d7e812c0fde58dc79113d16afcd76478012f