### PR TITLE
Introduce `StateVector` class and first round of refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,9 @@ set(CMAKE_CXX_STANDARD 20)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   string(APPEND DEAL_II_CXX_FLAGS " -fdiagnostics-color=always")
   string(REPLACE "-Qunused-arguments" "" DEAL_II_CXX_FLAGS "${DEAL_II_CXX_FLAGS}")
-  string(APPEND DEAL_II_CXX_FLAGS " -Wno-missing-braces -Wno-unknown-pragmas")
+  string(APPEND DEAL_II_CXX_FLAGS
+    " -Wno-changes-meaning -Wno-missing-braces -Wno-unknown-pragmas"
+    )
 
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)
     string(APPEND DEAL_II_CXX_FLAGS " -Wno-overloaded-virtual")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,9 +110,7 @@ set(CMAKE_CXX_STANDARD 20)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   string(APPEND DEAL_II_CXX_FLAGS " -fdiagnostics-color=always")
   string(REPLACE "-Qunused-arguments" "" DEAL_II_CXX_FLAGS "${DEAL_II_CXX_FLAGS}")
-  string(APPEND DEAL_II_CXX_FLAGS
-    " -Wno-changes-meaning -Wno-missing-braces -Wno-unknown-pragmas"
-    )
+  string(APPEND DEAL_II_CXX_FLAGS " -Wno-missing-braces -Wno-unknown-pragmas")
 
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)
     string(APPEND DEAL_II_CXX_FLAGS " -Wno-overloaded-virtual")

--- a/source/checkpointing.h
+++ b/source/checkpointing.h
@@ -73,7 +73,7 @@ namespace ryujin
 
         const auto &scalar_partitioner = offline_data.scalar_partitioner();
 
-        using ScalarVector = Vectors::ScalarVector<Number>;
+        using ScalarVector = typename Vectors::ScalarVector<Number>;
         std::array<ScalarVector, n_comp> state_vector;
         for (auto &it : state_vector) {
           it.reinit(scalar_partitioner);
@@ -159,7 +159,7 @@ namespace ryujin
 
         const auto &scalar_partitioner = offline_data.scalar_partitioner();
 
-        using ScalarVector = Vectors::ScalarVector<Number>;
+        using ScalarVector = typename Vectors::ScalarVector<Number>;
         std::array<ScalarVector, n_comp> state_vector;
         unsigned int d = 0;
         for (auto &it : state_vector) {

--- a/source/checkpointing.h
+++ b/source/checkpointing.h
@@ -58,12 +58,13 @@ namespace ryujin
      * @ingroup Miscellaneous
      */
     template <int dim, typename Number, int n_comp, int simd_length>
-    void load_state_vector(const OfflineData<dim, Number> &offline_data,
-                           const std::string &base_name,
-                           MultiComponentVector<Number, n_comp, simd_length> &U,
-                           Number &t,
-                           unsigned int &output_cycle,
-                           const MPI_Comm &mpi_communicator)
+    void load_state_vector(
+        const OfflineData<dim, Number> &offline_data,
+        const std::string &base_name,
+        Vectors::MultiComponentVector<Number, n_comp, simd_length> &U,
+        Number &t,
+        unsigned int &output_cycle,
+        const MPI_Comm &mpi_communicator)
     {
       if constexpr (have_distributed_triangulation<dim>) {
         const auto &dof_handler = offline_data.dof_handler();
@@ -72,7 +73,7 @@ namespace ryujin
 
         const auto &scalar_partitioner = offline_data.scalar_partitioner();
 
-        using ScalarVector = ryujin::ScalarVector<Number>;
+        using ScalarVector = Vectors::ScalarVector<Number>;
         std::array<ScalarVector, n_comp> state_vector;
         for (auto &it : state_vector) {
           it.reinit(scalar_partitioner);
@@ -141,13 +142,13 @@ namespace ryujin
      * @ingroup Miscellaneous
      */
     template <int dim, typename Number, int n_comp, int simd_length>
-    void
-    write_checkpoint(const OfflineData<dim, Number> &offline_data,
-                     const std::string &base_name,
-                     const MultiComponentVector<Number, n_comp, simd_length> &U,
-                     const Number t,
-                     const unsigned int output_cycle,
-                     const MPI_Comm &mpi_communicator)
+    void write_checkpoint(
+        const OfflineData<dim, Number> &offline_data,
+        const std::string &base_name,
+        const Vectors::MultiComponentVector<Number, n_comp, simd_length> &U,
+        const Number t,
+        const unsigned int output_cycle,
+        const MPI_Comm &mpi_communicator)
     {
       if constexpr (have_distributed_triangulation<dim>) {
         const auto &triangulation =
@@ -158,7 +159,7 @@ namespace ryujin
 
         const auto &scalar_partitioner = offline_data.scalar_partitioner();
 
-        using ScalarVector = ryujin::ScalarVector<Number>;
+        using ScalarVector = Vectors::ScalarVector<Number>;
         std::array<ScalarVector, n_comp> state_vector;
         unsigned int d = 0;
         for (auto &it : state_vector) {

--- a/source/checkpointing.h
+++ b/source/checkpointing.h
@@ -72,8 +72,8 @@ namespace ryujin
 
         const auto &scalar_partitioner = offline_data.scalar_partitioner();
 
-        using scalar_type = typename OfflineData<dim, Number>::scalar_type;
-        std::array<scalar_type, n_comp> state_vector;
+        using ScalarVector = ryujin::ScalarVector<Number>;
+        std::array<ScalarVector, n_comp> state_vector;
         for (auto &it : state_vector) {
           it.reinit(scalar_partitioner);
         }
@@ -81,10 +81,10 @@ namespace ryujin
         /* Create SolutionTransfer object, attach state vector and deserialize:
          */
 
-        dealii::parallel::distributed::SolutionTransfer<dim, scalar_type>
+        dealii::parallel::distributed::SolutionTransfer<dim, ScalarVector>
             solution_transfer(dof_handler);
 
-        std::vector<scalar_type *> ptr_state;
+        std::vector<ScalarVector *> ptr_state;
         std::transform(state_vector.begin(),
                        state_vector.end(),
                        std::back_inserter(ptr_state),
@@ -158,8 +158,8 @@ namespace ryujin
 
         const auto &scalar_partitioner = offline_data.scalar_partitioner();
 
-        using scalar_type = typename OfflineData<dim, Number>::scalar_type;
-        std::array<scalar_type, n_comp> state_vector;
+        using ScalarVector = ryujin::ScalarVector<Number>;
+        std::array<ScalarVector, n_comp> state_vector;
         unsigned int d = 0;
         for (auto &it : state_vector) {
           it.reinit(scalar_partitioner);
@@ -168,10 +168,10 @@ namespace ryujin
 
         /* Create SolutionTransfer object, attach state vector and write out: */
 
-        dealii::parallel::distributed::SolutionTransfer<dim, scalar_type>
+        dealii::parallel::distributed::SolutionTransfer<dim, ScalarVector>
             solution_transfer(dof_handler);
 
-        std::vector<const scalar_type *> ptr_state;
+        std::vector<const ScalarVector *> ptr_state;
         std::transform(state_vector.begin(),
                        state_vector.end(),
                        std::back_inserter(ptr_state),

--- a/source/convenience_macros.h
+++ b/source/convenience_macros.h
@@ -46,7 +46,7 @@ namespace ryujin
    * Convenience wrapper that creates a (scalar) dealii::Function object
    * out of a (fairly general) callable object returning array-like values.
    * An example usage is given by the interpolation of initial values
-   * performed in InitialValues::interpolate();
+   * performed in InitialValues::interpolate_state_vector();
    * ```
    * for(unsigned int i = 0; i < problem_dimension; ++i)
    *   dealii::VectorTools::interpolate(

--- a/source/diagonal_preconditioner.h
+++ b/source/diagonal_preconditioner.h
@@ -8,6 +8,7 @@
 #include "offline_data.h"
 #include "openmp.h"
 #include "simd.h"
+#include "state_vector.h"
 
 #include <deal.II/lac/la_parallel_block_vector.h>
 
@@ -19,21 +20,19 @@ namespace ryujin
    *
    * @ingroup DissipationModule
    */
-  template <int dim, typename Number>
+  template <typename Number>
   class DiagonalPreconditioner
   {
   public:
     /**
-     * @copydoc OfflineData::scalar_type
+     * @copydoc ryujin::ScalarVector
      */
-    using scalar_type = typename OfflineData<dim, Number>::scalar_type;
+    using ScalarVector = ryujin::ScalarVector<Number>;
 
     /**
-     * A distributed block vector used for temporary storage of the
-     * velocity field.
+     * @copydoc ryujin::BlockVector
      */
-    using block_vector_type =
-        dealii::LinearAlgebra::distributed::BlockVector<Number>;
+    using BlockVector = ryujin::BlockVector<Number>;
 
     /**
      * Constructor
@@ -43,8 +42,8 @@ namespace ryujin
     /**
      * Reinit with a scalar partitioner
      */
-    void reinit(std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
-                    scalar_partitioner)
+    void reinit(const std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
+                    &scalar_partitioner)
     {
       diagonal_.reinit(scalar_partitioner);
     }
@@ -52,7 +51,7 @@ namespace ryujin
     /**
      * Get access to the internal vector to be externally filled.
      */
-    scalar_type &scaling_vector()
+    ScalarVector &scaling_vector()
     {
       return diagonal_;
     }
@@ -60,7 +59,7 @@ namespace ryujin
     /**
      * Apply on a scalar vector.
      */
-    void vmult(scalar_type &dst, const scalar_type &src) const
+    void vmult(ScalarVector &dst, const ScalarVector &src) const
     {
       const auto n_owned = diagonal_.get_partitioner()->locally_owned_size();
       AssertDimension(n_owned, src.get_partitioner()->locally_owned_size());
@@ -75,7 +74,7 @@ namespace ryujin
     /**
      * Apply on a block vector.
      */
-    void vmult(block_vector_type &dst, const block_vector_type &src) const
+    void vmult(BlockVector &dst, const BlockVector &src) const
     {
       const auto n_blocks = src.n_blocks();
       AssertDimension(n_blocks, dst.n_blocks());
@@ -96,7 +95,7 @@ namespace ryujin
     }
 
   private:
-    scalar_type diagonal_;
+    ScalarVector diagonal_;
   };
 
 } /* namespace ryujin */

--- a/source/diagonal_preconditioner.h
+++ b/source/diagonal_preconditioner.h
@@ -5,9 +5,6 @@
 
 #pragma once
 
-#include "offline_data.h"
-#include "openmp.h"
-#include "simd.h"
 #include "state_vector.h"
 
 #include <deal.II/lac/la_parallel_block_vector.h>
@@ -27,12 +24,12 @@ namespace ryujin
     /**
      * @copydoc ryujin::ScalarVector
      */
-    using ScalarVector = ryujin::ScalarVector<Number>;
+    using ScalarVector = typename Vectors::ScalarVector<Number>;
 
     /**
      * @copydoc ryujin::BlockVector
      */
-    using BlockVector = ryujin::BlockVector<Number>;
+    using BlockVector = typename Vectors::BlockVector<Number>;
 
     /**
      * Constructor

--- a/source/diagonal_preconditioner.h
+++ b/source/diagonal_preconditioner.h
@@ -18,7 +18,7 @@ namespace ryujin
    * A preconditioner implementing a diagonal scaling used for the
    * non-multigrid CG iteration.
    *
-   * @ingroup DissipationModule
+   * @ingroup ParabolicModule
    */
   template <typename Number>
   class DiagonalPreconditioner

--- a/source/equation_dispatch.h
+++ b/source/equation_dispatch.h
@@ -27,6 +27,8 @@ namespace ryujin
   /**
    * Dispatcher class that calls into the right TimeLoop for a configured
    * equation depending on what has been set in the parameter file.
+   *
+   * @ingroup TimeLoop
    */
   class EquationDispatch : dealii::ParameterAcceptor
   {

--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -299,21 +299,22 @@ namespace ryujin
       /**
        * A compound state vector.
        */
-      using StateVector =
+      using StateVector = Vectors::
           StateVector<ScalarNumber, problem_dimension, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed states:
        */
       using PrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_initial_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber,
+                                        n_initial_precomputed_values>;
 
       //@}
       /**

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -89,17 +89,17 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_type = View::flux_type;
+      using flux_type = typename View::flux_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = IndicatorParameters<ScalarNumber>;
 

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -83,46 +83,27 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystem::problem_dimension
-       */
-      static constexpr unsigned int problem_dimension = View::problem_dimension;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystem::precomputed_state_type
-       */
-      using precomputed_state_type = typename View::precomputed_state_type;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystem::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystem::state_type
-       */
-      using state_type = typename View::state_type;
+      using flux_type = View::flux_type;
 
-      /**
-       * @copydoc HyperbolicSystem::flux_type
-       */
-      using flux_type = typename View::flux_type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc HyperbolicSystem::ScalarNumber
-       */
-      using ScalarNumber = typename View::ScalarNumber;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc IndicatorParameters
-       */
       using Parameters = IndicatorParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of indicators
        *
@@ -147,8 +128,7 @@ namespace ryujin
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
                 const Parameters &parameters,
-                const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values)
+                const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -184,9 +164,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;
@@ -216,8 +194,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[new_s_i, new_eta_i] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(i);
+          precomputed_values.template get_tensor<Number, precomputed_type>(i);
 
       const auto rho_i = view.density(U_i);
       rho_i_inverse = Number(1.) / rho_i;
@@ -243,8 +220,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[s_j, eta_j] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(js);
+          precomputed_values.template get_tensor<Number, precomputed_type>(js);
 
       const auto rho_j = view.density(U_j);
       const auto rho_j_inverse = Number(1.) / rho_j;

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -96,46 +96,27 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::problem_dimension
-       */
-      static constexpr unsigned int problem_dimension = View::problem_dimension;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::precomputed_state_type
-       */
-      using precomputed_state_type = typename View::precomputed_state_type;
+      using flux_contribution_type = View::flux_contribution_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::flux_contribution_type
-       */
-      using flux_contribution_type = typename View::flux_contribution_type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename View::ScalarNumber;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc LimiterParameters
-       */
       using Parameters = LimiterParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of bounds
        *
@@ -170,8 +151,7 @@ namespace ryujin
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const Parameters &parameters,
-              const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values)
+              const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -247,9 +227,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
 
@@ -313,8 +291,7 @@ namespace ryujin
       rho_max = std::max(rho_max, rho_ij_bar);
 
       const auto &[s_j, eta_j] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(js);
+          precomputed_values.template get_tensor<Number, precomputed_type>(js);
       s_min = std::min(s_min, s_j);
 
       /* Relaxation: */

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -102,17 +102,17 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_contribution_type = View::flux_contribution_type;
+      using flux_contribution_type = typename View::flux_contribution_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = LimiterParameters<ScalarNumber>;
 

--- a/source/euler/riemann_solver.h
+++ b/source/euler/riemann_solver.h
@@ -92,7 +92,6 @@ namespace ryujin
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 
       //@}
-
       /**
        * @name Compute wavespeed estimates
        */

--- a/source/euler/riemann_solver.h
+++ b/source/euler/riemann_solver.h
@@ -61,14 +61,17 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::problem_dimension
-       */
-      static constexpr unsigned int problem_dimension = View::problem_dimension;
+      using ScalarNumber = View::ScalarNumber;
+
+      static constexpr auto problem_dimension = View::problem_dimension;
+
+      using state_type = View::state_type;
 
       /**
        * Number of components in a primitive state, we store \f$[\rho, v,
@@ -82,26 +85,13 @@ namespace ryujin
        */
       using primitive_type = std::array<Number, riemann_data_size>;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename View::ScalarNumber;
-
-      /**
-       * @copydoc RiemannSolverParameters
-       */
       using Parameters = RiemannSolverParameters<ScalarNumber>;
+
+      //@}
 
       /**
        * @name Compute wavespeed estimates
@@ -111,11 +101,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      RiemannSolver(
-          const HyperbolicSystem &hyperbolic_system,
-          const Parameters &parameters,
-          const MultiComponentVector<ScalarNumber, n_precomputed_values>
-              &precomputed_values)
+      RiemannSolver(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -288,9 +276,7 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace Euler

--- a/source/euler/riemann_solver.h
+++ b/source/euler/riemann_solver.h
@@ -67,11 +67,11 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
       /**
        * Number of components in a primitive state, we store \f$[\rho, v,
@@ -85,9 +85,9 @@ namespace ryujin
        */
       using primitive_type = std::array<Number, riemann_data_size>;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -376,21 +376,22 @@ namespace ryujin
       /**
        * A compound state vector.
        */
-      using StateVector =
+      using StateVector = Vectors::
           StateVector<ScalarNumber, problem_dimension, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed states:
        */
       using PrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_initial_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber,
+                                        n_initial_precomputed_values>;
 
       //@}
       /**

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -89,17 +89,17 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_type = View::flux_type;
+      using flux_type = typename View::flux_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = IndicatorParameters<ScalarNumber>;
 

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -83,51 +83,27 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::problem_dimension
-       */
-      static constexpr unsigned int problem_dimension = View::problem_dimension;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::precomputed_state_type
-       */
-      using precomputed_state_type = typename View::precomputed_state_type;
+      using flux_type = View::flux_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::flux_type
-       */
-      using flux_type = typename View::flux_type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::flux_type
-       */
-      using flux_contribution_type = typename View::flux_contribution_type;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename View::ScalarNumber;
-
-      /**
-       * @copydoc IndicatorParameters
-       */
       using Parameters = IndicatorParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of indicators
        *
@@ -152,8 +128,7 @@ namespace ryujin
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
                 const Parameters &parameters,
-                const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values)
+                const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -189,9 +164,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
 
       Number rho_i_inverse = 0.;
@@ -227,8 +200,7 @@ namespace ryujin
       /* entropy viscosity commutator: */
 
       const auto &[p_i, gamma_min_i, s_i, new_eta_i] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(i);
+          precomputed_values.template get_tensor<Number, precomputed_type>(i);
 
       gamma_min = gamma_min_i;
 

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -104,17 +104,17 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_contribution_type = View::flux_contribution_type;
+      using flux_contribution_type = typename View::flux_contribution_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = LimiterParameters<ScalarNumber>;
 

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -98,46 +98,27 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::problem_dimension
-       */
-      static constexpr unsigned int problem_dimension = View::problem_dimension;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::precomputed_state_type
-       */
-      using precomputed_state_type = typename View::precomputed_state_type;
+      using flux_contribution_type = View::flux_contribution_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::flux_contribution_type
-       */
-      using flux_contribution_type = typename View::flux_contribution_type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename View::ScalarNumber;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc LimiterParameters
-       */
       using Parameters = LimiterParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of bounds
        *
@@ -172,8 +153,7 @@ namespace ryujin
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const Parameters &parameters,
-              const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values)
+              const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -249,9 +229,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -291,8 +269,7 @@ namespace ryujin
       s_min = Number(std::numeric_limits<ScalarNumber>::max());
 
       const auto &[p_i, gamma_min_i, s_i, eta_i] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(i);
+          precomputed_values.template get_tensor<Number, precomputed_type>(i);
 
       gamma_min = gamma_min_i;
 
@@ -369,8 +346,8 @@ namespace ryujin
          * relaxation as well.
          */
         const auto [p_j, gamma_min_j, s_j, eta_j] =
-            precomputed_values
-                .template get_tensor<Number, precomputed_state_type>(js);
+            precomputed_values.template get_tensor<Number, precomputed_type>(
+                js);
 
         const auto s_ij_bar =
             view.surrogate_specific_entropy(U_ij_bar, gamma_min);

--- a/source/euler_aeos/riemann_solver.h
+++ b/source/euler_aeos/riemann_solver.h
@@ -47,11 +47,11 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
       /**
        * Number of components in a primitive state, we store \f$[\rho, v,
@@ -63,11 +63,11 @@ namespace ryujin
        * The array type to store the expanded primitive state for the
        * Riemann solver \f$[\rho, v, p, a]\f$
        */
-      using primitive_type = std::array<Number, riemann_data_size>;
+      using primitive_type = typename std::array<Number, riemann_data_size>;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 

--- a/source/euler_aeos/riemann_solver.h
+++ b/source/euler_aeos/riemann_solver.h
@@ -41,14 +41,17 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::problem_dimension
-       */
-      static constexpr unsigned int problem_dimension = View::problem_dimension;
+      using ScalarNumber = View::ScalarNumber;
+
+      static constexpr auto problem_dimension = View::problem_dimension;
+
+      using state_type = View::state_type;
 
       /**
        * Number of components in a primitive state, we store \f$[\rho, v,
@@ -62,32 +65,13 @@ namespace ryujin
        */
       using primitive_type = std::array<Number, riemann_data_size>;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc HyperbolicSystemView::precomputed_state_type
-       */
-      using precomputed_state_type = typename View::precomputed_state_type;
-
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename View::ScalarNumber;
-
-      /**
-       * @copydoc RiemannSolverParameters
-       */
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Compute wavespeed estimates
        */
@@ -96,11 +80,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      RiemannSolver(
-          const HyperbolicSystem &hyperbolic_system,
-          const Parameters &parameters,
-          const MultiComponentVector<ScalarNumber, n_precomputed_values>
-              &precomputed_values)
+      RiemannSolver(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -270,9 +252,7 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace EulerAEOS

--- a/source/euler_aeos/riemann_solver.template.h
+++ b/source/euler_aeos/riemann_solver.template.h
@@ -626,12 +626,10 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &n_ij) const
     {
       const auto &[p_i, unused_i, s_i, eta_i] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(i);
+          precomputed_values.template get_tensor<Number, precomputed_type>(i);
 
       const auto &[p_j, unused_j, s_j, eta_j] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(js);
+          precomputed_values.template get_tensor<Number, precomputed_type>(js);
 
       const auto riemann_data_i = riemann_data_from_state(U_i, p_i, n_ij);
       const auto riemann_data_j = riemann_data_from_state(U_j, p_j, n_ij);

--- a/source/hyperbolic_module.cc
+++ b/source/hyperbolic_module.cc
@@ -8,13 +8,10 @@
 
 #define INSTANTIATE(dim, stages)                                               \
   template NUMBER HyperbolicModule<Description, dim, NUMBER>::step<stages>(    \
-      const vector_type &,                                                     \
-      std::array<std::reference_wrapper<const vector_type>, stages>,           \
-      std::array<std::reference_wrapper<const precomputed_vector_type>,        \
-                 stages>,                                                      \
+      StateVector &,                                                           \
+      std::array<std::reference_wrapper<const StateVector>, stages>,           \
       const std::array<NUMBER, stages>,                                        \
-      vector_type &,                                                           \
-      precomputed_vector_type &,                                               \
+      StateVector &,                                                           \
       NUMBER) const
 
 namespace ryujin

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -80,21 +80,22 @@ namespace ryujin
      */
     //@{
 
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 
-    using state_type = View::state_type;
+    using state_type = typename View::state_type;
 
-    using precomputed_type = View::precomputed_type;
+    using precomputed_type = typename View::precomputed_type;
 
-    using initial_precomputed_type = View::initial_precomputed_type;
+    using initial_precomputed_type = typename View::initial_precomputed_type;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
-    using InitialPrecomputedVector = View::InitialPrecomputedVector;
+    using InitialPrecomputedVector = typename View::InitialPrecomputedVector;
 
     static constexpr auto n_precomputation_cycles =
         View::n_precomputation_cycles;
@@ -310,7 +311,7 @@ namespace ryujin
 
     InitialPrecomputedVector initial_precomputed_;
 
-    using ScalarVector = Vectors::ScalarVector<Number>;
+    using ScalarVector = typename Vectors::ScalarVector<Number>;
     mutable ScalarVector alpha_;
 
     static constexpr auto n_bounds =

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -34,7 +34,7 @@ namespace ryujin
    * step size tau_max and the prescribed step size tau are within an
    * acceptable tolerance of about 10%.
    *
-   * @ingroup TimeLoop
+   * @ingroup HyperbolicModule
    */
   enum class IDViolationStrategy {
     /**

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -10,8 +10,8 @@
 #include "convenience_macros.h"
 #include "initial_values.h"
 #include "offline_data.h"
-#include "simd.h"
 #include "sparse_matrix_simd.h"
+#include "state_vector.h"
 
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
@@ -76,68 +76,37 @@ namespace ryujin
   {
   public:
     /**
-     * @copydoc HyperbolicSystem
+     * @name Typedefs and constexpr constants
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    //@{
 
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
-    /**
-     * @copydoc HyperbolicSystem::problem_dimension
-     */
-    static constexpr unsigned int problem_dimension = View::problem_dimension;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    /**
-     * @copydoc HyperbolicSystem::state_type
-     */
-    using state_type = typename View::state_type;
+    static constexpr auto problem_dimension = View::problem_dimension;
 
-    /**
-     * @copydoc OfflineData::scalar_type
-     */
-    using scalar_type = typename OfflineData<dim, Number>::scalar_type;
+    using state_type = View::state_type;
 
-    /**
-     * @copydoc HyperbolicSystemView::vector_type
-     */
-    using vector_type = typename View::vector_type;
+    using precomputed_type = View::precomputed_type;
 
-    /**
-     * @copydoc HyperbolicSystem::n_precomputed_values
-     */
-    static constexpr unsigned int n_precomputed_values =
-        View::n_precomputed_values;
+    using initial_precomputed_type = View::initial_precomputed_type;
 
-    /**
-     * @copydoc HyperbolicSystemView::n_precomputation_cycles
-     */
-    static constexpr unsigned int n_precomputation_cycles =
+    using StateVector = View::StateVector;
+
+    using InitialPrecomputedVector = View::InitialPrecomputedVector;
+
+    static constexpr auto n_precomputation_cycles =
         View::n_precomputation_cycles;
 
+    //@}
     /**
-     * Typedef for a MultiComponentVector storing precomputed values.
+     * @name Constructor and setup
      */
-    using precomputed_vector_type = typename View::precomputed_vector_type;
+    //@{
 
     /**
-     * @copydoc HyperbolicSystem::n_precomputed_initial_values
-     */
-    static constexpr unsigned int n_precomputed_initial_values =
-        View::n_precomputed_initial_values;
-
-    /**
-     * Typedef for a MultiComponentVector storing precomputed initial_values.
-     */
-    using precomputed_initial_vector_type =
-        typename View::precomputed_initial_vector_type;
-
-
-    /**
-     * Constructor.
+     * Constructor
      */
     HyperbolicModule(
         const MPI_Comm &mpi_communicator,
@@ -154,6 +123,7 @@ namespace ryujin
      */
     void prepare();
 
+    //@}
     /**
      * @name Functons for performing explicit time steps
      */
@@ -218,15 +188,12 @@ namespace ryujin
      * immediately after performing a time step.
      */
     template <int stages>
-    Number
-    step(const vector_type &old_U,
-         std::array<std::reference_wrapper<const vector_type>, stages> stage_U,
-         std::array<std::reference_wrapper<const precomputed_vector_type>,
-                    stages> stage_precomputed,
-         const std::array<Number, stages> stage_weights,
-         vector_type &new_U,
-         precomputed_vector_type &new_precomputed,
-         Number tau = Number(0.)) const;
+    Number step(StateVector &old_state_vector,
+                std::array<std::reference_wrapper<const StateVector>, stages>
+                    stage_state_vectors,
+                const std::array<Number, stages> stage_weights,
+                StateVector &new_state_vector,
+                Number tau = Number(0.)) const;
 
     /**
      * This function postprocesses a given state @p U to conform with all
@@ -241,7 +208,7 @@ namespace ryujin
      * @note The routine does update ghost vectors of the distributed
      * vector @p U
      */
-    void apply_boundary_conditions(vector_type &U, Number t) const;
+    void apply_boundary_conditions(StateVector &state_vector, Number t) const;
 
     /**
      * Sets the relative CFL number used for computing an appropriate
@@ -275,7 +242,7 @@ namespace ryujin
     /**
      * Return a reference to the precomputed initial data vector
      */
-    ACCESSOR_READ_ONLY(precomputed_initial)
+    ACCESSOR_READ_ONLY(initial_precomputed)
 
     /**
      * Return a reference to alpha vector storing indicator values. Note
@@ -341,15 +308,17 @@ namespace ryujin
 
     mutable unsigned int n_warnings_;
 
-    precomputed_initial_vector_type precomputed_initial_;
+    InitialPrecomputedVector initial_precomputed_;
 
-    mutable scalar_type alpha_;
+    using ScalarVector = ScalarVector<Number>;
+    mutable ScalarVector alpha_;
 
     static constexpr auto n_bounds =
         Description::template Limiter<dim, Number>::n_bounds;
     mutable MultiComponentVector<Number, n_bounds> bounds_;
 
-    mutable vector_type r_;
+    using HyperbolicVector = MultiComponentVector<Number, problem_dimension>;
+    mutable HyperbolicVector r_;
 
     mutable SparseMatrixSIMD<Number> dij_matrix_;
     mutable SparseMatrixSIMD<Number> lij_matrix_;

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -310,14 +310,15 @@ namespace ryujin
 
     InitialPrecomputedVector initial_precomputed_;
 
-    using ScalarVector = ScalarVector<Number>;
+    using ScalarVector = Vectors::ScalarVector<Number>;
     mutable ScalarVector alpha_;
 
     static constexpr auto n_bounds =
         Description::template Limiter<dim, Number>::n_bounds;
-    mutable MultiComponentVector<Number, n_bounds> bounds_;
+    mutable Vectors::MultiComponentVector<Number, n_bounds> bounds_;
 
-    using HyperbolicVector = MultiComponentVector<Number, problem_dimension>;
+    using HyperbolicVector =
+        Vectors::MultiComponentVector<Number, problem_dimension>;
     mutable HyperbolicVector r_;
 
     mutable SparseMatrixSIMD<Number> dij_matrix_;

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -88,7 +88,7 @@ namespace ryujin
     pij_matrix_.reinit(sparsity_simd);
 
     precomputed_initial_ =
-        initial_values_->interpolate_precomputed_initial_values();
+        initial_values_->interpolate_precomputed_initial_vector();
   }
 
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -293,11 +293,12 @@ namespace ryujin
 
         /* Stored thread locally: */
 
-        using RiemannSolver = Description::template RiemannSolver<dim, T>;
+        using RiemannSolver =
+            typename Description::template RiemannSolver<dim, T>;
         RiemannSolver riemann_solver(
             *hyperbolic_system_, riemann_solver_parameters_, old_precomputed);
 
-        using Indicator = Description::template Indicator<dim, T>;
+        using Indicator = typename Description::template Indicator<dim, T>;
         Indicator indicator(
             *hyperbolic_system_, indicator_parameters_, old_precomputed);
 
@@ -378,7 +379,8 @@ namespace ryujin
 
       /* Complete d_ij at boundary: */
 
-      using RiemannSolver = Description::template RiemannSolver<dim, Number>;
+      using RiemannSolver =
+          typename Description::template RiemannSolver<dim, Number>;
       RiemannSolver riemann_solver(
           *hyperbolic_system_, riemann_solver_parameters_, old_precomputed);
 
@@ -520,10 +522,11 @@ namespace ryujin
 
       auto loop = [&](auto sentinel, unsigned int left, unsigned int right) {
         using T = decltype(sentinel);
-        using View = Description::template HyperbolicSystemView<dim, T>;
-        using Limiter = Description::template Limiter<dim, T>;
-        using flux_contribution_type = View::flux_contribution_type;
-        using state_type = View::state_type;
+        using View =
+            typename Description::template HyperbolicSystemView<dim, T>;
+        using Limiter = typename Description::template Limiter<dim, T>;
+        using flux_contribution_type = typename View::flux_contribution_type;
+        using state_type = typename View::state_type;
 
         unsigned int stride_size = get_stride_size<T>;
 

--- a/source/initial_state_library.h
+++ b/source/initial_state_library.h
@@ -33,14 +33,11 @@ namespace ryujin
   class InitialState : public dealii::ParameterAcceptor
   {
   public:
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    using state_type = typename View::state_type;
-    using precomputed_state_type = typename View::precomputed_state_type;
+    using state_type = View::state_type;
+
+    using initial_precomputed_type = View::initial_precomputed_type;
 
     /**
      * Constructor taking initial state name @p name and a subsection @p
@@ -67,14 +64,14 @@ namespace ryujin
      * flux computation via HyperbolicSystem::flux_contribution().
      *
      * The default implementation of this function simply returns a zero
-     * value. In case of the @ref ShallowWaterEquations we precompute the
+     * value. In case of the @ref ShallowWaterEquations we pre-compute the
      * bathymetry. In case of @ref LinearTransport we precompute the
      * advection field.
      */
-    virtual precomputed_state_type
+    virtual initial_precomputed_type
     initial_precomputations(const dealii::Point<dim> & /*point*/)
     {
-      return precomputed_state_type();
+      return initial_precomputed_type{};
     }
 
     /**
@@ -103,7 +100,7 @@ namespace ryujin
     /**
      * @copydoc HyperbolicSystem
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
     /**
      * The type of the initial state list

--- a/source/initial_state_library.h
+++ b/source/initial_state_library.h
@@ -33,11 +33,12 @@ namespace ryujin
   class InitialState : public dealii::ParameterAcceptor
   {
   public:
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
-    using state_type = View::state_type;
+    using state_type = typename View::state_type;
 
-    using initial_precomputed_type = View::initial_precomputed_type;
+    using initial_precomputed_type = typename View::initial_precomputed_type;
 
     /**
      * Constructor taking initial state name @p name and a subsection @p
@@ -100,7 +101,7 @@ namespace ryujin
     /**
      * @copydoc HyperbolicSystem
      */
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
     /**
      * The type of the initial state list

--- a/source/initial_values.h
+++ b/source/initial_values.h
@@ -41,22 +41,23 @@ namespace ryujin
      * @name Typedefs and constexpr constants
      */
     //@{
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 
-    using state_type = View::state_type;
+    using state_type = typename View::state_type;
 
     static constexpr auto n_initial_precomputed_values =
         View::n_initial_precomputed_values;
 
-    using initial_precomputed_type = View::initial_precomputed_type;
+    using initial_precomputed_type = typename View::initial_precomputed_type;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
-    using InitialPrecomputedVector = View::InitialPrecomputedVector;
+    using InitialPrecomputedVector = typename View::InitialPrecomputedVector;
 
     //@}
     /**
@@ -146,8 +147,8 @@ namespace ryujin
     dealii::SmartPointer<const HyperbolicSystem> hyperbolic_system_;
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;
 
-    InitialStateLibrary<Description, dim, Number>::initial_state_list_type
-        initial_state_list_;
+    typename InitialStateLibrary<Description, dim, Number>::
+        initial_state_list_type initial_state_list_;
 
     std::function<state_type(const dealii::Point<dim> &, Number)>
         initial_state_;

--- a/source/initial_values.h
+++ b/source/initial_values.h
@@ -38,41 +38,31 @@ namespace ryujin
   {
   public:
     /**
-     * @copydoc HyperbolicSystem
+     * @name Typedefs and constexpr constants
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    //@{
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    /**
-     * @copydoc HyperbolicSystem::problem_dimension
-     */
-    static constexpr unsigned int problem_dimension = View::problem_dimension;
+    static constexpr auto problem_dimension = View::problem_dimension;
 
-    /**
-     * @copydoc HyperbolicSystem::state_type
-     */
-    using state_type = typename View::state_type;
+    using state_type = View::state_type;
 
-    /**
-     * Typedef for a MultiComponentVector storing the state U.
-     */
-    using vector_type = MultiComponentVector<Number, problem_dimension>;
+    static constexpr auto n_initial_precomputed_values =
+        View::n_initial_precomputed_values;
 
-    /**
-     * @copydoc HyperbolicSystem::n_precomputed_values
-     */
-    static constexpr unsigned int n_precomputed_values =
-        View::n_precomputed_initial_values;
+    using initial_precomputed_type = View::initial_precomputed_type;
 
+    using StateVector = View::StateVector;
+
+    using InitialPrecomputedVector = View::InitialPrecomputedVector;
+
+    //@}
     /**
-     * Array type used for precomputed values.
+     * @name Interpolate initial states
      */
-    using precomputed_state_type = typename View::precomputed_state_type;
+    //@{
 
     /**
      * Constructor.
@@ -106,23 +96,16 @@ namespace ryujin
 
 
     /**
-     * This routine computes and returns a state vector populated with
-     * initial values for a specified time @p t.
-     */
-    vector_type interpolate(Number t = 0) const;
-
-
-    /**
      * Given a position @p point returns the corresponding (conserved)
      * initial state. The function is used to interpolate initial values
      * and enforce Dirichlet boundary conditions. For the latter, the the
      * function signature has an additional parameter @p t denoting the
      * current time to allow for time-dependent (in-flow) Dirichlet data.
      */
-    DEAL_II_ALWAYS_INLINE inline precomputed_state_type
-    flux_contributions(const dealii::Point<dim> &point) const
+    DEAL_II_ALWAYS_INLINE inline initial_precomputed_type
+    initial_precomputed(const dealii::Point<dim> &point) const
     {
-      return flux_contributions_(point);
+      return initial_precomputed_(point);
     }
 
 
@@ -130,10 +113,17 @@ namespace ryujin
      * This routine computes and returns a state vector populated with
      * initial values for a specified time @p t.
      */
-    MultiComponentVector<Number, n_precomputed_values>
-    interpolate_precomputed_initial_values() const;
+    StateVector interpolate_state_vector(Number t = 0) const;
+
+
+    /**
+     * This routine computes and returns a state vector populated with
+     * initial values for a specified time @p t.
+     */
+    InitialPrecomputedVector interpolate_initial_precomputed_vector() const;
 
   private:
+    //@}
     /**
      * @name Run time options
      */
@@ -156,14 +146,14 @@ namespace ryujin
     dealii::SmartPointer<const HyperbolicSystem> hyperbolic_system_;
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;
 
-    typename InitialStateLibrary<Description, dim, Number>::
-        initial_state_list_type initial_state_list_;
+    InitialStateLibrary<Description, dim, Number>::initial_state_list_type
+        initial_state_list_;
 
-    std::function<state_type(const dealii::Point<dim> &point, Number t)>
+    std::function<state_type(const dealii::Point<dim> &, Number)>
         initial_state_;
 
-    std::function<precomputed_state_type(const dealii::Point<dim> &point)>
-        flux_contributions_;
+    std::function<initial_precomputed_type(const dealii::Point<dim> &)>
+        initial_precomputed_;
 
     //@}
   };

--- a/source/multicomponent_vector.cc
+++ b/source/multicomponent_vector.cc
@@ -7,34 +7,38 @@
 
 namespace ryujin
 {
-  std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
-  create_vector_partitioner(
-      const std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
-          &scalar_partitioner,
-      const unsigned int n_components)
+  namespace Vectors
   {
-    dealii::IndexSet vector_owned_set(n_components *
-                                      scalar_partitioner->size());
-    for (auto it = scalar_partitioner->locally_owned_range().begin_intervals();
-         it != scalar_partitioner->locally_owned_range().end_intervals();
-         ++it)
-      vector_owned_set.add_range(*it->begin() * n_components,
-                                 (it->last() + 1) * n_components);
-    vector_owned_set.compress();
-    dealii::IndexSet vector_ghost_set(n_components *
-                                      scalar_partitioner->size());
-    for (auto it = scalar_partitioner->ghost_indices().begin_intervals();
-         it != scalar_partitioner->ghost_indices().end_intervals();
-         ++it)
-      vector_ghost_set.add_range(*it->begin() * n_components,
-                                 (it->last() + 1) * n_components);
-    vector_ghost_set.compress();
-    const auto vector_partitioner =
-        std::make_shared<const dealii::Utilities::MPI::Partitioner>(
-            vector_owned_set,
-            vector_ghost_set,
-            scalar_partitioner->get_mpi_communicator());
+    std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
+    create_vector_partitioner(
+        const std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
+            &scalar_partitioner,
+        const unsigned int n_components)
+    {
+      dealii::IndexSet vector_owned_set(n_components *
+                                        scalar_partitioner->size());
+      for (auto it =
+               scalar_partitioner->locally_owned_range().begin_intervals();
+           it != scalar_partitioner->locally_owned_range().end_intervals();
+           ++it)
+        vector_owned_set.add_range(*it->begin() * n_components,
+                                   (it->last() + 1) * n_components);
+      vector_owned_set.compress();
+      dealii::IndexSet vector_ghost_set(n_components *
+                                        scalar_partitioner->size());
+      for (auto it = scalar_partitioner->ghost_indices().begin_intervals();
+           it != scalar_partitioner->ghost_indices().end_intervals();
+           ++it)
+        vector_ghost_set.add_range(*it->begin() * n_components,
+                                   (it->last() + 1) * n_components);
+      vector_ghost_set.compress();
+      const auto vector_partitioner =
+          std::make_shared<const dealii::Utilities::MPI::Partitioner>(
+              vector_owned_set,
+              vector_ghost_set,
+              scalar_partitioner->get_mpi_communicator());
 
-    return vector_partitioner;
-  }
+      return vector_partitioner;
+    }
+  } // namespace Vectors
 } // namespace ryujin

--- a/source/multicomponent_vector.h
+++ b/source/multicomponent_vector.h
@@ -14,334 +14,336 @@
 
 namespace ryujin
 {
-  /**
-   * This function takes a scalar MPI partitioner @p scalar_partitioner as
-   * argument and returns a shared pointer to a new "vector" multicomponent
-   * partitioner that defines storage and MPI synchronization for a vector
-   * consisting of @p n_comp components. The vector partitioner is intended
-   * to efficiently store non-scalar vectors such as the state vectors U.
-   * Let (U_i)_k denote the k-th component of a state vector element U_i,
-   * we then store
-   * \f{align}
-   *  (U_0)_0, (U_0)_1, (U_0)_2, (U_0)_3, (U_0)_4,
-   *  (U_1)_0, (U_1)_1, (U_1)_2, (U_1)_3, (U_1)_4,
-   *  \ldots
-   * \f}
-   *
-   * @note This function is used to efficiently set up a single vector
-   * partitioner in OfflineData used in all MultiComponentVector instances.
-   *
-   * @ingroup SIMD
-   */
-  std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
-  create_vector_partitioner(
-      const std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
-          &scalar_partitioner,
-      const unsigned int n_components);
-
-
-  /**
-   * A wrapper around dealii::LinearAlgebra::distributed::Vector<Number>
-   * that stores a vector element of @p n_comp components per entry
-   * (instead of a scalar value).
-   *
-   * @note reinit() has to be called with an appropriate "vector" MPI
-   * partitioner created by create_vector_partitioner().
-   *
-   * @ingroup SIMD
-   */
-  template <typename Number,
-            int n_comp,
-            int simd_length = dealii::VectorizedArray<Number>::size()>
-  class MultiComponentVector
-      : public dealii::LinearAlgebra::distributed::Vector<Number>
+  namespace Vectors
   {
-  public:
     /**
-     * Shorthand typedef for the underlying dealii::VectorizedArray type
-     * used to insert and extract SIMD packed values from the
-     * MultiComponentVector.
+     * This function takes a scalar MPI partitioner @p scalar_partitioner as
+     * argument and returns a shared pointer to a new "vector" multicomponent
+     * partitioner that defines storage and MPI synchronization for a vector
+     * consisting of @p n_comp components. The vector partitioner is intended
+     * to efficiently store non-scalar vectors such as the state vectors U.
+     * Let (U_i)_k denote the k-th component of a state vector element U_i,
+     * we then store
+     * \f{align}
+     *  (U_0)_0, (U_0)_1, (U_0)_2, (U_0)_3, (U_0)_4,
+     *  (U_1)_0, (U_1)_1, (U_1)_2, (U_1)_3, (U_1)_4,
+     *  \ldots
+     * \f}
+     *
+     * @note This function is used to efficiently set up a single vector
+     * partitioner in OfflineData used in all MultiComponentVector instances.
+     *
+     * @ingroup SIMD
      */
-    using VectorizedArray = dealii::VectorizedArray<Number, simd_length>;
-
-    /**
-     * Shorthand typedef for the underlying scalar
-     * dealii::LinearAlgebra::distributed::Vector<Number> used to insert
-     * and extract a single component of the MultiComponentVector.
-     */
-    using ScalarVector = dealii::LinearAlgebra::distributed::Vector<Number>;
-
-    /**
-     * We want to use the assignment operator of the virtual base class, so
-     * specify that here.
-     */
-    using ScalarVector::operator=;
-
-    /**
-     * Reinitializes the MultiComponentVector with a scalar MPI
-     * partitioner. The function calls create_vector_partitioner()
-     * internally to create and store a corresponding "vector" MPI
-     * partitioner.
-     */
-    void reinit_with_scalar_partitioner(
+    std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
+    create_vector_partitioner(
         const std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
-            &scalar_partitioner);
+            &scalar_partitioner,
+        const unsigned int n_components);
+
 
     /**
-     * Extracts a single component out of the MultiComponentVector and
-     * stores it in @p scalar_vector. The destination vector must have a
-     * compatible corresponding (scalar) MPI partitioner, i.e., the "local
-     * size", the number of locally owned elements, has to match.
+     * A wrapper around dealii::LinearAlgebra::distributed::Vector<Number>
+     * that stores a vector element of @p n_comp components per entry
+     * (instead of a scalar value).
      *
-     * The function calls scalar_vector.update_ghost_values() before
-     * returning.
+     * @note reinit() has to be called with an appropriate "vector" MPI
+     * partitioner created by create_vector_partitioner().
      *
-     * @note This function is used in the VTUOutput module to unpack a
-     * single component out of our custom MultiComponentVector in order to
-     * call deal.II specific functions (that can only operate on scalar
-     * vectors).
+     * @ingroup SIMD
      */
-    void extract_component(ScalarVector &scalar_vector,
-                           unsigned int component) const;
+    template <typename Number,
+              int n_comp,
+              int simd_length = dealii::VectorizedArray<Number>::size()>
+    class MultiComponentVector
+        : public dealii::LinearAlgebra::distributed::Vector<Number>
+    {
+    public:
+      /**
+       * Shorthand typedef for the underlying dealii::VectorizedArray type
+       * used to insert and extract SIMD packed values from the
+       * MultiComponentVector.
+       */
+      using VectorizedArray = dealii::VectorizedArray<Number, simd_length>;
 
-    /**
-     * Inserts a single component into a MultiComponentVector. The source
-     * vector must have a compatible corresponding (scalar) MPI
-     * partitioner, i.e., the "local size", the number of locally owned
-     * elements, has to match.
-     *
-     * The function does not call update_ghost_values() automatically. This
-     * has to be done by the user once all components are updated.
-     *
-     * @note This function is used in InitialValues to populate all
-     * components of the initial state that are returned component wise as
-     * single scalar vectors by deal.II interpolation functions.
-     */
-    void insert_component(const ScalarVector &scalar_vector,
-                          unsigned int component);
+      /**
+       * Shorthand typedef for the underlying scalar
+       * dealii::LinearAlgebra::distributed::Vector<Number> used to insert
+       * and extract a single component of the MultiComponentVector.
+       */
+      using ScalarVector = dealii::LinearAlgebra::distributed::Vector<Number>;
 
-    /**
-     * Return a dealii::Tensor populated with the @p n_comp component
-     * vector stored at index @p i.
-     *
-     * If the template parameter @a Number2 is a VectorizedArray then
-     * the function returns a SIMD vectorized dealii::Tensor populated with
-     * entries from the @p n_comp component vectors stored at indices i,
-     * i+1, ..., i+simd_length-1.
-     */
-    template <typename Number2 = Number,
-              typename Tensor = dealii::Tensor<1, n_comp, Number2>>
-    Tensor get_tensor(const unsigned int i) const;
+      /**
+       * We want to use the assignment operator of the virtual base class, so
+       * specify that here.
+       */
+      using ScalarVector::operator=;
 
-    /**
-     * Variant of above function.
-     *
-     * Returns a SIMD vectorized dealii::Tensor populated with entries from
-     * the @p n_comp component vectors stored at indices *(js), *(js+1),
-     * ..., *(js+simd_length-1), i.e., @p js has to point to an array of
-     * size @p simd_length containing all indices.
-     */
-    template <typename Number2 = Number,
-              typename Tensor = dealii::Tensor<1, n_comp, Number2>>
-    Tensor get_tensor(const unsigned int *js) const;
+      /**
+       * Reinitializes the MultiComponentVector with a scalar MPI
+       * partitioner. The function calls create_vector_partitioner()
+       * internally to create and store a corresponding "vector" MPI
+       * partitioner.
+       */
+      void reinit_with_scalar_partitioner(
+          const std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
+              &scalar_partitioner);
 
-    /**
-     * Update the values of the @p n_comp component vector at index @p i
-     * with the values supplied by @p tensor.
-     *
-     * If the template parameter @a Number2 is a VectorizedArray then
-     * the function takes a SIMD vectorized @p tensor as argument instead
-     * and updates the values of the @p n_comp component vectors at indices
-     * i, i+1, ..., i+simd_length_1. with the values supplied by @p tensor.
-     *
-     * @note @p tensor can be an arbitrary indexable container, such as
-     * dealii::Tensor or std::array, that has an `operator[]()` returning a @p
-     * Number, and has a type trait `value_type`.
-     */
-    template <typename Number2 = Number,
-              typename Tensor = dealii::Tensor<1, n_comp, Number2>>
-    void write_tensor(const Tensor &tensor, const unsigned int i);
-  };
+      /**
+       * Extracts a single component out of the MultiComponentVector and
+       * stores it in @p scalar_vector. The destination vector must have a
+       * compatible corresponding (scalar) MPI partitioner, i.e., the "local
+       * size", the number of locally owned elements, has to match.
+       *
+       * The function calls scalar_vector.update_ghost_values() before
+       * returning.
+       *
+       * @note This function is used in the VTUOutput module to unpack a
+       * single component out of our custom MultiComponentVector in order to
+       * call deal.II specific functions (that can only operate on scalar
+       * vectors).
+       */
+      void extract_component(ScalarVector &scalar_vector,
+                             unsigned int component) const;
+
+      /**
+       * Inserts a single component into a MultiComponentVector. The source
+       * vector must have a compatible corresponding (scalar) MPI
+       * partitioner, i.e., the "local size", the number of locally owned
+       * elements, has to match.
+       *
+       * The function does not call update_ghost_values() automatically. This
+       * has to be done by the user once all components are updated.
+       *
+       * @note This function is used in InitialValues to populate all
+       * components of the initial state that are returned component wise as
+       * single scalar vectors by deal.II interpolation functions.
+       */
+      void insert_component(const ScalarVector &scalar_vector,
+                            unsigned int component);
+
+      /**
+       * Return a dealii::Tensor populated with the @p n_comp component
+       * vector stored at index @p i.
+       *
+       * If the template parameter @a Number2 is a VectorizedArray then
+       * the function returns a SIMD vectorized dealii::Tensor populated with
+       * entries from the @p n_comp component vectors stored at indices i,
+       * i+1, ..., i+simd_length-1.
+       */
+      template <typename Number2 = Number,
+                typename Tensor = dealii::Tensor<1, n_comp, Number2>>
+      Tensor get_tensor(const unsigned int i) const;
+
+      /**
+       * Variant of above function.
+       *
+       * Returns a SIMD vectorized dealii::Tensor populated with entries from
+       * the @p n_comp component vectors stored at indices *(js), *(js+1),
+       * ..., *(js+simd_length-1), i.e., @p js has to point to an array of
+       * size @p simd_length containing all indices.
+       */
+      template <typename Number2 = Number,
+                typename Tensor = dealii::Tensor<1, n_comp, Number2>>
+      Tensor get_tensor(const unsigned int *js) const;
+
+      /**
+       * Update the values of the @p n_comp component vector at index @p i
+       * with the values supplied by @p tensor.
+       *
+       * If the template parameter @a Number2 is a VectorizedArray then
+       * the function takes a SIMD vectorized @p tensor as argument instead
+       * and updates the values of the @p n_comp component vectors at indices
+       * i, i+1, ..., i+simd_length_1. with the values supplied by @p tensor.
+       *
+       * @note @p tensor can be an arbitrary indexable container, such as
+       * dealii::Tensor or std::array, that has an `operator[]()` returning a @p
+       * Number, and has a type trait `value_type`.
+       */
+      template <typename Number2 = Number,
+                typename Tensor = dealii::Tensor<1, n_comp, Number2>>
+      void write_tensor(const Tensor &tensor, const unsigned int i);
+    };
 
 
 #ifndef DOXYGEN
-  /* Template definitions: */
+    /* Template definitions: */
 
-  template <typename Number, int n_comp, int simd_length>
-  void MultiComponentVector<Number, n_comp, simd_length>::
-      reinit_with_scalar_partitioner(
-          const std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
-              &scalar_partitioner)
-  {
-    /* Special case of a zero component vector */
-    if (n_comp == 0)
-      return;
+    template <typename Number, int n_comp, int simd_length>
+    void MultiComponentVector<Number, n_comp, simd_length>::
+        reinit_with_scalar_partitioner(
+            const std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
+                &scalar_partitioner)
+    {
+      /* Special case of a zero component vector */
+      if (n_comp == 0)
+        return;
 
-    auto vector_partitioner =
-        create_vector_partitioner(scalar_partitioner, n_comp);
+      auto vector_partitioner =
+          create_vector_partitioner(scalar_partitioner, n_comp);
 
-    dealii::LinearAlgebra::distributed::Vector<Number>::reinit(
-        vector_partitioner);
-  }
-
-
-  template <typename Number, int n_comp, int simd_length>
-  void MultiComponentVector<Number, n_comp, simd_length>::extract_component(
-      ScalarVector &scalar_vector, unsigned int component) const
-  {
-    Assert(n_comp > 0,
-           dealii::ExcMessage(
-               "Cannot extract from a vector with zero components."));
-
-    Assert(n_comp * scalar_vector.get_partitioner()->locally_owned_size() ==
-               this->get_partitioner()->locally_owned_size(),
-           dealii::ExcMessage("Called with a scalar_vector argument that has "
-                              "incompatible local range."));
-    const auto local_size =
-        scalar_vector.get_partitioner()->locally_owned_size();
-    for (unsigned int i = 0; i < local_size; ++i)
-      scalar_vector.local_element(i) =
-          this->local_element(i * n_comp + component);
-    scalar_vector.update_ghost_values();
-  }
+      dealii::LinearAlgebra::distributed::Vector<Number>::reinit(
+          vector_partitioner);
+    }
 
 
-  template <typename Number, int n_comp, int simd_length>
-  void MultiComponentVector<Number, n_comp, simd_length>::insert_component(
-      const ScalarVector &scalar_vector, unsigned int component)
-  {
-    Assert(n_comp > 0,
-           dealii::ExcMessage(
-               "Cannot insert into a vector with zero components."));
+    template <typename Number, int n_comp, int simd_length>
+    void MultiComponentVector<Number, n_comp, simd_length>::extract_component(
+        ScalarVector &scalar_vector, unsigned int component) const
+    {
+      Assert(n_comp > 0,
+             dealii::ExcMessage(
+                 "Cannot extract from a vector with zero components."));
 
-    Assert(n_comp * scalar_vector.get_partitioner()->locally_owned_size() ==
-               this->get_partitioner()->locally_owned_size(),
-           dealii::ExcMessage("Called with a scalar_vector argument that has "
-                              "incompatible local range."));
-    const auto local_size =
-        scalar_vector.get_partitioner()->locally_owned_size();
-    for (unsigned int i = 0; i < local_size; ++i)
-      this->local_element(i * n_comp + component) =
-          scalar_vector.local_element(i);
-  }
+      Assert(n_comp * scalar_vector.get_partitioner()->locally_owned_size() ==
+                 this->get_partitioner()->locally_owned_size(),
+             dealii::ExcMessage("Called with a scalar_vector argument that has "
+                                "incompatible local range."));
+      const auto local_size =
+          scalar_vector.get_partitioner()->locally_owned_size();
+      for (unsigned int i = 0; i < local_size; ++i)
+        scalar_vector.local_element(i) =
+            this->local_element(i * n_comp + component);
+      scalar_vector.update_ghost_values();
+    }
 
-  /* Inline function  definitions: */
 
-  template <typename Number, int n_comp, int simd_length>
-  template <typename Number2, typename Tensor>
-  DEAL_II_ALWAYS_INLINE inline Tensor
-  MultiComponentVector<Number, n_comp, simd_length>::get_tensor(
-      const unsigned int i) const
-  {
-    static_assert(std::is_same<Number2, typename Tensor::value_type>::value,
-                  "dummy type mismatch");
-    Tensor tensor;
+    template <typename Number, int n_comp, int simd_length>
+    void MultiComponentVector<Number, n_comp, simd_length>::insert_component(
+        const ScalarVector &scalar_vector, unsigned int component)
+    {
+      Assert(n_comp > 0,
+             dealii::ExcMessage(
+                 "Cannot insert into a vector with zero components."));
 
-    /* Special case of a zero component vector */
-    if constexpr (n_comp == 0)
+      Assert(n_comp * scalar_vector.get_partitioner()->locally_owned_size() ==
+                 this->get_partitioner()->locally_owned_size(),
+             dealii::ExcMessage("Called with a scalar_vector argument that has "
+                                "incompatible local range."));
+      const auto local_size =
+          scalar_vector.get_partitioner()->locally_owned_size();
+      for (unsigned int i = 0; i < local_size; ++i)
+        this->local_element(i * n_comp + component) =
+            scalar_vector.local_element(i);
+    }
+
+    /* Inline function  definitions: */
+
+    template <typename Number, int n_comp, int simd_length>
+    template <typename Number2, typename Tensor>
+    DEAL_II_ALWAYS_INLINE inline Tensor
+    MultiComponentVector<Number, n_comp, simd_length>::get_tensor(
+        const unsigned int i) const
+    {
+      static_assert(std::is_same<Number2, typename Tensor::value_type>::value,
+                    "dummy type mismatch");
+      Tensor tensor;
+
+      /* Special case of a zero component vector */
+      if constexpr (n_comp == 0)
+        return tensor;
+
+      if constexpr (std::is_same<Number, Number2>::value) {
+        /* Non-vectorized sequential access. */
+
+        for (unsigned int d = 0; d < n_comp; ++d)
+          tensor[d] = this->local_element(i * n_comp + d);
+
+      } else if constexpr (std::is_same<VectorizedArray, Number2>::value) {
+
+        /* Vectorized fast access. index must be divisible by simd_length */
+        std::array<unsigned int, VectorizedArray::size()> indices;
+        for (unsigned int k = 0; k < VectorizedArray::size(); ++k)
+          indices[k] = k * n_comp;
+
+        dealii::vectorized_load_and_transpose(
+            n_comp, this->begin() + i * n_comp, indices.data(), &tensor[0]);
+
+      } else {
+        /* not implemented */
+        __builtin_trap();
+      }
+
       return tensor;
-
-    if constexpr (std::is_same<Number, Number2>::value) {
-      /* Non-vectorized sequential access. */
-
-      for (unsigned int d = 0; d < n_comp; ++d)
-        tensor[d] = this->local_element(i * n_comp + d);
-
-    } else if constexpr (std::is_same<VectorizedArray, Number2>::value) {
-
-      /* Vectorized fast access. index must be divisible by simd_length */
-      std::array<unsigned int, VectorizedArray::size()> indices;
-      for (unsigned int k = 0; k < VectorizedArray::size(); ++k)
-        indices[k] = k * n_comp;
-
-      dealii::vectorized_load_and_transpose(
-          n_comp, this->begin() + i * n_comp, indices.data(), &tensor[0]);
-
-    } else {
-      /* not implemented */
-      __builtin_trap();
     }
 
-    return tensor;
-  }
 
+    template <typename Number, int n_comp, int simd_length>
+    template <typename Number2, typename Tensor>
+    DEAL_II_ALWAYS_INLINE inline Tensor
+    MultiComponentVector<Number, n_comp, simd_length>::get_tensor(
+        const unsigned int *js) const
+    {
+      static_assert(std::is_same<Number2, typename Tensor::value_type>::value,
+                    "dummy type mismatch");
+      Tensor tensor;
 
-  template <typename Number, int n_comp, int simd_length>
-  template <typename Number2, typename Tensor>
-  DEAL_II_ALWAYS_INLINE inline Tensor
-  MultiComponentVector<Number, n_comp, simd_length>::get_tensor(
-      const unsigned int *js) const
-  {
-    static_assert(std::is_same<Number2, typename Tensor::value_type>::value,
-                  "dummy type mismatch");
-    Tensor tensor;
+      /* Special case of a zero component vector */
+      if constexpr (n_comp == 0)
+        return tensor;
 
-    /* Special case of a zero component vector */
-    if constexpr (n_comp == 0)
+      if constexpr (std::is_same<Number, Number2>::value) {
+        /* Non-vectorized sequential access. */
+
+        for (unsigned int d = 0; d < n_comp; ++d)
+          tensor[d] = this->local_element(js[0] * n_comp + d);
+
+      } else if constexpr (std::is_same<VectorizedArray, Number2>::value) {
+        /* Vectorized fast access. index must be divisible by simd_length */
+
+        std::array<unsigned int, VectorizedArray::size()> indices;
+        for (unsigned int k = 0; k < VectorizedArray::size(); ++k)
+          indices[k] = js[k] * n_comp;
+
+        dealii::vectorized_load_and_transpose(
+            n_comp, this->begin(), indices.data(), &tensor[0]);
+
+      } else {
+        /* not implemented */
+        __builtin_trap();
+      }
+
       return tensor;
-
-    if constexpr (std::is_same<Number, Number2>::value) {
-      /* Non-vectorized sequential access. */
-
-      for (unsigned int d = 0; d < n_comp; ++d)
-        tensor[d] = this->local_element(js[0] * n_comp + d);
-
-    } else if constexpr (std::is_same<VectorizedArray, Number2>::value) {
-      /* Vectorized fast access. index must be divisible by simd_length */
-
-      std::array<unsigned int, VectorizedArray::size()> indices;
-      for (unsigned int k = 0; k < VectorizedArray::size(); ++k)
-        indices[k] = js[k] * n_comp;
-
-      dealii::vectorized_load_and_transpose(
-          n_comp, this->begin(), indices.data(), &tensor[0]);
-
-    } else {
-      /* not implemented */
-      __builtin_trap();
     }
 
-    return tensor;
-  }
 
+    template <typename Number, int n_comp, int simd_length>
+    template <typename Number2, typename Tensor>
+    DEAL_II_ALWAYS_INLINE inline void
+    MultiComponentVector<Number, n_comp, simd_length>::write_tensor(
+        const Tensor &tensor, const unsigned int i)
+    {
+      static_assert(std::is_same<Number2, typename Tensor::value_type>::value,
+                    "dummy type mismatch");
 
-  template <typename Number, int n_comp, int simd_length>
-  template <typename Number2, typename Tensor>
-  DEAL_II_ALWAYS_INLINE inline void
-  MultiComponentVector<Number, n_comp, simd_length>::write_tensor(
-      const Tensor &tensor, const unsigned int i)
-  {
-    static_assert(std::is_same<Number2, typename Tensor::value_type>::value,
-                  "dummy type mismatch");
+      /* Special case of a zero component vector */
+      if constexpr (n_comp == 0)
+        return;
 
-    /* Special case of a zero component vector */
-    if constexpr (n_comp == 0)
-      return;
+      if constexpr (std::is_same<Number, Number2>::value) {
+        /* Non-vectorized sequential access. */
 
-    if constexpr (std::is_same<Number, Number2>::value) {
-      /* Non-vectorized sequential access. */
+        for (unsigned int d = 0; d < n_comp; ++d)
+          this->local_element(i * n_comp + d) = tensor[d];
 
-      for (unsigned int d = 0; d < n_comp; ++d)
-        this->local_element(i * n_comp + d) = tensor[d];
+      } else if constexpr (std::is_same<VectorizedArray, Number2>::value) {
+        /* Vectorized fast access. index must be divisible by simd_length */
 
-    } else if constexpr (std::is_same<VectorizedArray, Number2>::value) {
-      /* Vectorized fast access. index must be divisible by simd_length */
+        std::array<unsigned int, VectorizedArray::size()> indices;
+        for (unsigned int k = 0; k < VectorizedArray::size(); ++k)
+          indices[k] = k * n_comp;
 
-      std::array<unsigned int, VectorizedArray::size()> indices;
-      for (unsigned int k = 0; k < VectorizedArray::size(); ++k)
-        indices[k] = k * n_comp;
+        dealii::vectorized_transpose_and_store(false,
+                                               n_comp,
+                                               &tensor[0],
+                                               indices.data(),
+                                               this->begin() + i * n_comp);
 
-      dealii::vectorized_transpose_and_store(false,
-                                             n_comp,
-                                             &tensor[0],
-                                             indices.data(),
-                                             this->begin() + i * n_comp);
-
-    } else {
-      /* not implemented */
-      __builtin_trap();
+      } else {
+        /* not implemented */
+        __builtin_trap();
+      }
     }
-  }
 #endif
-
+  } // namespace Vectors
 } // namespace ryujin

--- a/source/multicomponent_vector.h
+++ b/source/multicomponent_vector.h
@@ -69,13 +69,13 @@ namespace ryujin
      * dealii::LinearAlgebra::distributed::Vector<Number> used to insert
      * and extract a single component of the MultiComponentVector.
      */
-    using scalar_type = dealii::LinearAlgebra::distributed::Vector<Number>;
+    using ScalarVector = dealii::LinearAlgebra::distributed::Vector<Number>;
 
     /**
      * We want to use the assignment operator of the virtual base class, so
      * specify that here.
      */
-    using scalar_type::operator=;
+    using ScalarVector::operator=;
 
     /**
      * Reinitializes the MultiComponentVector with a scalar MPI
@@ -101,7 +101,7 @@ namespace ryujin
      * call deal.II specific functions (that can only operate on scalar
      * vectors).
      */
-    void extract_component(scalar_type &scalar_vector,
+    void extract_component(ScalarVector &scalar_vector,
                            unsigned int component) const;
 
     /**
@@ -117,7 +117,7 @@ namespace ryujin
      * components of the initial state that are returned component wise as
      * single scalar vectors by deal.II interpolation functions.
      */
-    void insert_component(const scalar_type &scalar_vector,
+    void insert_component(const ScalarVector &scalar_vector,
                           unsigned int component);
 
     /**
@@ -187,7 +187,7 @@ namespace ryujin
 
   template <typename Number, int n_comp, int simd_length>
   void MultiComponentVector<Number, n_comp, simd_length>::extract_component(
-      scalar_type &scalar_vector, unsigned int component) const
+      ScalarVector &scalar_vector, unsigned int component) const
   {
     Assert(n_comp > 0,
            dealii::ExcMessage(
@@ -208,7 +208,7 @@ namespace ryujin
 
   template <typename Number, int n_comp, int simd_length>
   void MultiComponentVector<Number, n_comp, simd_length>::insert_component(
-      const scalar_type &scalar_vector, unsigned int component)
+      const ScalarVector &scalar_vector, unsigned int component)
   {
     Assert(n_comp > 0,
            dealii::ExcMessage(

--- a/source/navier_stokes/parabolic_solver.h
+++ b/source/navier_stokes/parabolic_solver.h
@@ -113,37 +113,33 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystem
+       * @name Typedefs and constexpr constants
        */
-      using HyperbolicSystem = typename Description::HyperbolicSystem;
+      //@{
 
-      /**
-       * @copydoc ParabolicSystem
-       */
-      using ParabolicSystem = typename Description::ParabolicSystem;
+      using HyperbolicSystem = Description::HyperbolicSystem;
 
-      /**
-       * @copydoc HyperbolicSystemView
-       */
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = Description::template HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc OfflineData::scalar_type
-       */
-      using scalar_type = typename OfflineData<dim, Number>::scalar_type;
+      using ParabolicSystem = Description::ParabolicSystem;
 
-      /**
-       * @copydoc HyperbolicSystemView::vector_type
-       */
-      using vector_type = typename View::vector_type;
+      using ScalarNumber = View::ScalarNumber;
 
+      static constexpr auto problem_dimension = View::problem_dimension;
+
+      using state_type = View::state_type;
+
+      using StateVector = View::StateVector;
+
+      using ScalarVector = ScalarVector<Number>;
+
+      using BlockVector = BlockVector<Number>;
+
+      //@}
       /**
-       * A distributed block vector used for temporary storage of the
-       * velocity field.
+       * @name Constructor and setup
        */
-      using block_vector_type =
-          dealii::LinearAlgebra::distributed::BlockVector<Number>;
+      //@{
 
       /**
        * Constructor.
@@ -164,19 +160,20 @@ namespace ryujin
        */
       void prepare();
 
+      //@}
       /**
        * @name Functions for performing implicit time steps
        */
       //@{
 
       /**
-       * Given a reference to a previous state vector @p old_U at time @p
-       * old_t and a time-step size @p tau perform an implicit backward
-       * Euler step (and store the result in @p new_U).
+       * Given a reference to a previous state vector @p old_state_vector
+       * at time @p old_t and a time-step size @p tau perform an implicit
+       * backward Euler step (and store the result in @p new_state_vector).
        */
-      void backward_euler_step(const vector_type &old_U,
+      void backward_euler_step(const StateVector &old_state_vector,
                                const Number old_t,
-                               vector_type &new_U,
+                               StateVector &new_state_vector,
                                Number tau,
                                const IDViolationStrategy id_violation_strategy,
                                const bool reinitialize_gmg) const;
@@ -252,11 +249,11 @@ namespace ryujin
 
       mutable dealii::MatrixFree<dim, Number> matrix_free_;
 
-      mutable block_vector_type velocity_;
-      mutable block_vector_type velocity_rhs_;
-      mutable scalar_type internal_energy_;
-      mutable scalar_type internal_energy_rhs_;
-      mutable scalar_type density_;
+      mutable BlockVector velocity_;
+      mutable BlockVector velocity_rhs_;
+      mutable ScalarVector internal_energy_;
+      mutable ScalarVector internal_energy_rhs_;
+      mutable ScalarVector density_;
 
       mutable dealii::MGLevelObject<dealii::MatrixFree<dim, float>>
           level_matrix_free_;

--- a/source/navier_stokes/parabolic_solver.h
+++ b/source/navier_stokes/parabolic_solver.h
@@ -131,9 +131,9 @@ namespace ryujin
 
       using StateVector = View::StateVector;
 
-      using ScalarVector = ScalarVector<Number>;
+      using ScalarVector = Vectors::ScalarVector<Number>;
 
-      using BlockVector = BlockVector<Number>;
+      using BlockVector = Vectors::BlockVector<Number>;
 
       //@}
       /**

--- a/source/navier_stokes/parabolic_solver.h
+++ b/source/navier_stokes/parabolic_solver.h
@@ -117,19 +117,20 @@ namespace ryujin
        */
       //@{
 
-      using HyperbolicSystem = Description::HyperbolicSystem;
+      using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-      using View = Description::template HyperbolicSystemView<dim, Number>;
+      using View =
+          typename Description::template HyperbolicSystemView<dim, Number>;
 
-      using ParabolicSystem = Description::ParabolicSystem;
+      using ParabolicSystem = typename Description::ParabolicSystem;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using StateVector = View::StateVector;
+      using StateVector = typename View::StateVector;
 
       using ScalarVector = Vectors::ScalarVector<Number>;
 

--- a/source/newton.h
+++ b/source/newton.h
@@ -32,7 +32,7 @@ namespace ryujin
    *
    * @todo Write out the quadratic Newton step in more detail.
    *
-   * @ingroup HyperbolicModule
+   * @ingroup Miscellenaous
    */
   template <typename Number>
   DEAL_II_ALWAYS_INLINE inline void

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -41,7 +41,7 @@ namespace ryujin
    * independent, it only depends on the chosen geometry and ansatz stored
    * in the Discretization class.
    *
-   * @ingroup TimeLoop
+   * @ingroup Mesh
    */
   template <int dim, typename Number = double>
   class OfflineData : public dealii::ParameterAcceptor

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -50,12 +50,12 @@ namespace ryujin
     /**
      * @copydoc ryujin::ScalarVector
      */
-    using ScalarVector = ryujin::ScalarVector<Number>;
+    using ScalarVector = Vectors::ScalarVector<Number>;
 
     /**
      * Scalar vector storing single-precision floats
      */
-    using ScalarVectorFloat = ryujin::ScalarVector<float>;
+    using ScalarVectorFloat = Vectors::ScalarVector<float>;
 
     /**
      * A tuple describing global dof index, boundary normal, normal mass,
@@ -80,8 +80,8 @@ namespace ryujin
      * Prepare offline data. A call to prepare() internally calls setup()
      * and assemble().
      *
-     * The problem_dimension parameter is used to setup up an
-     * appropriately sized vector partitioner for the MultiComponentVector.
+     * The problem_dimension parameter is used to setup up an appropriately
+     * sized vector partitioner for the MultiComponentVector.
      */
     void prepare(const unsigned int problem_dimension)
     {

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -336,8 +336,8 @@ namespace ryujin
     scalar_partitioner_ = std::make_shared<dealii::Utilities::MPI::Partitioner>(
         locally_owned, locally_relevant, mpi_communicator_);
 
-    vector_partitioner_ =
-        create_vector_partitioner(scalar_partitioner_, problem_dimension);
+    vector_partitioner_ = Vectors::create_vector_partitioner(
+        scalar_partitioner_, problem_dimension);
 
     /*
      * After elminiating periodicity and hanging node constraints we need

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -731,11 +731,10 @@ namespace ryujin
 
     {
 #ifdef DEAL_II_WITH_TRILINOS
-      using scalar_type = dealii::LinearAlgebra::distributed::Vector<double>;
-      scalar_type one(scalar_partitioner_);
+      ScalarVector one(scalar_partitioner_);
       one = 1.;
 
-      scalar_type local_lumped_mass_matrix(scalar_partitioner_);
+      ScalarVector local_lumped_mass_matrix(scalar_partitioner_);
       mass_matrix_tmp.vmult(local_lumped_mass_matrix, one);
       lumped_mass_matrix_.compress(VectorOperation::add);
 
@@ -751,10 +750,10 @@ namespace ryujin
 
 #else
 
-      Vector<Number> one(mass_matrix_tmp.m());
+      dealii::Vector<Number> one(mass_matrix_tmp.m());
       one = 1.;
 
-      Vector<Number> local_lumped_mass_matrix(mass_matrix_tmp.m());
+      dealii::Vector<Number> local_lumped_mass_matrix(mass_matrix_tmp.m());
       mass_matrix_tmp.vmult(local_lumped_mass_matrix, one);
 
       for (unsigned int i = 0; i < scalar_partitioner_->locally_owned_size();
@@ -824,7 +823,7 @@ namespace ryujin
       level_lumped_mass_matrix_[level].reinit(partitioner);
       std::vector<types::global_dof_index> dof_indices(
           dof_handler.get_fe().dofs_per_cell);
-      Vector<Number> mass_values(dof_handler.get_fe().dofs_per_cell);
+      dealii::Vector<Number> mass_values(dof_handler.get_fe().dofs_per_cell);
       FEValues<dim> fe_values(discretization_->mapping(),
                               discretization_->finite_element(),
                               discretization_->quadrature(),
@@ -856,11 +855,10 @@ namespace ryujin
 
   template <int dim, typename Number>
   template <typename ITERATOR1, typename ITERATOR2>
-  typename OfflineData<dim, Number>::boundary_map_type
-  OfflineData<dim, Number>::construct_boundary_map(
+  auto OfflineData<dim, Number>::construct_boundary_map(
       const ITERATOR1 &begin,
       const ITERATOR2 &end,
-      const Utilities::MPI::Partitioner &partitioner) const
+      const Utilities::MPI::Partitioner &partitioner) const -> BoundaryMap
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "OfflineData<dim, Number>::construct_boundary_map()"
@@ -1011,11 +1009,11 @@ namespace ryujin
 
   template <int dim, typename Number>
   template <typename ITERATOR1, typename ITERATOR2>
-  typename OfflineData<dim, Number>::coupling_boundary_pairs_type
-  OfflineData<dim, Number>::collect_coupling_boundary_pairs(
+  auto OfflineData<dim, Number>::collect_coupling_boundary_pairs(
       const ITERATOR1 &begin,
       const ITERATOR2 &end,
       const Utilities::MPI::Partitioner &partitioner) const
+      -> CouplingBoundaryPairs
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "OfflineData<dim, Number>::collect_coupling_boundary_pairs()"
@@ -1076,7 +1074,7 @@ namespace ryujin
      * Now, collect all coupling boundary pairs:
      */
 
-    coupling_boundary_pairs_type result;
+    CouplingBoundaryPairs result;
 
     for (const auto i : locally_relevant_boundary_indices) {
 

--- a/source/parabolic_module.cc
+++ b/source/parabolic_module.cc
@@ -8,11 +8,11 @@
 
 #define INSTANTIATE(dim, stages)                                               \
   template void ParabolicModule<Description, dim, NUMBER>::step<stages>(       \
-      const vector_type &,                                                     \
+      const StateVector &,                                                     \
       const NUMBER,                                                            \
-      std::array<std::reference_wrapper<const vector_type>, stages>,           \
+      std::array<std::reference_wrapper<const StateVector>, stages>,           \
       const std::array<NUMBER, stages>,                                        \
-      vector_type &,                                                           \
+      StateVector &,                                                           \
       NUMBER) const
 
 namespace ryujin

--- a/source/parabolic_module.h
+++ b/source/parabolic_module.h
@@ -37,15 +37,17 @@ namespace ryujin
      */
     //@{
 
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
-    using ParabolicSystem = Description::ParabolicSystem;
+    using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using ParabolicSolver = Description::template ParabolicSolver<dim, Number>;
+    using ParabolicSolver =
+        typename Description::template ParabolicSolver<dim, Number>;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
     //@}
     /**

--- a/source/parabolic_module.h
+++ b/source/parabolic_module.h
@@ -12,8 +12,6 @@
 #include "convenience_macros.h"
 #include "initial_values.h"
 #include "offline_data.h"
-#include "simd.h"
-#include "sparse_matrix_simd.h"
 
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
@@ -35,31 +33,25 @@ namespace ryujin
   {
   public:
     /**
-     * @copydoc HyperbolicSystem
+     * @name Typedefs and constexpr constants
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    //@{
 
-    /**
-     * @copydoc ParabolicSystem
-     */
-    using ParabolicSystem = typename Description::ParabolicSystem;
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
-    /**
-     * The ParabolicSolver
-     */
-    using ParabolicSolver =
-        typename Description::template ParabolicSolver<dim, Number>;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using ParabolicSystem = Description::ParabolicSystem;
 
+    using ParabolicSolver = Description::template ParabolicSolver<dim, Number>;
+
+    using StateVector = View::StateVector;
+
+    //@}
     /**
-     * @copydoc HyperbolicSystemView::vector_type
+     * @name Constructor and setup
      */
-    using vector_type = typename View::vector_type;
+    //@{
 
     /**
      * Constructor.
@@ -80,6 +72,7 @@ namespace ryujin
      */
     void prepare();
 
+    //@}
     /**
      * @name Functons for performing explicit time steps
      */
@@ -95,13 +88,13 @@ namespace ryujin
      * high-order right-hand side / flux.
      */
     template <int stages>
-    void
-    step(const vector_type &old_U,
-         const Number old_t,
-         std::array<std::reference_wrapper<const vector_type>, stages> stage_U,
-         const std::array<Number, stages> stage_weights,
-         vector_type &new_U,
-         Number tau) const;
+    void step(const StateVector &old_state_vector,
+              const Number old_t,
+              std::array<std::reference_wrapper<const StateVector>, stages>
+                  stage_state_vectors,
+              const std::array<Number, stages> stage_weights,
+              StateVector &new_state_vector,
+              Number tau) const;
 
     /**
      * Print a status line with solver statistics. This function is used

--- a/source/parabolic_module.template.h
+++ b/source/parabolic_module.template.h
@@ -52,11 +52,12 @@ namespace ryujin
   template <typename Description, int dim, typename Number>
   template <int stages>
   void ParabolicModule<Description, dim, Number>::step(
-      const vector_type &old_U,
+      const StateVector &old_state_vector,
       const Number old_t,
-      std::array<std::reference_wrapper<const vector_type>, stages> /*stage_U*/,
+      std::array<std::reference_wrapper<const StateVector>,
+                 stages> /*stage_state_vectors*/,
       const std::array<Number, stages> /*stage_weights*/,
-      vector_type &new_U,
+      StateVector &new_state_vector,
       Number tau) const
   {
     if constexpr (ParabolicSystem::is_identity) {
@@ -71,6 +72,8 @@ namespace ryujin
       static_assert(stages == 0, "high order fluxes are not implemented");
 
       /* FIXME: This needs to be refactored really really badly. */
+      const auto &[old_U, old_precomputed, old_V] = old_state_vector;
+      auto &[new_U, new_precomputed, new_V] = new_state_vector;
 
       const bool reinit_gmg = cycle_++ % 4 == 0;
       parabolic_solver_.backward_euler_step(

--- a/source/parabolic_module.template.h
+++ b/source/parabolic_module.template.h
@@ -71,13 +71,13 @@ namespace ryujin
 
       static_assert(stages == 0, "high order fluxes are not implemented");
 
-      /* FIXME: This needs to be refactored really really badly. */
-      const auto &[old_U, old_precomputed, old_V] = old_state_vector;
-      auto &[new_U, new_precomputed, new_V] = new_state_vector;
-
       const bool reinit_gmg = cycle_++ % 4 == 0;
-      parabolic_solver_.backward_euler_step(
-          old_U, old_t, new_U, tau, id_violation_strategy_, reinit_gmg);
+      parabolic_solver_.backward_euler_step(old_state_vector,
+                                            old_t,
+                                            new_state_vector,
+                                            tau,
+                                            id_violation_strategy_,
+                                            reinit_gmg);
       n_restarts_ = parabolic_solver_.n_restarts();
       n_warnings_ = parabolic_solver_.n_warnings();
     }

--- a/source/patterns_conversion.h
+++ b/source/patterns_conversion.h
@@ -19,6 +19,12 @@ struct ConversionHelper : std::false_type {
 };
 
 
+/**
+ * Inject conversion rules into the deal.II namespace by specializing
+ * Patterns::Tools::Convert for our custom enum classes.
+ *
+ * @ingroup Miscellaneous
+ */
 template <typename T>
 struct Patterns::Tools::
     Convert<T, typename std::enable_if_t<ConversionHelper<T>::value>> {
@@ -69,6 +75,12 @@ DEAL_II_NAMESPACE_CLOSE
 
 #define LIST(...) __VA_ARGS__
 
+/**
+ * Shorthand macro for declaring "string to enum class" conversion rules
+ * for the deal.II Patterns::Tools::Convert mechanism.
+ *
+ * @ingroup Miscellaneous
+ */
 #define DECLARE_ENUM(type, s)                                                  \
   namespace dealii                                                             \
   {                                                                            \

--- a/source/postprocessor.h
+++ b/source/postprocessor.h
@@ -43,13 +43,14 @@ namespace ryujin
      */
     //@{
 
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 
-    using state_type = View::state_type;
+    using state_type = typename View::state_type;
 
     template <typename T>
     using grad_type = dealii::Tensor<1, dim, T>;
@@ -57,7 +58,7 @@ namespace ryujin
     template <typename T>
     using curl_type = dealii::Tensor<1, dim == 2 ? 1 : dim, T>;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
     using ScalarVector = Vectors::ScalarVector<Number>;
 

--- a/source/postprocessor.h
+++ b/source/postprocessor.h
@@ -39,49 +39,33 @@ namespace ryujin
   {
   public:
     /**
-     * @copydoc HyperbolicSystem
+     * @name Typedefs and constexpr constants
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    //@{
 
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
-    /**
-     * @copydoc HyperbolicSystem::problem_dimension
-     */
-    static constexpr unsigned int problem_dimension = View::problem_dimension;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    /**
-     * @copydoc HyperbolicSystem::state_type
-     */
-    using state_type = typename View::state_type;
+    static constexpr auto problem_dimension = View::problem_dimension;
 
-    /**
-     * The type used to store the gradient of a scalar quantitty;
-     */
+    using state_type = View::state_type;
+
     template <typename T>
     using grad_type = dealii::Tensor<1, dim, T>;
 
-    /**
-     * Type used to store the curl of an 2D/3D vector field. Departing from
-     * mathematical rigor, in 2D this is a number (stored as
-     * `Tensor<1,1>`), in 3D this is a rank 1 tensor.
-     */
     template <typename T>
     using curl_type = dealii::Tensor<1, dim == 2 ? 1 : dim, T>;
 
-    /**
-     * @copydoc OfflineData::scalar_type
-     */
-    using scalar_type = typename OfflineData<dim, Number>::scalar_type;
+    using StateVector = View::StateVector;
 
+    using ScalarVector = ScalarVector<Number>;
+
+    //@}
     /**
-     * @copydoc HyperbolicSystemView::vector_type
+     * @name Constructor and setup
      */
-    using vector_type = MultiComponentVector<Number, problem_dimension>;
+    //@{
 
     /**
      * Constructor.
@@ -138,7 +122,7 @@ namespace ryujin
      *
      * The function requires MPI communication and is not reentrant.
      */
-    void compute(const vector_type &U) const;
+    void compute(const StateVector &state_vector) const;
 
     /**
      * Returns a reference to the quantities_ vector that has been filled
@@ -175,7 +159,7 @@ namespace ryujin
     std::vector<std::pair<bool /*primitive*/, unsigned int>> vorticity_indices_;
 
     mutable std::vector<std::pair<Number, Number>> bounds_;
-    mutable std::vector<scalar_type> quantities_;
+    mutable std::vector<ScalarVector> quantities_;
     //@}
   };
 

--- a/source/postprocessor.h
+++ b/source/postprocessor.h
@@ -59,7 +59,7 @@ namespace ryujin
 
     using StateVector = View::StateVector;
 
-    using ScalarVector = ScalarVector<Number>;
+    using ScalarVector = Vectors::ScalarVector<Number>;
 
     //@}
     /**

--- a/source/postprocessor.template.h
+++ b/source/postprocessor.template.h
@@ -103,12 +103,14 @@ namespace ryujin
 
 
   template <typename Description, int dim, typename Number>
-  void
-  Postprocessor<Description, dim, Number>::compute(const vector_type &U) const
+  void Postprocessor<Description, dim, Number>::compute(
+      const StateVector &state_vector) const
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "Postprocessor<dim, Number>::compute()" << std::endl;
 #endif
+
+    const auto &U = std::get<0>(state_vector);
 
     using VA = dealii::VectorizedArray<Number>;
 

--- a/source/quantities.h
+++ b/source/quantities.h
@@ -7,11 +7,7 @@
 
 #include <compile_time_options.h>
 
-#include "convenience_macros.h"
-#include "initial_values.h"
 #include "offline_data.h"
-#include "simd.h"
-#include "sparse_matrix_simd.h"
 
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/timer.h>
@@ -31,30 +27,22 @@ namespace ryujin
   {
   public:
     /**
-     * @copydoc HyperbolicSystem
+     * @name Typedefs and constexpr constants
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    //@{
 
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
-    /**
-     * @copydoc HyperbolicSystemView::problem_dimension
-     */
-    static constexpr unsigned int problem_dimension = View::problem_dimension;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    /**
-     * @copydoc HyperbolicSystemView::state_type
-     */
-    using state_type = typename View::state_type;
+    using state_type = View::state_type;
 
+    using StateVector = View::StateVector;
+
+    //@}
     /**
-     * Typedef for a MultiComponentVector storing the state U.
+     * @name Constructor and setup
      */
-    using vector_type = MultiComponentVector<Number, problem_dimension>;
 
     /**
      * Constructor.
@@ -82,12 +70,14 @@ namespace ryujin
      * Strang step) and accumulates statistics for quantities of interests
      * for all defined manifolds.
      */
-    void accumulate(const vector_type &U, const Number t);
+    void accumulate(const StateVector &state_vector, const Number t);
 
     /**
      * Write quantities of interest to designated output files.
      */
-    void write_out(const vector_type &U, const Number t, unsigned int cycle);
+    void write_out(const StateVector &state_vector,
+                   const Number t,
+                   unsigned int cycle);
 
     //@}
 
@@ -219,7 +209,7 @@ namespace ryujin
     std::string header_;
 
     template <typename point_type, typename value_type>
-    value_type internal_accumulate(const vector_type &U,
+    value_type internal_accumulate(const StateVector &state_vector,
                                    const std::vector<point_type> &interior_map,
                                    std::vector<value_type> &new_val);
 

--- a/source/quantities.h
+++ b/source/quantities.h
@@ -31,13 +31,14 @@ namespace ryujin
      */
     //@{
 
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
-    using state_type = View::state_type;
+    using state_type = typename View::state_type;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
     //@}
     /**

--- a/source/quantities.template.h
+++ b/source/quantities.template.h
@@ -360,10 +360,12 @@ namespace ryujin
   template <typename Description, int dim, typename Number>
   template <typename point_type, typename value_type>
   value_type Quantities<Description, dim, Number>::internal_accumulate(
-      const vector_type &U,
+      const StateVector &state_vector,
       const std::vector<point_type> &points_vector,
       std::vector<value_type> &val_new)
   {
+    const auto &U = std::get<0>(state_vector);
+
     value_type spatial_average;
     Number mass_sum = Number(0.);
 
@@ -473,8 +475,8 @@ namespace ryujin
 
 
   template <typename Description, int dim, typename Number>
-  void Quantities<Description, dim, Number>::accumulate(const vector_type &U,
-                                                        const Number t)
+  void Quantities<Description, dim, Number>::accumulate(
+      const StateVector &state_vector, const Number t)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "Quantities<dim, Number>::accumulate()" << std::endl;
@@ -502,7 +504,8 @@ namespace ryujin
 
         /* accumulate new values */
 
-        const auto spatial_average = internal_accumulate(U, point_map, val_new);
+        const auto spatial_average =
+            internal_accumulate(state_vector, point_map, val_new);
 
         /* Average in time with trapezoidal rule: */
 
@@ -543,9 +546,8 @@ namespace ryujin
 
 
   template <typename Description, int dim, typename Number>
-  void Quantities<Description, dim, Number>::write_out(const vector_type &U,
-                                                       const Number t,
-                                                       unsigned int cycle)
+  void Quantities<Description, dim, Number>::write_out(
+      const StateVector &state_vector, const Number t, unsigned int cycle)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "Quantities<dim, Number>::write_out()" << std::endl;
@@ -576,7 +578,7 @@ namespace ryujin
 
           if (options.find("time_averaged") == std::string::npos &&
               options.find("space_averaged") == std::string::npos)
-            internal_accumulate(U, point_map, val_new);
+            internal_accumulate(state_vector, point_map, val_new);
           else
             AssertThrow(t_new == t, dealii::ExcInternalError());
 

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -238,21 +238,22 @@ namespace ryujin
       /**
        * A compound state vector.
        */
-      using StateVector =
+      using StateVector = Vectors::
           StateVector<ScalarNumber, problem_dimension, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed states:
        */
       using PrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_initial_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber,
+                                        n_initial_precomputed_values>;
 
       //@}
       /**

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -49,36 +49,27 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystem::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::precomputed_state_type
-       */
-      using precomputed_state_type = typename View::precomputed_state_type;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystem::state_type
-       */
-      using state_type = typename View::state_type;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystem::ScalarNumber
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
+      using flux_type = View::flux_type;
 
-      /**
-       * @copydoc IndicatorParameters
-       */
+      using precomputed_type = View::precomputed_type;
+
+      using PrecomputedVector = View::PrecomputedVector;
+
       using Parameters = IndicatorParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of indicators
        *
@@ -103,8 +94,7 @@ namespace ryujin
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
                 const Parameters &parameters,
-                const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values)
+                const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -140,9 +130,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
       Number u_i;
       Number u_abs_max;
@@ -169,8 +157,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto prec_i =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(i);
+          precomputed_values.template get_tensor<Number, precomputed_type>(i);
 
       u_i = view.state(U_i);
       u_abs_max = std::abs(u_i);
@@ -191,8 +178,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto prec_j =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(js);
+          precomputed_values.template get_tensor<Number, precomputed_type>(js);
 
       const auto u_j = view.state(U_j);
       u_abs_max = std::max(u_abs_max, std::abs(u_j));

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -55,17 +55,17 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_type = View::flux_type;
+      using flux_type = typename View::flux_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = IndicatorParameters<ScalarNumber>;
 

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -58,17 +58,17 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_contribution_type = View::flux_contribution_type;
+      using flux_contribution_type = typename View::flux_contribution_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = LimiterParameters<ScalarNumber>;
 

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -52,36 +52,27 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystemView::flux_contribution_type
-       */
-      using flux_contribution_type = typename View::flux_contribution_type;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
+      using flux_contribution_type = View::flux_contribution_type;
 
-      /**
-       * @copydoc LimiterParameters
-       */
+      using precomputed_type = View::precomputed_type;
+
+      using PrecomputedVector = View::PrecomputedVector;
+
       using Parameters = LimiterParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of bounds
        *
@@ -116,8 +107,7 @@ namespace ryujin
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const Parameters &parameters,
-              const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values)
+              const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -186,9 +176,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
       flux_contribution_type flux_i;

--- a/source/scalar_conservation/riemann_solver.h
+++ b/source/scalar_conservation/riemann_solver.h
@@ -76,35 +76,25 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystemView::precomputed_state_type
-       */
-      using precomputed_state_type = typename View::precomputed_state_type;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc RiemannSolverParameters
-       */
+      using PrecomputedVector = View::PrecomputedVector;
+
       using Parameters = RiemannSolverParameters<ScalarNumber>;
+
+      //@}
 
       /**
        * @name Compute wavespeed estimates
@@ -114,11 +104,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      RiemannSolver(
-          const HyperbolicSystem &hyperbolic_system,
-          const Parameters &parameters,
-          const MultiComponentVector<ScalarNumber, n_precomputed_values>
-              &precomputed_values)
+      RiemannSolver(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -132,8 +120,8 @@ namespace ryujin
        */
       Number compute(const Number &u_i,
                      const Number &u_j,
-                     const precomputed_state_type &prec_i,
-                     const precomputed_state_type &prec_j,
+                     const precomputed_type &prec_i,
+                     const precomputed_type &prec_j,
                      const dealii::Tensor<1, dim, Number> &n_ij) const;
 
       /**
@@ -149,9 +137,7 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace ScalarConservation

--- a/source/scalar_conservation/riemann_solver.h
+++ b/source/scalar_conservation/riemann_solver.h
@@ -82,15 +82,15 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 

--- a/source/scalar_conservation/riemann_solver.template.h
+++ b/source/scalar_conservation/riemann_solver.template.h
@@ -23,8 +23,8 @@ namespace ryujin
     Number RiemannSolver<dim, Number>::compute(
         const Number &u_i,
         const Number &u_j,
-        const precomputed_state_type &prec_i,
-        const precomputed_state_type &prec_j,
+        const precomputed_type &prec_i,
+        const precomputed_type &prec_j,
         const dealii::Tensor<1, dim, Number> &n_ij) const
     {
       const auto &view = hyperbolic_system.view<dim, Number>();
@@ -202,7 +202,7 @@ namespace ryujin
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 
-      using pst = typename View::precomputed_state_type;
+      using pst = typename View::precomputed_type;
 
       const auto u_i = view.state(U_i);
       const auto u_j = view.state(U_j);

--- a/source/scratch_data.h
+++ b/source/scratch_data.h
@@ -17,6 +17,8 @@ namespace ryujin
   /**
    * Internal scratch data for thread parallelized assembly. See the
    * deal.II Workstream documentation for details.
+   *
+   * @ingroup Mesh
    */
   template <int dim>
   class AssemblyScratchData

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -288,7 +288,6 @@ namespace ryujin
        */
       //@{
 
-
       /**
        * The number of precomputation cycles.
        */

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -266,21 +266,22 @@ namespace ryujin
       /**
        * A compound state vector.
        */
-      using StateVector =
+      using StateVector = Vectors::
           StateVector<ScalarNumber, problem_dimension, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed states:
        */
       using PrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_initial_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber,
+                                        n_initial_precomputed_values>;
 
       //@}
       /**

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -14,6 +14,7 @@
 #include <openmp.h>
 #include <patterns_conversion.h>
 #include <simd.h>
+#include <state_vector.h>
 
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/tensor.h>
@@ -174,25 +175,30 @@ namespace ryujin
     public:
       //@}
       /**
-       * @name Types and compile time constants
+       * @name Types and constexpr constants
        */
       //@{
 
       /**
        * The dimension of the state space.
        */
-      static constexpr unsigned int problem_dimension = dim + 1;
+      static constexpr unsigned int problem_dimension = 1 + dim;
 
       /**
-       * The storage type used for a (conserved) state vector \f$\boldsymbol
-       * U\f$.
+       * Storage type for a (conserved) state vector \f$\boldsymbol U\f$.
        */
       using state_type = dealii::Tensor<1, problem_dimension, Number>;
 
       /**
-       * MulticomponentVector for storing a vector of conserved states:
+       * Storage type for the flux \f$\mathbf{f}\f$.
        */
-      using vector_type = MultiComponentVector<ScalarNumber, problem_dimension>;
+      using flux_type =
+          dealii::Tensor<1, problem_dimension, dealii::Tensor<1, dim, Number>>;
+
+      /**
+       * The storage type used for flux contributions.
+       */
+      using flux_contribution_type = std::tuple<state_type, Number>;
 
       /**
        * An array holding all component names of the conserved state as a
@@ -225,47 +231,6 @@ namespace ryujin
       }();
 
       /**
-       * The storage type used for the flux \f$\mathbf{f}\f$.
-       */
-      using flux_type =
-          dealii::Tensor<1, problem_dimension, dealii::Tensor<1, dim, Number>>;
-
-      /**
-       * The storage type used for flux contributions.
-       */
-      using flux_contribution_type = std::tuple<state_type, Number>;
-
-      //@}
-      /**
-       * @name Precomputed quantities
-       */
-      //@{
-
-      /**
-       * The number of precomputed initial values.
-       */
-      static constexpr unsigned int n_precomputed_initial_values = 1;
-
-      /**
-       * Array type used for precomputed initial values.
-       */
-      using precomputed_initial_state_type =
-          std::array<Number, n_precomputed_initial_values>;
-
-      /**
-       * MulticomponentVector for storing a vector of precomputed initial
-       * states:
-       */
-      using precomputed_initial_vector_type =
-          MultiComponentVector<ScalarNumber, n_precomputed_initial_values>;
-
-      /**
-       * An array holding all component names of the precomputed values.
-       */
-      static inline const auto precomputed_initial_names =
-          std::array<std::string, n_precomputed_initial_values>{"bathymetry"};
-
-      /**
        * The number of precomputed values.
        */
       static constexpr unsigned int n_precomputed_values = 2;
@@ -273,19 +238,56 @@ namespace ryujin
       /**
        * Array type used for precomputed values.
        */
-      using precomputed_state_type = std::array<Number, n_precomputed_values>;
-
-      /**
-       * MulticomponentVector for storing a vector of precomputed states:
-       */
-      using precomputed_vector_type =
-          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+      using precomputed_type = std::array<Number, n_precomputed_values>;
 
       /**
        * An array holding all component names of the precomputed values.
        */
       static inline const auto precomputed_names =
           std::array<std::string, n_precomputed_values>{"eta_m", "h_star"};
+
+      /**
+       * The number of precomputed initial values.
+       */
+      static constexpr unsigned int n_initial_precomputed_values = 1;
+
+      /**
+       * Array type used for precomputed initial values.
+       */
+      using initial_precomputed_type =
+          std::array<Number, n_initial_precomputed_values>;
+
+      /**
+       * An array holding all component names of the precomputed values.
+       */
+      static inline const auto initial_precomputed_names =
+          std::array<std::string, n_initial_precomputed_values>{"bathymetry"};
+
+      /**
+       * A compound state vector.
+       */
+      using StateVector =
+          StateVector<ScalarNumber, problem_dimension, n_precomputed_values>;
+
+      /**
+       * MulticomponentVector for storing a vector of precomputed states:
+       */
+      using PrecomputedVector =
+          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+
+      /**
+       * MulticomponentVector for storing a vector of precomputed initial
+       * states:
+       */
+      using InitialPrecomputedVector =
+          MultiComponentVector<ScalarNumber, n_initial_precomputed_values>;
+
+      //@}
+      /**
+       * @name Computing precomputed quantities
+       */
+      //@{
+
 
       /**
        * The number of precomputation cycles.
@@ -299,9 +301,8 @@ namespace ryujin
       template <typename DISPATCH, typename SPARSITY>
       void precomputation_loop(unsigned int cycle,
                                const DISPATCH &dispatch_check,
-                               precomputed_vector_type &precomputed_values,
                                const SPARSITY &sparsity_simd,
-                               const vector_type &U,
+                               StateVector &state_vector,
                                unsigned int left,
                                unsigned int right) const;
 
@@ -495,14 +496,14 @@ namespace ryujin
        * bathymetry and return, both, state and bathymetry.
        */
       flux_contribution_type
-      flux_contribution(const precomputed_vector_type &pv,
-                        const precomputed_initial_vector_type &piv,
+      flux_contribution(const PrecomputedVector &pv,
+                        const InitialPrecomputedVector &piv,
                         const unsigned int i,
                         const state_type &U_i) const;
 
       flux_contribution_type
-      flux_contribution(const precomputed_vector_type &pv,
-                        const precomputed_initial_vector_type &piv,
+      flux_contribution(const PrecomputedVector &pv,
+                        const InitialPrecomputedVector &piv,
                         const unsigned int *js,
                         const state_type &U_j) const;
 
@@ -559,12 +560,12 @@ namespace ryujin
                                   const Number &h_star,
                                   const ScalarNumber tau) const;
 
-      state_type nodal_source(const precomputed_vector_type &pv,
+      state_type nodal_source(const PrecomputedVector &pv,
                               const unsigned int i,
                               const state_type &U_i,
                               const ScalarNumber tau) const;
 
-      state_type nodal_source(const precomputed_vector_type &pv,
+      state_type nodal_source(const PrecomputedVector &pv,
                               const unsigned int *js,
                               const state_type &U_j,
                               const ScalarNumber tau) const;
@@ -672,13 +673,15 @@ namespace ryujin
     HyperbolicSystemView<dim, Number>::precomputation_loop(
         unsigned int cycle [[maybe_unused]],
         const DISPATCH &dispatch_check,
-        precomputed_vector_type &precomputed_values,
         const SPARSITY &sparsity_simd,
-        const vector_type &U,
+        StateVector &state_vector,
         unsigned int left,
         unsigned int right) const
     {
       Assert(cycle == 0, dealii::ExcInternalError());
+
+      const auto &U = std::get<0>(state_vector);
+      auto &precomputed = std::get<1>(state_vector);
 
       /* We are inside a thread parallel context */
 
@@ -701,8 +704,8 @@ namespace ryujin
         const auto h_sharp = water_depth_sharp(U_i);
         const auto h_star = ryujin::pow(h_sharp, ScalarNumber(4. / 3.));
 
-        const precomputed_state_type prec_i{eta_m, h_star};
-        precomputed_values.template write_tensor<Number>(prec_i, i);
+        const precomputed_type prec_i{eta_m, h_star};
+        precomputed.template write_tensor<Number>(prec_i, i);
       }
     }
 
@@ -1080,8 +1083,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const precomputed_vector_type & /*pv*/,
-        const precomputed_initial_vector_type &piv,
+        const PrecomputedVector & /*pv*/,
+        const InitialPrecomputedVector &piv,
         const unsigned int i,
         const state_type &U_i) const -> flux_contribution_type
     {
@@ -1093,8 +1096,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const precomputed_vector_type & /*pv*/,
-        const precomputed_initial_vector_type &piv,
+        const PrecomputedVector & /*pv*/,
+        const InitialPrecomputedVector &piv,
         const unsigned int *js,
         const state_type &U_j) const -> flux_contribution_type
     {
@@ -1212,13 +1215,13 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::nodal_source(
-        const precomputed_vector_type &pv,
+        const PrecomputedVector &pv,
         const unsigned int i,
         const state_type &U_i,
         const ScalarNumber tau) const -> state_type
     {
       const auto &[eta_m, h_star] =
-          pv.template get_tensor<Number, precomputed_state_type>(i);
+          pv.template get_tensor<Number, precomputed_type>(i);
 
       return manning_friction(U_i, h_star, tau);
     }
@@ -1227,13 +1230,13 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::nodal_source(
-        const precomputed_vector_type &pv,
+        const PrecomputedVector &pv,
         const unsigned int *js,
         const state_type &U_j,
         const ScalarNumber tau) const -> state_type
     {
       const auto &[eta_m, h_star] =
-          pv.template get_tensor<Number, precomputed_state_type>(js);
+          pv.template get_tensor<Number, precomputed_type>(js);
 
       return manning_friction(U_j, h_star, tau);
     }

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -56,17 +56,17 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_type = View::flux_type;
+      using flux_type = typename View::flux_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = IndicatorParameters<ScalarNumber>;
 

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -50,46 +50,27 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystem::problem_dimension
-       */
-      static constexpr unsigned int problem_dimension = View::problem_dimension;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystem::precomputed_state_type
-       */
-      using precomputed_state_type = typename View::precomputed_state_type;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystem::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystem::state_type
-       */
-      using state_type = typename View::state_type;
+      using flux_type = View::flux_type;
 
-      /**
-       * @copydoc HyperbolicSystem::flux_type
-       */
-      using flux_type = typename View::flux_type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc HyperbolicSystem::ScalarNumber
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc IndicatorParameters
-       */
       using Parameters = IndicatorParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of indicators
        *
@@ -114,8 +95,7 @@ namespace ryujin
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
                 const Parameters &parameters,
-                const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values)
+                const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -151,9 +131,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
       Number h_i = 0.;
       Number eta_i = 0.;
@@ -183,8 +161,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[eta_m, h_star] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(i);
+          precomputed_values.template get_tensor<Number, precomputed_type>(i);
 
       h_i = view.water_depth(U_i);
       eta_i = eta_m;
@@ -208,8 +185,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[eta_j, h_star_j] =
-          precomputed_values
-              .template get_tensor<Number, precomputed_state_type>(js);
+          precomputed_values.template get_tensor<Number, precomputed_type>(js);
 
       const auto velocity_j =
           view.momentum(U_j) * view.inverse_water_depth_sharp(U_j);

--- a/source/shallow_water/initial_state_flow_over_bump.h
+++ b/source/shallow_water/initial_state_flow_over_bump.h
@@ -107,7 +107,7 @@ namespace ryujin
 
       auto initial_precomputations(const dealii::Point<dim> &point) ->
           typename InitialState<Description, dim, Number>::
-              precomputed_state_type final
+              initial_precomputed_type final
       {
         /* Compute bathymetry: */
         return {compute_bathymetry(point)};

--- a/source/shallow_water/initial_state_geotiff.h
+++ b/source/shallow_water/initial_state_geotiff.h
@@ -130,8 +130,9 @@ namespace ryujin
         return view.from_initial_state(primitive);
       }
 
-      typename InitialState<Description, dim, Number>::precomputed_state_type
-      initial_precomputations(const dealii::Point<dim> &point) final
+      auto initial_precomputations(const dealii::Point<dim> &point) ->
+          typename InitialState<Description, dim, Number>::
+              initial_precomputed_type final
       {
         /* Compute bathymetry: */
         return {compute_bathymetry(point)};

--- a/source/shallow_water/initial_state_hou_test.h
+++ b/source/shallow_water/initial_state_hou_test.h
@@ -61,7 +61,7 @@ namespace ryujin
 
       auto initial_precomputations(const dealii::Point<dim> &point) ->
           typename InitialState<Description, dim, Number>::
-              precomputed_state_type final
+              initial_precomputed_type final
       {
         /* Compute bathymetry: */
         return {compute_bathymetry(point)};

--- a/source/shallow_water/initial_state_paraboloid.h
+++ b/source/shallow_water/initial_state_paraboloid.h
@@ -124,7 +124,7 @@ namespace ryujin
 
       auto initial_precomputations(const dealii::Point<dim> &point) ->
           typename InitialState<Description, dim, Number>::
-              precomputed_state_type final
+              initial_precomputed_type final
       {
         /* Compute bathymetry: */
         return {compute_bathymetry(point)};

--- a/source/shallow_water/initial_state_sloping_friction.h
+++ b/source/shallow_water/initial_state_sloping_friction.h
@@ -71,7 +71,7 @@ namespace ryujin
 
       auto initial_precomputations(const dealii::Point<dim> &point) ->
           typename InitialState<Description, dim, Number>::
-              precomputed_state_type final
+              initial_precomputed_type final
       {
         /* Compute bathymetry: */
         return {compute_bathymetry(point)};

--- a/source/shallow_water/initial_state_smooth_vortex.h
+++ b/source/shallow_water/initial_state_smooth_vortex.h
@@ -88,7 +88,7 @@ namespace ryujin
 
       auto initial_precomputations(const dealii::Point<dim> &point) ->
           typename InitialState<Description, dim, Number>::
-              precomputed_state_type final
+              initial_precomputed_type final
       {
         /* Compute bathymetry: */
         return {compute_bathymetry(point)};

--- a/source/shallow_water/initial_state_three_bumps_dam_break.h
+++ b/source/shallow_water/initial_state_three_bumps_dam_break.h
@@ -83,7 +83,7 @@ namespace ryujin
 
       auto initial_precomputations(const dealii::Point<dim> &point) ->
           typename InitialState<Description, dim, Number>::
-              precomputed_state_type final
+              initial_precomputed_type final
       {
         /* Compute bathymetry: */
         return {compute_bathymetry(point)};

--- a/source/shallow_water/initial_state_transient.h
+++ b/source/shallow_water/initial_state_transient.h
@@ -78,7 +78,7 @@ namespace ryujin
 
       auto initial_precomputations(const dealii::Point<dim> &point) ->
           typename InitialState<Description, dim, Number>::
-              precomputed_state_type final
+              initial_precomputed_type final
       {
         /* Compute bathymetry: */
         return {compute_bathymetry(point)};

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -94,17 +94,17 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_contribution_type = View::flux_contribution_type;
+      using flux_contribution_type = typename View::flux_contribution_type;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = LimiterParameters<ScalarNumber>;
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -88,36 +88,27 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      static constexpr auto problem_dimension = View::problem_dimension;
 
-      /**
-       * @copydoc HyperbolicSystemView::flux_contribution_type
-       */
-      using flux_contribution_type = typename View::flux_contribution_type;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
+      using flux_contribution_type = View::flux_contribution_type;
 
-      /**
-       * @copydoc LimiterParameters
-       */
+      using precomputed_type = View::precomputed_type;
+
+      using PrecomputedVector = View::PrecomputedVector;
+
       using Parameters = LimiterParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of bounds
        *
@@ -153,8 +144,7 @@ namespace ryujin
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const Parameters &parameters,
-              const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values)
+              const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -224,9 +214,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
 

--- a/source/shallow_water/riemann_solver.h
+++ b/source/shallow_water/riemann_solver.h
@@ -48,11 +48,11 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
       static constexpr auto problem_dimension = View::problem_dimension;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
       /**
        * Number of components in a primitive state, we store \f$[\rho, v,
@@ -64,11 +64,11 @@ namespace ryujin
        * The array type to store the expanded primitive state for the
        * Riemann solver \f$[\rho, v, p, a]\f$
        */
-      using primitive_type = std::array<Number, riemann_data_size>;
+      using primitive_type = typename std::array<Number, riemann_data_size>;
 
-      using precomputed_type = View::precomputed_type;
+      using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 

--- a/source/shallow_water/riemann_solver.h
+++ b/source/shallow_water/riemann_solver.h
@@ -42,14 +42,17 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::problem_dimension
-       */
-      static constexpr unsigned int problem_dimension = View::problem_dimension;
+      using ScalarNumber = View::ScalarNumber;
+
+      static constexpr auto problem_dimension = View::problem_dimension;
+
+      using state_type = View::state_type;
 
       /**
        * Number of components in a primitive state, we store \f$[\rho, v,
@@ -63,27 +66,13 @@ namespace ryujin
        */
       using primitive_type = std::array<Number, riemann_data_size>;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      using precomputed_type = View::precomputed_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename View::ScalarNumber;
-
-      /**
-       * @copydoc RiemannSolverParameters
-       */
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Compute wavespeed estimates
        */
@@ -92,11 +81,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      RiemannSolver(
-          const HyperbolicSystem &hyperbolic_system,
-          const Parameters &parameters,
-          const MultiComponentVector<ScalarNumber, n_precomputed_values>
-              &precomputed_values)
+      RiemannSolver(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -157,9 +144,7 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace ShallowWater

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -195,21 +195,22 @@ namespace ryujin
       /**
        * A compound state vector.
        */
-      using StateVector =
+      using StateVector = Vectors::
           StateVector<ScalarNumber, problem_dimension, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed states:
        */
       using PrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
-          MultiComponentVector<ScalarNumber, n_initial_precomputed_values>;
+          Vectors::MultiComponentVector<ScalarNumber,
+                                        n_initial_precomputed_values>;
 
       //@}
       /**

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -10,6 +10,7 @@
 #include <multicomponent_vector.h>
 #include <patterns_conversion.h>
 #include <simd.h>
+#include <state_vector.h>
 
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/tensor.h>
@@ -91,11 +92,6 @@ namespace ryujin
         return HyperbolicSystemView<dim2, Number2>{hyperbolic_system_};
       }
 
-      /**
-       * The underlying scalar number type.
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
-
 
     private:
       const HyperbolicSystem &hyperbolic_system_;
@@ -103,9 +99,14 @@ namespace ryujin
 
     public:
       /**
-       * @name Types and compile time constants
+       * @name Types and constexpr constants
        */
       //@{
+
+      /**
+       * The underlying scalar number type.
+       */
+      using ScalarNumber = typename get_value_type<Number>::type;
 
       /**
        * The dimension of the state space.
@@ -113,15 +114,20 @@ namespace ryujin
       static constexpr unsigned int problem_dimension = 1;
 
       /**
-       * The storage type used for a (conserved) state vector \f$\boldsymbol
-       * U\f$.
+       * Storage type for a (conserved) state vector \f$\boldsymbol U\f$.
        */
       using state_type = dealii::Tensor<1, problem_dimension, Number>;
 
       /**
-       * MulticomponentVector for storing a vector of conserved states:
+       * Storage type for the flux \f$\mathbf{f}\f$.
        */
-      using vector_type = MultiComponentVector<ScalarNumber, problem_dimension>;
+      using flux_type =
+          dealii::Tensor<1, problem_dimension, dealii::Tensor<1, dim, Number>>;
+
+      /**
+       * The storage type used for flux contributions.
+       */
+      using flux_contribution_type = flux_type;
 
       /**
        * An array holding all component names of the conserved state as a
@@ -143,48 +149,15 @@ namespace ryujin
        * string.
        */
       static inline const auto primitive_component_names =
-          std::array<std::string, problem_dimension>{"u"};
-
-      /**
-       * The storage type used for the flux \f$\mathbf{f}\f$.
-       */
-      using flux_type =
-          dealii::Tensor<1, problem_dimension, dealii::Tensor<1, dim, Number>>;
-
-      /**
-       * The storage type used for flux contributions.
-       */
-      using flux_contribution_type = flux_type;
-
-      //@}
-      /**
-       * @name Precomputed quantities
-       */
-      //@{
-
-      /**
-       * The number of precomputed initial values.
-       */
-      static constexpr unsigned int n_precomputed_initial_values = 0;
-
-      /**
-       * Array type used for precomputed initial values.
-       */
-      using precomputed_initial_state_type =
-          std::array<Number, n_precomputed_initial_values>;
-
-      /**
-       * MulticomponentVector for storing a vector of precomputed initial
-       * states:
-       */
-      using precomputed_initial_vector_type =
-          MultiComponentVector<ScalarNumber, n_precomputed_initial_values>;
-
-      /**
-       * An array holding all component names of the precomputed values.
-       */
-      static inline const auto precomputed_initial_names =
-          std::array<std::string, n_precomputed_initial_values>{};
+          []() -> std::array<std::string, problem_dimension> {
+        if constexpr (dim == 1)
+          return {"u"};
+        else if constexpr (dim == 2)
+          return {"u"};
+        else if constexpr (dim == 3)
+          return {"u"};
+        __builtin_trap();
+      }();
 
       /**
        * The number of precomputed values.
@@ -194,13 +167,7 @@ namespace ryujin
       /**
        * Array type used for precomputed values.
        */
-      using precomputed_state_type = std::array<Number, n_precomputed_values>;
-
-      /**
-       * MulticomponentVector for storing a vector of precomputed states:
-       */
-      using precomputed_vector_type =
-          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+      using precomputed_type = std::array<Number, n_precomputed_values>;
 
       /**
        * An array holding all component names of the precomputed values.
@@ -209,20 +176,61 @@ namespace ryujin
           std::array<std::string, n_precomputed_values>{};
 
       /**
+       * The number of precomputed initial values.
+       */
+      static constexpr unsigned int n_initial_precomputed_values = 0;
+
+      /**
+       * Array type used for precomputed initial values.
+       */
+      using initial_precomputed_type =
+          std::array<Number, n_initial_precomputed_values>;
+
+      /**
+       * An array holding all component names of the precomputed values.
+       */
+      static inline const auto initial_precomputed_names =
+          std::array<std::string, n_initial_precomputed_values>{};
+
+      /**
+       * A compound state vector.
+       */
+      using StateVector =
+          StateVector<ScalarNumber, problem_dimension, n_precomputed_values>;
+
+      /**
+       * MulticomponentVector for storing a vector of precomputed states:
+       */
+      using PrecomputedVector =
+          MultiComponentVector<ScalarNumber, n_precomputed_values>;
+
+      /**
+       * MulticomponentVector for storing a vector of precomputed initial
+       * states:
+       */
+      using InitialPrecomputedVector =
+          MultiComponentVector<ScalarNumber, n_initial_precomputed_values>;
+
+      //@}
+      /**
+       * @name Computing precomputed quantities
+       */
+      //@{
+
+      /**
        * The number of precomputation cycles.
        */
       static constexpr unsigned int n_precomputation_cycles = 0;
 
       /**
-       * Step 0: precompute values for hyperbolic update. This routine is
-       * called within our usual loop() idiom in HyperbolicModule
+       * Precompute values for hyperbolic update. This routine is called
+       * within our usual loop() idiom in HyperbolicModule
        */
       template <typename DISPATCH, typename SPARSITY>
       void precomputation_loop(unsigned int /*cycle*/,
                                const DISPATCH &dispatch_check,
-                               precomputed_vector_type & /*precomputed_values*/,
                                const SPARSITY & /*sparsity_simd*/,
-                               const vector_type & /*U*/,
+                               StateVector & /*state_vector*/,
                                unsigned int /*left*/,
                                unsigned int /*right*/) const = delete;
 
@@ -287,8 +295,8 @@ namespace ryujin
        * For the Euler equations we simply compute <code>f(U_i)</code>.
        */
       flux_contribution_type
-      flux_contribution(const precomputed_vector_type & /*pv*/,
-                        const precomputed_initial_vector_type & /*piv*/,
+      flux_contribution(const PrecomputedVector & /*pv*/,
+                        const InitialPrecomputedVector & /*piv*/,
                         const unsigned int /*i*/,
                         const state_type & /*U_i*/) const
       {
@@ -296,8 +304,8 @@ namespace ryujin
       }
 
       flux_contribution_type
-      flux_contribution(const precomputed_vector_type & /*pv*/,
-                        const precomputed_initial_vector_type & /*piv*/,
+      flux_contribution(const PrecomputedVector & /*pv*/,
+                        const InitialPrecomputedVector & /*piv*/,
                         const unsigned int * /*js*/,
                         const state_type & /*U_j*/) const
       {
@@ -335,15 +343,15 @@ namespace ryujin
       /** We do not have source terms */
       static constexpr bool have_source_terms = false;
 
-      state_type nodal_source(const precomputed_vector_type &pv,
-                              const unsigned int i,
-                              const state_type &U_i,
-                              const ScalarNumber tau) const = delete;
+      state_type nodal_source(const PrecomputedVector & /*pv*/,
+                              const unsigned int /*i*/,
+                              const state_type & /*U_i*/,
+                              const ScalarNumber /*tau*/) const = delete;
 
-      state_type nodal_source(const precomputed_vector_type &pv,
-                              const unsigned int *js,
-                              const state_type &U_j,
-                              const ScalarNumber tau) const = delete;
+      state_type nodal_source(const PrecomputedVector & /*pv*/,
+                              const unsigned int * /*js*/,
+                              const state_type & /*U_j*/,
+                              const ScalarNumber /*tau*/) const = delete;
 
       //@}
       /**

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -40,36 +40,21 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystem::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystem::state_type
-       */
-      using state_type = typename View::state_type;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystem::flux_type
-       */
-      using flux_type = typename View::flux_type;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc HyperbolicSystem::ScalarNumber
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
-
-      /**
-       * @copydoc IndicatorParameters
-       */
       using Parameters = IndicatorParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of indicators
        *
@@ -94,8 +79,7 @@ namespace ryujin
        */
       Indicator(const HyperbolicSystem &hyperbolic_system,
                 const Parameters &parameters,
-                const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                    &precomputed_values)
+                const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -140,9 +124,8 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
+      const PrecomputedVector &precomputed_values;
 
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
       //@}
     };
   } // namespace Skeleton

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -46,11 +46,11 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = IndicatorParameters<ScalarNumber>;
 

--- a/source/skeleton/initial_state_uniform.h
+++ b/source/skeleton/initial_state_uniform.h
@@ -24,7 +24,7 @@ namespace ryujin
     {
     public:
       using View = HyperbolicSystemView<dim, Number>;
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
       Uniform(const HyperbolicSystem &hyperbolic_system,
               const std::string subsection)

--- a/source/skeleton/initial_state_uniform.h
+++ b/source/skeleton/initial_state_uniform.h
@@ -24,7 +24,7 @@ namespace ryujin
     {
     public:
       using View = HyperbolicSystemView<dim, Number>;
-      using state_type = typename View::state_type;
+      using state_type = View::state_type;
 
       Uniform(const HyperbolicSystem &hyperbolic_system,
               const std::string subsection)

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -45,36 +45,23 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::flux_contribution_type
-       */
-      using flux_contribution_type = typename View::flux_contribution_type;
+      using flux_contribution_type = View::flux_contribution_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc LimiterParameters
-       */
       using Parameters = LimiterParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Stencil-based computation of bounds
        *
@@ -109,8 +96,7 @@ namespace ryujin
        */
       Limiter(const HyperbolicSystem &hyperbolic_system,
               const Parameters &parameters,
-              const MultiComponentVector<ScalarNumber, n_precomputed_values>
-                  &precomputed_values)
+              const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -196,9 +182,7 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
 
       Bounds bounds_;
       //@}

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -51,13 +51,13 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using flux_contribution_type = View::flux_contribution_type;
+      using flux_contribution_type = typename View::flux_contribution_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = LimiterParameters<ScalarNumber>;
 

--- a/source/skeleton/riemann_solver.h
+++ b/source/skeleton/riemann_solver.h
@@ -46,11 +46,11 @@ namespace ryujin
 
       using View = HyperbolicSystemView<dim, Number>;
 
-      using ScalarNumber = View::ScalarNumber;
+      using ScalarNumber = typename View::ScalarNumber;
 
-      using state_type = View::state_type;
+      using state_type = typename View::state_type;
 
-      using PrecomputedVector = View::PrecomputedVector;
+      using PrecomputedVector = typename View::PrecomputedVector;
 
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 

--- a/source/skeleton/riemann_solver.h
+++ b/source/skeleton/riemann_solver.h
@@ -40,31 +40,21 @@ namespace ryujin
     {
     public:
       /**
-       * @copydoc HyperbolicSystemView
+       * @name Typedefs and constexpr constants
        */
+      //@{
+
       using View = HyperbolicSystemView<dim, Number>;
 
-      /**
-       * @copydoc HyperbolicSystemView::state_type
-       */
-      using state_type = typename View::state_type;
+      using ScalarNumber = View::ScalarNumber;
 
-      /**
-       * @copydoc HyperbolicSystemView::n_precomputed_values
-       */
-      static constexpr unsigned int n_precomputed_values =
-          View::n_precomputed_values;
+      using state_type = View::state_type;
 
-      /**
-       * @copydoc HyperbolicSystemView::ScalarNumber
-       */
-      using ScalarNumber = typename get_value_type<Number>::type;
+      using PrecomputedVector = View::PrecomputedVector;
 
-      /**
-       * @copydoc RiemannSolverParameters
-       */
       using Parameters = RiemannSolverParameters<ScalarNumber>;
 
+      //@}
       /**
        * @name Compute wavespeed estimates
        */
@@ -73,11 +63,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      RiemannSolver(
-          const HyperbolicSystem &hyperbolic_system,
-          const Parameters &parameters,
-          const MultiComponentVector<ScalarNumber, n_precomputed_values>
-              &precomputed_values)
+      RiemannSolver(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -94,15 +82,13 @@ namespace ryujin
                      const unsigned int * /*js*/,
                      const dealii::Tensor<1, dim, Number> & /*n_ij*/) const
       {
-        return Number(0.);
+        return Number(1.);
       }
 
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-
-      const MultiComponentVector<ScalarNumber, n_precomputed_values>
-          &precomputed_values;
+      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace Skeleton

--- a/source/solution_transfer.h
+++ b/source/solution_transfer.h
@@ -40,7 +40,7 @@ namespace ryujin
 
     using StateVector = View::StateVector;
 
-    using ScalarVector = ScalarVector<Number>;
+    using ScalarVector = Vectors::ScalarVector<Number>;
 
     //@}
     /**
@@ -79,8 +79,9 @@ namespace ryujin
         it.reinit(scalar_partitioner);
 
       /*
-       * FIXME: we need to copy over to an auxiliary  state_ vector because
-       * dealii::SolutionTransfer cannot work on our MultiComponentVector
+       * We need to copy over to an auxiliary state vector formed by a
+       * ScalarVector for each component because dealii::SolutionTransfer
+       * cannot work on our StateVector or MultiComponentVector
        */
 
       for (unsigned int k = 0; k < problem_dimension; ++k) {

--- a/source/solution_transfer.h
+++ b/source/solution_transfer.h
@@ -32,13 +32,14 @@ namespace ryujin
      */
     //@{
 
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
     using ScalarVector = Vectors::ScalarVector<Number>;
 

--- a/source/solution_transfer.h
+++ b/source/solution_transfer.h
@@ -28,35 +28,25 @@ namespace ryujin
   {
   public:
     /**
-     * @copydoc HyperbolicSystem
+     * @name Typedefs and constexpr constants
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    //@{
 
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
-    /**
-     * @copydoc HyperbolicSystem::problem_dimension
-     */
-    static constexpr unsigned int problem_dimension = View::problem_dimension;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    /**
-     * @copydoc HyperbolicSystem::state_type
-     */
-    using state_type = typename View::state_type;
+    static constexpr auto problem_dimension = View::problem_dimension;
 
-    /**
-     * @copydoc OfflineData::scalar_type
-     */
-    using scalar_type = typename OfflineData<dim, Number>::scalar_type;
+    using StateVector = View::StateVector;
 
+    using ScalarVector = ScalarVector<Number>;
+
+    //@}
     /**
-     * Typedef for a MultiComponentVector storing the state U.
+     * @name Constructor and setup
      */
-    using vector_type = MultiComponentVector<Number, problem_dimension>;
+    //@{
 
     /**
      * Constructor.
@@ -77,8 +67,10 @@ namespace ryujin
      *
      * This function has to be called before the actual grid refinement.
      */
-    void prepare_for_interpolation(const vector_type &U)
+    void prepare_for_interpolation(const StateVector &state_vector)
     {
+      const auto &U = std::get<0>(state_vector);
+
       const auto &scalar_partitioner = offline_data_->scalar_partitioner();
       const auto &affine_constraints = offline_data_->affine_constraints();
 
@@ -97,7 +89,7 @@ namespace ryujin
         state_[k].update_ghost_values();
       }
 
-      std::vector<const scalar_type *> ptr_state;
+      std::vector<const ScalarVector *> ptr_state;
       std::transform(state_.begin(),
                      state_.end(),
                      std::back_inserter(ptr_state),
@@ -112,8 +104,10 @@ namespace ryujin
      *
      * This function has to be called after the actual grid refinement.
      */
-    void interpolate(vector_type &U)
+    void interpolate(StateVector &state_vector)
     {
+      auto &U = std::get<0>(state_vector);
+
       const auto &scalar_partitioner = offline_data_->scalar_partitioner();
 
       U.reinit(offline_data_->vector_partitioner());
@@ -124,7 +118,7 @@ namespace ryujin
         it.zero_out_ghost_values();
       }
 
-      std::vector<scalar_type *> ptr_interpolated_state;
+      std::vector<ScalarVector *> ptr_interpolated_state;
       std::transform(interpolated_state_.begin(),
                      interpolated_state_.end(),
                      std::back_inserter(ptr_interpolated_state),
@@ -150,11 +144,11 @@ namespace ryujin
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;
     const HyperbolicSystem &hyperbolic_system_;
 
-    dealii::parallel::distributed::SolutionTransfer<dim, scalar_type>
+    dealii::parallel::distributed::SolutionTransfer<dim, ScalarVector>
         solution_transfer_;
 
-    std::vector<scalar_type> state_;
-    std::vector<scalar_type> interpolated_state_;
+    std::vector<ScalarVector> state_;
+    std::vector<ScalarVector> interpolated_state_;
     //@}
   };
 

--- a/source/state_vector.h
+++ b/source/state_vector.h
@@ -1,0 +1,40 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2024 by the ryujin authors
+//
+
+#pragma once
+
+#include "multicomponent_vector.h"
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+
+namespace ryujin
+{
+  /**
+   * Shorthand for dealii::LinearAlgebra::distributed::Vector<Number>.
+   */
+  template <typename Number>
+  using ScalarVector = dealii::LinearAlgebra::distributed::Vector<Number>;
+
+  /**
+   * Shorthand for dealii::LinearAlgebra::distributed::BlockVector<Number>.
+   */
+  template <typename Number>
+  using BlockVector = dealii::LinearAlgebra::distributed::BlockVector<Number>;
+
+  /**
+   * A compound state vector formed by a std::tuple consisting of the
+   * hyperbolic state vector @p U, precomputed values, and an "parabolic
+   * state" vector stored as a BlockVector. All of these vectors have in
+   * common that they are associated with a hyperbolic, or parabolic state
+   * and precomputed data (derived from the hyperbolic state) for point in
+   * time.
+   */
+  template <typename Number, unsigned int problem_dim, unsigned int prec_dim>
+  using StateVector =
+      std::tuple<MultiComponentVector<Number, problem_dim> /*U*/,
+                 MultiComponentVector<Number, prec_dim> /*precomputed values*/,
+                 BlockVector<Number> /*parabolic state vector*/>;
+
+} // namespace ryujin

--- a/source/state_vector.h
+++ b/source/state_vector.h
@@ -12,29 +12,37 @@
 namespace ryujin
 {
   /**
-   * Shorthand for dealii::LinearAlgebra::distributed::Vector<Number>.
+   * A namespace for various vector type aliases.
+   *
+   * @ingroup Mesh
    */
-  template <typename Number>
-  using ScalarVector = dealii::LinearAlgebra::distributed::Vector<Number>;
+  namespace Vectors
+  {
+    /**
+     * Shorthand for dealii::LinearAlgebra::distributed::Vector<Number>.
+     */
+    template <typename Number>
+    using ScalarVector = dealii::LinearAlgebra::distributed::Vector<Number>;
 
-  /**
-   * Shorthand for dealii::LinearAlgebra::distributed::BlockVector<Number>.
-   */
-  template <typename Number>
-  using BlockVector = dealii::LinearAlgebra::distributed::BlockVector<Number>;
+    /**
+     * Shorthand for dealii::LinearAlgebra::distributed::BlockVector<Number>.
+     */
+    template <typename Number>
+    using BlockVector = dealii::LinearAlgebra::distributed::BlockVector<Number>;
 
-  /**
-   * A compound state vector formed by a std::tuple consisting of the
-   * hyperbolic state vector @p U, precomputed values, and an "parabolic
-   * state" vector stored as a BlockVector. All of these vectors have in
-   * common that they are associated with a hyperbolic, or parabolic state
-   * and precomputed data (derived from the hyperbolic state) for point in
-   * time.
-   */
-  template <typename Number, unsigned int problem_dim, unsigned int prec_dim>
-  using StateVector =
-      std::tuple<MultiComponentVector<Number, problem_dim> /*U*/,
-                 MultiComponentVector<Number, prec_dim> /*precomputed values*/,
-                 BlockVector<Number> /*parabolic state vector*/>;
+    /**
+     * A compound state vector formed by a std::tuple consisting of the
+     * hyperbolic state vector @p U, precomputed values, and an "parabolic
+     * state" vector stored as a BlockVector. All of these vectors have in
+     * common that they are associated with a hyperbolic, or parabolic state
+     * and precomputed data (derived from the hyperbolic state) for point in
+     * time.
+     */
+    template <typename Number, unsigned int problem_dim, unsigned int prec_dim>
+    using StateVector = std::tuple<
+        MultiComponentVector<Number, problem_dim> /*U*/,
+        MultiComponentVector<Number, prec_dim> /*precomputed values*/,
+        BlockVector<Number> /*parabolic state vector*/>;
+  } // namespace Vectors
 
 } // namespace ryujin

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -173,41 +173,23 @@ namespace ryujin
   {
   public:
     /**
-     * @copydoc HyperbolicSystem
+     * @name Typedefs and constexpr constants
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    //@{
 
-    /**
-     * @copydoc ParabolicSystem
-     */
-    using ParabolicSystem = typename Description::ParabolicSystem;
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    /**
-     * @copydoc HyperbolicSystem::problem_dimension
-     */
-    static constexpr unsigned int problem_dimension = View::problem_dimension;
+    using ParabolicSystem = Description::ParabolicSystem;
 
-    /**
-     * @copydoc HyperbolicSystem::n_precomputed_values
-     */
-    static constexpr unsigned int n_precomputed_values =
-        View::n_precomputed_values;
+    using StateVector = View::StateVector;
 
+    //@}
     /**
-     * Typedef for a MultiComponentVector storing the state U.
+     * @name Constructor and setup
      */
-    using vector_type = MultiComponentVector<Number, problem_dimension>;
-
-    /**
-     * Typedef for a MultiComponentVector storing precomputed values.
-     */
-    using precomputed_type = MultiComponentVector<Number, n_precomputed_values>;
+    //@{
 
     /**
      * Constructor.
@@ -227,6 +209,7 @@ namespace ryujin
      */
     void prepare();
 
+    //@}
     /**
      * @name Functions for performing explicit time steps
      */
@@ -244,7 +227,7 @@ namespace ryujin
      * adaptation and recovery strategies for invariant domain violations
      * are used.
      */
-    Number step(vector_type &U, Number t);
+    Number step(StateVector &state_vector, Number t);
 
     /**
      * The selected time-stepping scheme.
@@ -270,7 +253,7 @@ namespace ryujin
      * supplied value is used for time stepping instead of the computed
      * maximal time step size.
      */
-    Number step_ssprk_22(vector_type &U, Number t);
+    Number step_ssprk_22(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
@@ -282,35 +265,35 @@ namespace ryujin
      * supplied value is used for time stepping instead of the computed
      * maximal time step size.
      */
-    Number step_ssprk_33(vector_type &U, Number t);
+    Number step_ssprk_33(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * first-order Euler step ERK(1,1;1) time step (and store the result
      * in U). The function returns the chosen time step size tau.
      */
-    Number step_erk_11(vector_type &U, Number t);
+    Number step_erk_11(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * second-order Runge-Kutta ERK(2,2;1) time step (and store the result
      * in U). The function returns the chosen time step size tau.
      */
-    Number step_erk_22(vector_type &U, Number t);
+    Number step_erk_22(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * third-order Runge-Kutta ERK(3,3;1) time step (and store the result
      * in U). The function returns the chosen time step size tau.
      */
-    Number step_erk_33(vector_type &U, Number t);
+    Number step_erk_33(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * 4 stage third-order Runge-Kutta ERK(4,3;1) time step (and store the
      * result in U). The function returns the chosen time step size tau.
      */
-    Number step_erk_43(vector_type &U, Number t);
+    Number step_erk_43(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
@@ -318,7 +301,7 @@ namespace ryujin
      * the result in U). The function returns the chosen time step size
      * tau.
      */
-    Number step_erk_54(vector_type &U, Number t);
+    Number step_erk_54(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs a combined
@@ -327,7 +310,7 @@ namespace ryujin
      * store the result in U). The function returns the chosen time step
      * size tau.
      */
-    Number step_strang_ssprk_33_cn(vector_type &U, Number t);
+    Number step_strang_ssprk_33_cn(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs a combined
@@ -336,7 +319,7 @@ namespace ryujin
      * the result in U). The function returns the chosen time step size
      * tau.
      */
-    Number step_strang_erk_33_cn(vector_type &U, Number t);
+    Number step_strang_erk_33_cn(StateVector &state_vector, Number t);
 
     /**
      * Given a reference to a previous state vector U performs a combined
@@ -345,7 +328,7 @@ namespace ryujin
      * the result in U). The function returns the chosen time step size
      * tau.
      */
-    Number step_strang_erk_43_cn(vector_type &U, Number t);
+    Number step_strang_erk_43_cn(StateVector &state_vector, Number t);
 
   private:
     //@}
@@ -379,8 +362,7 @@ namespace ryujin
     dealii::SmartPointer<const ParabolicModule<Description, dim, Number>>
         parabolic_module_;
 
-    std::vector<vector_type> U_;
-    std::vector<precomputed_type> precomputed_;
+    std::vector<StateVector> temporary_;
 
     //@}
   };

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -17,6 +17,8 @@ namespace ryujin
 {
   /**
    * Controls the chosen invariant domain / CFL recovery strategy.
+   *
+   * @ingroup TimeLoop
    */
   enum class CFLRecoveryStrategy {
     /**
@@ -37,6 +39,8 @@ namespace ryujin
 
   /**
    * Controls the chosen time-stepping scheme.
+   *
+   * @ingroup TimeLoop
    */
   enum class TimeSteppingScheme {
     /**

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -181,13 +181,14 @@ namespace ryujin
      */
     //@{
 
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
-    using ParabolicSystem = Description::ParabolicSystem;
+    using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
     //@}
     /**

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -11,6 +11,20 @@ namespace ryujin
 {
   using namespace dealii;
 
+
+  /**
+   * TODO: clear out precomputed vector and also scale add V.
+   */
+  template <typename StateVector, typename Number>
+  void
+  sadd(StateVector &dst, const Number s, const Number b, const StateVector &src)
+  {
+    auto &dst_U = std::get<0>(dst);
+    auto &src_U = std::get<0>(src);
+    dst_U.sadd(s, b, src_U);
+  }
+
+
   template <typename Description, int dim, typename Number>
   TimeIntegrator<Description, dim, Number>::TimeIntegrator(
       const MPI_Comm &mpi_communicator,
@@ -69,66 +83,57 @@ namespace ryujin
 
     switch (time_stepping_scheme_) {
     case TimeSteppingScheme::ssprk_22:
-      U_.resize(2);
-      precomputed_.resize(1);
+      temporary_.resize(2);
       efficiency_ = 1.;
       break;
     case TimeSteppingScheme::ssprk_33:
-      U_.resize(2);
-      precomputed_.resize(1);
+      temporary_.resize(2);
       efficiency_ = 1.;
       break;
     case TimeSteppingScheme::erk_11:
-      U_.resize(1);
-      precomputed_.resize(1);
+      temporary_.resize(1);
       efficiency_ = 1.;
       break;
     case TimeSteppingScheme::erk_22:
-      U_.resize(2);
-      precomputed_.resize(2);
+      temporary_.resize(2);
       efficiency_ = 2.;
       break;
     case TimeSteppingScheme::erk_33:
-      U_.resize(3);
-      precomputed_.resize(3);
+      temporary_.resize(3);
       efficiency_ = 3.;
       break;
     case TimeSteppingScheme::erk_43:
-      U_.resize(4);
-      precomputed_.resize(4);
+      temporary_.resize(4);
       efficiency_ = 4.;
       break;
     case TimeSteppingScheme::erk_54:
-      U_.resize(5);
-      precomputed_.resize(5);
+      temporary_.resize(5);
       efficiency_ = 5.;
       break;
     case TimeSteppingScheme::strang_ssprk_33_cn:
-      U_.resize(3);
-      precomputed_.resize(1);
+      temporary_.resize(3);
       efficiency_ = 2.;
       break;
     case TimeSteppingScheme::strang_erk_33_cn:
-      U_.resize(4);
-      precomputed_.resize(3);
+      temporary_.resize(4);
       efficiency_ = 6.;
       break;
     case TimeSteppingScheme::strang_erk_43_cn:
-      U_.resize(4); // FIXME
-      precomputed_.resize(4);
+      temporary_.resize(4);
       efficiency_ = 8.;
       break;
     }
 
-    /* Initialize temporary vectors and matrices: */
-
-    const auto &vector_partitioner = offline_data_->vector_partitioner();
-    for (auto &it : U_)
-      it.reinit(vector_partitioner);
+    /* Initialize temporary vectors: */
 
     const auto &scalar_partitioner = offline_data_->scalar_partitioner();
-    for (auto &it : precomputed_)
-      it.reinit_with_scalar_partitioner(scalar_partitioner);
+    const auto &vector_partitioner = offline_data_->vector_partitioner();
+
+    for (auto &it : temporary_) {
+      auto &[U, precomputed, V] = it;
+      U.reinit(vector_partitioner);
+      precomputed.reinit_with_scalar_partitioner(scalar_partitioner);
+    }
 
     /* Reset CFL to canonical starting value: */
 
@@ -187,8 +192,9 @@ namespace ryujin
 
 
   template <typename Description, int dim, typename Number>
-  Number TimeIntegrator<Description, dim, Number>::step(vector_type &U,
-                                                        Number t)
+  Number
+  TimeIntegrator<Description, dim, Number>::step(StateVector &state_vector,
+                                                 Number t)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step()" << std::endl;
@@ -197,25 +203,25 @@ namespace ryujin
     const auto single_step = [&]() {
       switch (time_stepping_scheme_) {
       case TimeSteppingScheme::ssprk_22:
-        return step_ssprk_22(U, t);
+        return step_ssprk_22(state_vector, t);
       case TimeSteppingScheme::ssprk_33:
-        return step_ssprk_33(U, t);
+        return step_ssprk_33(state_vector, t);
       case TimeSteppingScheme::erk_11:
-        return step_erk_11(U, t);
+        return step_erk_11(state_vector, t);
       case TimeSteppingScheme::erk_22:
-        return step_erk_22(U, t);
+        return step_erk_22(state_vector, t);
       case TimeSteppingScheme::erk_33:
-        return step_erk_33(U, t);
+        return step_erk_33(state_vector, t);
       case TimeSteppingScheme::erk_43:
-        return step_erk_43(U, t);
+        return step_erk_43(state_vector, t);
       case TimeSteppingScheme::erk_54:
-        return step_erk_54(U, t);
+        return step_erk_54(state_vector, t);
       case TimeSteppingScheme::strang_ssprk_33_cn:
-        return step_strang_ssprk_33_cn(U, t);
+        return step_strang_ssprk_33_cn(state_vector, t);
       case TimeSteppingScheme::strang_erk_33_cn:
-        return step_strang_erk_33_cn(U, t);
+        return step_strang_erk_33_cn(state_vector, t);
       case TimeSteppingScheme::strang_erk_43_cn:
-        return step_strang_erk_43_cn(U, t);
+        return step_strang_erk_43_cn(state_vector, t);
       default:
         __builtin_unreachable();
       }
@@ -249,58 +255,58 @@ namespace ryujin
   }
 
   template <typename Description, int dim, typename Number>
-  Number TimeIntegrator<Description, dim, Number>::step_ssprk_22(vector_type &U,
-                                                                 Number t)
+  Number TimeIntegrator<Description, dim, Number>::step_ssprk_22(
+      StateVector &state_vector, Number t)
   {
     /* SSP-RK3, see @cite Shu1988, Eq. 2.15. */
 
     /* Step 1: U1 = U_old + tau * L(U_old) at time t + tau */
     Number tau = hyperbolic_module_->template step<0>(
-        U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
     /* Step 2: U2 = 1/2 U_old + 1/2 (U1 + tau L(U1)) at time t + tau */
     hyperbolic_module_->template step<0>(
-        U_[0], {}, {}, {}, U_[1], precomputed_[0], tau);
-    U_[1].sadd(Number(1. / 2.), Number(1. / 2.), U);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + tau);
+        temporary_[0], {}, {}, temporary_[1], tau);
+    sadd(temporary_[1], Number(1. / 2.), Number(1. / 2.), state_vector);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + tau);
 
-    U.swap(U_[1]);
+    state_vector.swap(temporary_[1]);
     return tau;
   }
 
 
   template <typename Description, int dim, typename Number>
-  Number TimeIntegrator<Description, dim, Number>::step_ssprk_33(vector_type &U,
-                                                                 Number t)
+  Number TimeIntegrator<Description, dim, Number>::step_ssprk_33(
+      StateVector &state_vector, Number t)
   {
     /* SSP-RK3, see @cite Shu1988, Eq. 2.18. */
 
     /* Step 1: U1 = U_old + tau * L(U_old) at time t + tau */
     Number tau = hyperbolic_module_->template step<0>(
-        U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
     /* Step 2: U2 = 3/4 U_old + 1/4 (U1 + tau L(U1)) at time t + 0.5 * tau */
     hyperbolic_module_->template step<0>(
-        U_[0], {}, {}, {}, U_[1], precomputed_[0], tau);
-    U_[1].sadd(Number(1. / 4.), Number(3. / 4.), U);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 0.5 * tau);
+        temporary_[0], {}, {}, temporary_[1], tau);
+    sadd(temporary_[1], Number(1. / 4.), Number(3. / 4.), state_vector);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 0.5 * tau);
 
     /* Step 3: U3 = 1/3 U_old + 2/3 (U2 + tau L(U2)) at final time t + tau */
     hyperbolic_module_->template step<0>(
-        U_[1], {}, {}, {}, U_[0], precomputed_[0], tau);
-    U_[0].sadd(Number(2. / 3.), Number(1. / 3.), U);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        temporary_[1], {}, {}, temporary_[0], tau);
+    sadd(temporary_[0], Number(2. / 3.), Number(1. / 3.), state_vector);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
-    U.swap(U_[0]);
+    state_vector.swap(temporary_[0]);
     return tau;
   }
 
 
   template <typename Description, int dim, typename Number>
-  Number TimeIntegrator<Description, dim, Number>::step_erk_11(vector_type &U,
-                                                               Number t)
+  Number TimeIntegrator<Description, dim, Number>::step_erk_11(
+      StateVector &state_vector, Number t)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_11()" << std::endl;
@@ -308,17 +314,17 @@ namespace ryujin
 
     /* Step 1: U1 <- {U, 1} at time t + tau */
     Number tau = hyperbolic_module_->template step<0>(
-        U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
-    U.swap(U_[0]);
+    state_vector.swap(temporary_[0]);
     return tau;
   }
 
 
   template <typename Description, int dim, typename Number>
-  Number TimeIntegrator<Description, dim, Number>::step_erk_22(vector_type &U,
-                                                               Number t)
+  Number TimeIntegrator<Description, dim, Number>::step_erk_22(
+      StateVector &state_vector, Number t)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_22()" << std::endl;
@@ -326,27 +332,22 @@ namespace ryujin
 
     /* Step 1: U1 <- {U, 1} at time t + tau */
     Number tau = hyperbolic_module_->template step<0>(
-        U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
     /* Step 2: U2 <- {U1, 2} and {U, -1} at time t + 2 tau */
-    hyperbolic_module_->template step<1>(U_[0],
-                                         {{U}},
-                                         {{precomputed_[0]}},
-                                         {{Number(-1.)}},
-                                         U_[1],
-                                         precomputed_[1],
-                                         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 2. * tau);
+    hyperbolic_module_->template step<1>(
+        temporary_[0], {{state_vector}}, {{Number(-1.)}}, temporary_[1], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 2. * tau);
 
-    U.swap(U_[1]);
+    state_vector.swap(temporary_[1]);
     return 2. * tau;
   }
 
 
   template <typename Description, int dim, typename Number>
-  Number TimeIntegrator<Description, dim, Number>::step_erk_33(vector_type &U,
-                                                               Number t)
+  Number TimeIntegrator<Description, dim, Number>::step_erk_33(
+      StateVector &state_vector, Number t)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_33()" << std::endl;
@@ -354,37 +355,30 @@ namespace ryujin
 
     /* Step 1: U1 <- {U, 1} at time t + tau */
     Number tau = hyperbolic_module_->template step<0>(
-        U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
     /* Step 2: U2 <- {U1, 2} and {U, -1} at time t + 2 tau */
-    hyperbolic_module_->template step<1>(U_[0],
-                                         {{U}},
-                                         {{precomputed_[0]}},
-                                         {{Number(-1.)}},
-                                         U_[1],
-                                         precomputed_[1],
-                                         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 2. * tau);
+    hyperbolic_module_->template step<1>(
+        temporary_[0], {{state_vector}}, {{Number(-1.)}}, temporary_[1], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 2. * tau);
 
     /* Step 3: U3 <- {U2, 9/4} and {U1, -2} and {U, 3/4} at time t + 3 tau */
-    hyperbolic_module_->template step<2>(U_[1],
-                                         {{U, U_[0]}},
-                                         {{precomputed_[0], precomputed_[1]}},
+    hyperbolic_module_->template step<2>(temporary_[1],
+                                         {{state_vector, temporary_[0]}},
                                          {{Number(0.75), Number(-2.)}},
-                                         U_[2],
-                                         precomputed_[2],
+                                         temporary_[2],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[2], t + 3. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[2], t + 3. * tau);
 
-    U.swap(U_[2]);
+    state_vector.swap(temporary_[2]);
     return 3. * tau;
   }
 
 
   template <typename Description, int dim, typename Number>
-  Number TimeIntegrator<Description, dim, Number>::step_erk_43(vector_type &U,
-                                                               Number t)
+  Number TimeIntegrator<Description, dim, Number>::step_erk_43(
+      StateVector &state_vector, Number t)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_43()" << std::endl;
@@ -392,47 +386,35 @@ namespace ryujin
 
     /* Step 1: U1 <- {U, 1} at time t + tau */
     Number tau = hyperbolic_module_->template step<0>(
-        U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
     /* Step 2: U2 <- {U1, 2} and {U, -1} at time t + 2 tau */
-    hyperbolic_module_->template step<1>(U_[0],
-                                         {{U}},
-                                         {{precomputed_[0]}},
-                                         {{Number(-1.)}},
-                                         U_[1],
-                                         precomputed_[1],
-                                         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 2. * tau);
+    hyperbolic_module_->template step<1>(
+        temporary_[0], {{state_vector}}, {{Number(-1.)}}, temporary_[1], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 2. * tau);
 
     /* Step 3: U3 <- {U2, 2} and {U1, -1} at time t + 3 tau */
-    hyperbolic_module_->template step<1>(U_[1],
-                                         {{U_[0]}},
-                                         {{precomputed_[1]}},
-                                         {{Number(-1.)}},
-                                         U_[2],
-                                         precomputed_[2],
-                                         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[2], t + 3. * tau);
+    hyperbolic_module_->template step<1>(
+        temporary_[1], {{temporary_[0]}}, {{Number(-1.)}}, temporary_[2], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[2], t + 3. * tau);
 
     /* Step 4: U4 <- {U3, 8/3} and {U2,-10/3} and {U1, 5/3} at time t + 4 tau */
-    hyperbolic_module_->template step<2>(U_[2],
-                                         {{U_[0], U_[1]}},
-                                         {{precomputed_[1], precomputed_[2]}},
+    hyperbolic_module_->template step<2>(temporary_[2],
+                                         {{temporary_[0], temporary_[1]}},
                                          {{Number(5. / 3.), Number(-10. / 3.)}},
-                                         U_[3],
-                                         precomputed_[3],
+                                         temporary_[3],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[3], t + 4. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[3], t + 4. * tau);
 
-    U.swap(U_[3]);
+    state_vector.swap(temporary_[3]);
     return 4. * tau;
   }
 
 
   template <typename Description, int dim, typename Number>
-  Number TimeIntegrator<Description, dim, Number>::step_erk_54(vector_type &U,
-                                                               Number t)
+  Number TimeIntegrator<Description, dim, Number>::step_erk_54(
+      StateVector &state_vector, Number t)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_54()" << std::endl;
@@ -457,63 +439,55 @@ namespace ryujin
 
     /* Step 1: */
     Number tau = hyperbolic_module_->template step<0>(
-        U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
     /* Step 2: */
-    hyperbolic_module_->template step<1>(U_[0],
-                                         {{U}},
-                                         {{precomputed_[0]}},
+    hyperbolic_module_->template step<1>(temporary_[0],
+                                         {{state_vector}},
                                          {{(a_31 - a_21) / c}},
-                                         U_[1],
-                                         precomputed_[1],
+                                         temporary_[1],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 2. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 2. * tau);
 
     /* Step 3: */
     hyperbolic_module_->template step<2>(
-        U_[1],
-        {{U, U_[0]}},
-        {{precomputed_[0], precomputed_[1]}},
+        temporary_[1],
+        {{state_vector, temporary_[0]}},
         {{(a_41 - a_31) / c, (a_42 - a_32) / c}},
-        U_[2],
-        precomputed_[2],
+        temporary_[2],
         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[2], t + 3. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[2], t + 3. * tau);
 
     /* Step 4: */
     hyperbolic_module_->template step<3>(
-        U_[2],
-        {{U, U_[0], U_[1]}},
-        {{precomputed_[0], precomputed_[1], precomputed_[2]}},
+        temporary_[2],
+        {{state_vector, temporary_[0], temporary_[1]}},
         {{(a_51 - a_41) / c, (a_52 - a_42) / c, (a_53 - a_43) / c}},
-        U_[3],
-        precomputed_[3],
+        temporary_[3],
         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[3], t + 4. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[3], t + 4. * tau);
 
     /* Step 5: */
     hyperbolic_module_->template step<4>(
-        U_[3],
-        {{U, U_[0], U_[1], U_[2]}},
-        {{precomputed_[0], precomputed_[1], precomputed_[2], precomputed_[3]}},
+        temporary_[3],
+        {{state_vector, temporary_[0], temporary_[1], temporary_[2]}},
         {{(a_61 - a_51) / c,
           (a_62 - a_52) / c,
           (a_63 - a_53) / c,
           (a_64 - a_54) / c}},
-        U_[4],
-        precomputed_[4],
+        temporary_[4],
         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[4], t + 5. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[4], t + 5. * tau);
 
-    U.swap(U_[4]);
+    state_vector.swap(temporary_[4]);
     return 5. * tau;
   }
 
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_strang_ssprk_33_cn(
-      vector_type &U, Number t)
+      StateVector &state_vector, Number t)
   {
     // FIXME: avoid code duplication with step_ssprk_33
 
@@ -522,50 +496,63 @@ namespace ryujin
               << std::endl;
 #endif
 
-    /* First explicit SSPRK 3 step with final result in U_[0]: */
+    /* First explicit SSPRK 3 step with final result in temporary_[0]: */
 
     Number tau = hyperbolic_module_->template step<0>(
-        /*input*/ U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        /*input*/ state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
     hyperbolic_module_->template step<0>(
-        U_[0], {}, {}, {}, U_[1], precomputed_[0], tau);
-    U_[1].sadd(Number(1. / 4.), Number(3. / 4.), /*input*/ U);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 0.5 * tau);
+        temporary_[0], {}, {}, temporary_[1], tau);
+    sadd(temporary_[1],
+         Number(1. / 4.),
+         Number(3. / 4.),
+         /*input*/ state_vector);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 0.5 * tau);
 
     hyperbolic_module_->template step<0>(
-        U_[1], {}, {}, {}, U_[0], precomputed_[0], tau);
-    U_[0].sadd(Number(2. / 3.), Number(1. / 3.), /*input*/ U);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        temporary_[1], {}, {}, temporary_[0], tau);
+    sadd(temporary_[0],
+         Number(2. / 3.),
+         Number(1. / 3.),
+         /*input*/ state_vector);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
-    /* Implicit Crank-Nicolson step with final result in U_[2]: */
-    parabolic_module_->template step<0>(U_[0], t, {}, {}, U_[2], tau);
-    U_[2].sadd(Number(2.), Number(-1.), U_[0]);
+    /* Implicit Crank-Nicolson step with final result in temporary_[2]: */
+    parabolic_module_->template step<0>(
+        temporary_[0], t, {}, {}, temporary_[2], tau);
+    sadd(temporary_[2], Number(2.), Number(-1.), temporary_[0]);
 
-    /* Second SSPRK 3 step with final result in U_[0]: */
-
-    hyperbolic_module_->template step<0>(
-        /*intermediate*/ U_[2], {}, {}, {}, U_[0], precomputed_[0], tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + 2.0 * tau);
-
-    hyperbolic_module_->template step<0>(
-        U_[0], {}, {}, {}, U_[1], precomputed_[0], tau);
-    U_[1].sadd(Number(1. / 4.), Number(3. / 4.), /*intermediate*/ U_[2]);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 1.5 * tau);
+    /* Second SSPRK 3 step with final result in temporary_[0]: */
 
     hyperbolic_module_->template step<0>(
-        U_[1], {}, {}, {}, U_[0], precomputed_[0], tau);
-    U_[0].sadd(Number(2. / 3.), Number(1. / 3.), /*intermediate*/ U_[2]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + 2.0 * tau);
+        /*intermediate*/ temporary_[2], {}, {}, temporary_[0], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + 2.0 * tau);
 
-    U.swap(U_[0]);
+    hyperbolic_module_->template step<0>(
+        temporary_[0], {}, {}, temporary_[1], tau);
+    sadd(temporary_[1],
+         Number(1. / 4.),
+         Number(3. / 4.),
+         /*intermediate*/ temporary_[2]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 1.5 * tau);
+
+    hyperbolic_module_->template step<0>(
+        temporary_[1], {}, {}, temporary_[0], tau);
+    sadd(temporary_[0],
+         Number(2. / 3.),
+         Number(1. / 3.),
+         /*intermediate*/ temporary_[2]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + 2.0 * tau);
+
+    state_vector.swap(temporary_[0]);
     return 2.0 * tau;
   }
 
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_strang_erk_33_cn(
-      vector_type &U, Number t)
+      StateVector &state_vector, Number t)
   {
     // FIXME: refactor to avoid code duplication with step_erk_33
 
@@ -574,66 +561,61 @@ namespace ryujin
               << std::endl;
 #endif
 
-    /* First explicit ERK(3,3,1) step with final result in U_[2]: */
+    /* First explicit ERK(3,3,1) step with final result in temporary_[2]: */
 
     Number tau = hyperbolic_module_->template step<0>(
-        /*input*/ U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        /*input*/ state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
-    hyperbolic_module_->template step<1>(U_[0],
-                                         {{/*input*/ U}},
-                                         {{precomputed_[0]}},
+    hyperbolic_module_->template step<1>(temporary_[0],
+                                         {{/*input*/ state_vector}},
                                          {{Number(-1.)}},
-                                         U_[1],
-                                         precomputed_[1],
+                                         temporary_[1],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 2. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 2. * tau);
 
-    hyperbolic_module_->template step<2>(U_[1],
-                                         {{/*input*/ U, U_[0]}},
-                                         {{precomputed_[0], precomputed_[1]}},
-                                         {{Number(0.75), Number(-2.)}},
-                                         U_[2],
-                                         precomputed_[2],
-                                         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[2], t + 3. * tau);
+    hyperbolic_module_->template step<2>(
+        temporary_[1],
+        {{/*input*/ state_vector, temporary_[0]}},
+        {{Number(0.75), Number(-2.)}},
+        temporary_[2],
+        tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[2], t + 3. * tau);
 
-    /* Implicit Crank-Nicolson step with final result in U_[3]: */
-    parabolic_module_->template step<0>(U_[2], t, {}, {}, U_[3], 3.0 * tau);
-    U_[3].sadd(Number(2.), Number(-1.), U_[2]);
+    /* Implicit Crank-Nicolson step with final result in temporary_[3]: */
+    parabolic_module_->template step<0>(
+        temporary_[2], t, {}, {}, temporary_[3], 3.0 * tau);
+    sadd(temporary_[3], Number(2.), Number(-1.), temporary_[2]);
 
-    /* First explicit SSPRK 3 step with final result in U_[2]: */
+    /* Second explicit SSPRK 3 step with final result in temporary_[2]: */
 
     hyperbolic_module_->template step<0>(
-        /*intermediate*/ U_[3], {}, {}, {}, U_[0], precomputed_[0], tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + 4. * tau);
+        /*intermediate*/ temporary_[3], {}, {}, temporary_[0], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + 4. * tau);
 
-    hyperbolic_module_->template step<1>(U_[0],
-                                         {{/*intermediate*/ U_[3]}},
-                                         {{precomputed_[0]}},
+    hyperbolic_module_->template step<1>(temporary_[0],
+                                         {{/*intermediate*/ temporary_[3]}},
                                          {{Number(-1.)}},
-                                         U_[1],
-                                         precomputed_[1],
+                                         temporary_[1],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 5. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 5. * tau);
 
-    hyperbolic_module_->template step<2>(U_[1],
-                                         {{/*intermediate*/ U_[3], U_[0]}},
-                                         {{precomputed_[0], precomputed_[1]}},
-                                         {{Number(0.75), Number(-2.)}},
-                                         U_[2],
-                                         precomputed_[2],
-                                         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[2], t + 6. * tau);
+    hyperbolic_module_->template step<2>(
+        temporary_[1],
+        {{/*intermediate*/ temporary_[3], temporary_[0]}},
+        {{Number(0.75), Number(-2.)}},
+        temporary_[2],
+        tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[2], t + 6. * tau);
 
-    U.swap(U_[2]);
+    state_vector.swap(temporary_[2]);
     return 6. * tau;
   }
 
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_strang_erk_43_cn(
-      vector_type &U, Number t)
+      StateVector &state_vector, Number t)
   {
     // FIXME: refactor to avoid code duplication with step_erk_43
 
@@ -642,85 +624,68 @@ namespace ryujin
               << std::endl;
 #endif
 
-    /* First explicit ERK(4,3,1) step with final result in U_[3]: */
+    /* First explicit ERK(4,3,1) step with final result in temporary_[3]: */
 
     /* Step 1: U1 <- {U, 1} at time t + tau */
     Number tau = hyperbolic_module_->template step<0>(
-        /*input*/ U, {}, {}, {}, U_[0], precomputed_[0]);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + tau);
+        /*input*/ state_vector, {}, {}, temporary_[0]);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + tau);
 
     /* Step 2: U2 <- {U1, 2} and {U, -1} at time t + 2 tau */
-    hyperbolic_module_->template step<1>(U_[0],
-                                         {{/*input*/ U}},
-                                         {{precomputed_[0]}},
+    hyperbolic_module_->template step<1>(temporary_[0],
+                                         {{/*input*/ state_vector}},
                                          {{Number(-1.)}},
-                                         U_[1],
-                                         precomputed_[1],
+                                         temporary_[1],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 2. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 2. * tau);
 
     /* Step 3: U3 <- {U2, 2} and {U1, -1} at time t + 3 tau */
-    hyperbolic_module_->template step<1>(U_[1],
-                                         {{U_[0]}},
-                                         {{precomputed_[1]}},
-                                         {{Number(-1.)}},
-                                         U_[2],
-                                         precomputed_[2],
-                                         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[2], t + 3. * tau);
+    hyperbolic_module_->template step<1>(
+        temporary_[1], {{temporary_[0]}}, {{Number(-1.)}}, temporary_[2], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[2], t + 3. * tau);
 
     /* Step 4: U4 <- {U3, 8/3} and {U2,-10/3} and {U1, 5/3} at time t + 4 tau */
-    hyperbolic_module_->template step<2>(U_[2],
-                                         {{U_[0], U_[1]}},
-                                         {{precomputed_[1], precomputed_[2]}},
+    hyperbolic_module_->template step<2>(temporary_[2],
+                                         {{temporary_[0], temporary_[1]}},
                                          {{Number(5. / 3.), Number(-10. / 3.)}},
-                                         U_[3],
-                                         precomputed_[3],
+                                         temporary_[3],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[3], t + 4. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[3], t + 4. * tau);
 
-    /* Implicit Crank-Nicolson step with final result in U_[2]: */
-    parabolic_module_->template step<0>(U_[3], t, {}, {}, U_[2], 4.0 * tau);
-    U_[2].sadd(Number(2.), Number(-1.), U_[3]);
+    /* Implicit Crank-Nicolson step with final result in temporary_[2]: */
+    parabolic_module_->template step<0>(
+        temporary_[3], t, {}, {}, temporary_[2], 4.0 * tau);
+    sadd(temporary_[2], Number(2.), Number(-1.), temporary_[3]);
 
-    /* First explicit SSPRK 3 step with final result in U_[3]: */
+    /* First explicit SSPRK 3 step with final result in temporary_[3]: */
 
     /* Step 1: U1 <- {U, 1} at time t + tau */
     hyperbolic_module_->template step<0>(
-        /*intermediate*/ U_[2], {}, {}, {}, U_[0], precomputed_[0], tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[0], t + 5. * tau);
+        /*intermediate*/ temporary_[2], {}, {}, temporary_[0], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[0], t + 5. * tau);
 
     /* Step 2: U2 <- {U1, 2} and {U, -1} at time t + 2 tau */
-    hyperbolic_module_->template step<1>(U_[0],
-                                         {{/*intermediate*/ U_[2]}},
-                                         {{precomputed_[0]}},
+    hyperbolic_module_->template step<1>(temporary_[0],
+                                         {{/*intermediate*/ temporary_[2]}},
                                          {{Number(-1.)}},
-                                         U_[1],
-                                         precomputed_[1],
+                                         temporary_[1],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[1], t + 6. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[1], t + 6. * tau);
 
     /* Step 3: U3 <- {U2, 2} and {U1, -1} at time t + 3 tau */
-    hyperbolic_module_->template step<1>(U_[1],
-                                         {{U_[0]}},
-                                         {{precomputed_[1]}},
-                                         {{Number(-1.)}},
-                                         U_[2],
-                                         precomputed_[2],
-                                         tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[2], t + 7. * tau);
+    hyperbolic_module_->template step<1>(
+        temporary_[1], {{temporary_[0]}}, {{Number(-1.)}}, temporary_[2], tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[2], t + 7. * tau);
 
     /* Step 4: U4 <- {U3, 8/3} and {U2,-10/3} and {U1, 5/3} at time t + 4 tau */
-    hyperbolic_module_->template step<2>(U_[2],
-                                         {{U_[0], U_[1]}},
-                                         {{precomputed_[1], precomputed_[2]}},
+    hyperbolic_module_->template step<2>(temporary_[2],
+                                         {{temporary_[0], temporary_[1]}},
                                          {{Number(5. / 3.), Number(-10. / 3.)}},
-                                         U_[3],
-                                         precomputed_[3],
+                                         temporary_[3],
                                          tau);
-    hyperbolic_module_->apply_boundary_conditions(U_[3], t + 8. * tau);
+    hyperbolic_module_->apply_boundary_conditions(temporary_[3], t + 8. * tau);
 
-    U.swap(U_[3]);
+    state_vector.swap(temporary_[3]);
     return 8. * tau;
   }
 

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -55,7 +55,7 @@ namespace ryujin
 
     using StateVector = View::StateVector;
 
-    using ScalarVector = ryujin::ScalarVector<Number>;
+    using ScalarVector = Vectors::ScalarVector<Number>;
 
     //@}
     /**

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -39,21 +39,23 @@ namespace ryujin
      */
     //@{
 
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
-    using ParabolicSystem = Description::ParabolicSystem;
+    using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using ParabolicSolver = Description::template ParabolicSolver<dim, Number>;
+    using ParabolicSolver =
+        typename Description::template ParabolicSolver<dim, Number>;
 
-    using ScalarNumber = View::ScalarNumber;
+    using ScalarNumber = typename View::ScalarNumber;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 
     static constexpr auto n_precomputed_values = View::n_precomputed_values;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
     using ScalarVector = Vectors::ScalarVector<Number>;
 

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -21,8 +21,6 @@
 #include <deal.II/base/timer.h>
 
 #include <fstream>
-#include <future>
-#include <sstream>
 
 namespace ryujin
 {
@@ -37,47 +35,33 @@ namespace ryujin
   {
   public:
     /**
-     * @copydoc HyperbolicSystem
+     * @name Typedefs and constexpr constants
      */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
+    //@{
 
+    using HyperbolicSystem = Description::HyperbolicSystem;
+
+    using View = Description::template HyperbolicSystemView<dim, Number>;
+
+    using ParabolicSystem = Description::ParabolicSystem;
+
+    using ParabolicSolver = Description::template ParabolicSolver<dim, Number>;
+
+    using ScalarNumber = View::ScalarNumber;
+
+    static constexpr auto problem_dimension = View::problem_dimension;
+
+    static constexpr auto n_precomputed_values = View::n_precomputed_values;
+
+    using StateVector = View::StateVector;
+
+    using ScalarVector = ryujin::ScalarVector<Number>;
+
+    //@}
     /**
-     * @copydoc ParabolicSystem
+     * @name Constructor and setup
      */
-    using ParabolicSystem = typename Description::ParabolicSystem;
-
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
-
-    /**
-     * @copydoc HyperbolicSystem::problem_dimension
-     */
-    static constexpr unsigned int problem_dimension = View::problem_dimension;
-
-    /**
-     * @copydoc HyperbolicSystem::n_precomputed_values
-     */
-    static constexpr unsigned int n_precomputed_values =
-        View::n_precomputed_values;
-
-
-    /**
-     * @copydoc OfflineData::scalar_type
-     */
-    using scalar_type = typename OfflineData<dim, Number>::scalar_type;
-
-    /**
-     * Typedef for a MultiComponentVector storing the state U.
-     */
-    using vector_type = MultiComponentVector<Number, problem_dimension>;
-
-    /**
-     * Typedef for a MultiComponentVector storing precomputed values.
-     */
-    using precomputed_type = MultiComponentVector<Number, n_precomputed_values>;
+    //@{
 
     /**
      * Constructor.
@@ -95,9 +79,9 @@ namespace ryujin
      */
     //@{
 
-    void compute_error(const vector_type &U, Number t);
+    void compute_error(const StateVector &state_vector, Number t);
 
-    void output(const vector_type &U,
+    void output(StateVector &state_vector,
                 const std::string &name,
                 Number t,
                 unsigned int cycle);

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -267,7 +267,7 @@ namespace ryujin
 
         print_info("interpolating initial values");
         U.reinit(offline_data_.vector_partitioner());
-        U = initial_values_.interpolate();
+        U = initial_values_.interpolate_state_vector();
 #ifdef DEBUG
         /* Poison constrained degrees of freedom: */
         const unsigned int n_owned = offline_data_.n_locally_owned();
@@ -313,7 +313,7 @@ namespace ryujin
         if (write_output_files) {
           output(U, base_name_ + "-solution", t, output_cycle);
           if (enable_compute_error_) {
-            const auto analytic = initial_values_.interpolate(t);
+            const auto analytic = initial_values_.interpolate_state_vector(t);
             output(
                 analytic, base_name_ + "-analytic_solution", t, output_cycle);
           }
@@ -427,7 +427,7 @@ namespace ryujin
     Number l1_norm = 0;
     Number l2_norm = 0;
 
-    const auto analytic = initial_values_.interpolate(t);
+    const auto analytic = initial_values_.interpolate_state_vector(t);
 
     scalar_type analytic_component;
     scalar_type error_component;

--- a/source/transfinite_interpolation.h
+++ b/source/transfinite_interpolation.h
@@ -19,6 +19,8 @@ namespace ryujin
    * deal.II. In contrast to the deal.II version it copies the coarse grid
    * and all relevant Manifold information. That way it can be initialized
    * with one Triangulation and be used with another Triangulation.
+   *
+   * @ingroup Mesh
    */
   template <int dim, int spacedim = dim>
   class TransfiniteInterpolationManifold : public Manifold<dim, spacedim>

--- a/source/vtu_output.h
+++ b/source/vtu_output.h
@@ -35,19 +35,20 @@ namespace ryujin
      */
     //@{
 
-    using HyperbolicSystem = Description::HyperbolicSystem;
+    using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View = Description::template HyperbolicSystemView<dim, Number>;
+    using View =
+        typename Description::template HyperbolicSystemView<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 
-    using state_type = View::state_type;
+    using state_type = typename View::state_type;
 
     static constexpr auto n_precomputed_values = View::n_precomputed_values;
 
-    using precomputed_type = View::precomputed_type;
+    using precomputed_type = typename View::precomputed_type;
 
-    using StateVector = View::StateVector;
+    using StateVector = typename View::StateVector;
 
     using ScalarVector = Vectors::ScalarVector<Number>;
 

--- a/source/vtu_output.h
+++ b/source/vtu_output.h
@@ -16,8 +16,6 @@
 #include <deal.II/grid/intergrid_map.h>
 #include <deal.II/multigrid/mg_transfer_matrix_free.h>
 
-#include <future>
-
 namespace ryujin
 {
 
@@ -31,48 +29,33 @@ namespace ryujin
   template <typename Description, int dim, typename Number = double>
   class VTUOutput final : public dealii::ParameterAcceptor
   {
-    /**
-     * @copydoc HyperbolicSystem
-     */
-    using HyperbolicSystem = typename Description::HyperbolicSystem;
-
-    /**
-     * @copydoc HyperbolicSystemView
-     */
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
-
   public:
     /**
-     * @copydoc HyperbolicSystem::problem_dimension
+     * @name Typedefs and constexpr constants
      */
-    static constexpr unsigned int problem_dimension = View::problem_dimension;
+    //@{
 
-    /**
-     * @copydoc HyperbolicSystem::state_type
-     */
-    using state_type = typename View::state_type;
+    using HyperbolicSystem = Description::HyperbolicSystem;
 
-    /**
-     * @copydoc HyperbolicSystem::n_precomputed_values
-     */
-    static constexpr unsigned int n_precomputed_values =
-        View::n_precomputed_values;
+    using View = Description::template HyperbolicSystemView<dim, Number>;
 
-    /**
-     * @copydoc OfflineData::scalar_type
-     */
-    using scalar_type = typename OfflineData<dim, Number>::scalar_type;
+    static constexpr auto problem_dimension = View::problem_dimension;
 
-    /**
-     * Typedef for a MultiComponentVector storing the state U.
-     */
-    using vector_type = MultiComponentVector<Number, problem_dimension>;
+    using state_type = View::state_type;
 
+    static constexpr auto n_precomputed_values = View::n_precomputed_values;
+
+    using precomputed_type = View::precomputed_type;
+
+    using StateVector = View::StateVector;
+
+    using ScalarVector = ScalarVector<Number>;
+
+    //@}
     /**
-     * Typedef for a MultiComponentVector storing precomputed values.
+     * @name Constructor and setup
      */
-    using precomputed_type = MultiComponentVector<Number, n_precomputed_values>;
+    //@{
 
     /**
      * Constructor.
@@ -110,8 +93,7 @@ namespace ryujin
      *
      * The function requires MPI communication and is not reentrant.
      */
-    void schedule_output(const vector_type &U,
-                         const precomputed_type &precomputed_values,
+    void schedule_output(const StateVector &state_vector,
                          std::string name,
                          Number t,
                          unsigned int cycle,
@@ -154,12 +136,12 @@ namespace ryujin
 
     bool need_to_prepare_step_;
 
-    std::vector<scalar_type> quantities_;
+    std::vector<ScalarVector> quantities_;
 
-    std::vector<std::tuple<std::string /*name*/,
-                           std::function<void(scalar_type & /*result*/,
-                                              const vector_type & /*U*/,
-                                              const precomputed_type &)>>>
+    std::vector<
+        std::tuple<std::string /*name*/,
+                   std::function<void(ScalarVector & /*result*/,
+                                      const StateVector & /*state_vector*/)>>>
         quantities_mapping_;
 
     //@}

--- a/source/vtu_output.h
+++ b/source/vtu_output.h
@@ -49,7 +49,7 @@ namespace ryujin
 
     using StateVector = View::StateVector;
 
-    using ScalarVector = ScalarVector<Number>;
+    using ScalarVector = Vectors::ScalarVector<Number>;
 
     //@}
     /**

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -30,7 +30,8 @@ int main()
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
 
-  using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
+  using precomputed_type =
+      Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
   Limiter<dim, double> limiter(hyperbolic_system, limiter_parameters, dummy);

--- a/tests/euler/riemann_solver.cc
+++ b/tests/euler/riemann_solver.cc
@@ -32,7 +32,8 @@ int main()
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, Number>::n_precomputed_values;
-  using precomputed_type = MultiComponentVector<Number, n_precomputed_values>;
+  using precomputed_type =
+      Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
   RiemannSolver<dim> riemann_solver(

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -46,7 +46,8 @@ int main()
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
 
-  using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
+  using precomputed_type =
+      Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
   Limiter<dim, double> limiter(hyperbolic_system, limiter_parameters, dummy);

--- a/tests/euler_aeos/riemann_solver-strict.cc
+++ b/tests/euler_aeos/riemann_solver-strict.cc
@@ -21,7 +21,8 @@ int main()
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
-  using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
+  using precomputed_type =
+      Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
   RiemannSolver<dim> riemann_solver(

--- a/tests/euler_aeos/riemann_solver.cc
+++ b/tests/euler_aeos/riemann_solver.cc
@@ -21,7 +21,8 @@ int main()
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
-  using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
+  using precomputed_type =
+      Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
   RiemannSolver<dim> riemann_solver(

--- a/tests/scalar_conservation/riemann_solver.cc
+++ b/tests/scalar_conservation/riemann_solver.cc
@@ -40,13 +40,12 @@ void test(const std::string &expression)
   }
 
   using View = HyperbolicSystemView<dim, Number>;
-  using state_type = typename View::state_type;
-  using precomputed_state_type = typename View::precomputed_state_type;
-  static constexpr unsigned int n_precomputed_values =
-      View::n_precomputed_values;
-  using precomputed_type = MultiComponentVector<Number, n_precomputed_values>;
+  using state_type = View::state_type;
+  using precomputed_type = View::precomputed_type;
+  static constexpr auto n_precomputed_values = View::n_precomputed_values;
+  using PrecomputedVector = View::PrecomputedVector;
 
-  precomputed_type dummy;
+  PrecomputedVector dummy;
 
   RiemannSolver<dim> riemann_solver(
       hyperbolic_system, riemann_solver_parameters, dummy);
@@ -62,8 +61,8 @@ void test(const std::string &expression)
   const auto f_j = view.flux_function(u_j);
   const auto df_j = view.flux_gradient_function(u_j);
 
-  precomputed_state_type prec_i;
-  precomputed_state_type prec_j;
+  precomputed_type prec_i;
+  precomputed_type prec_j;
 
   for (unsigned int k = 0; k < n_precomputed_values / 2; ++k) {
     prec_i[k] = f_i[k];

--- a/tests/scalar_conservation/riemann_solver.cc
+++ b/tests/scalar_conservation/riemann_solver.cc
@@ -40,10 +40,10 @@ void test(const std::string &expression)
   }
 
   using View = HyperbolicSystemView<dim, Number>;
-  using state_type = View::state_type;
-  using precomputed_type = View::precomputed_type;
+  using state_type = typename View::state_type;
+  using precomputed_type = typename View::precomputed_type;
   static constexpr auto n_precomputed_values = View::n_precomputed_values;
-  using PrecomputedVector = View::PrecomputedVector;
+  using PrecomputedVector = typename View::PrecomputedVector;
 
   PrecomputedVector dummy;
 

--- a/tests/shallow_water/riemann_solver.cc
+++ b/tests/shallow_water/riemann_solver.cc
@@ -23,7 +23,8 @@ int main()
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
-  using precomputed_type = MultiComponentVector<double, n_precomputed_values>;
+  using precomputed_type =
+      Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
   RiemannSolver<dim> riemann_solver(


### PR DESCRIPTION
OK, this is a rather big changeset that refactors the old `vector_type` and `precomputed_type` into a compound `StateVector`, and, while we are at it, add a block vector `V` for carrying additional state:
 - we need this change in order to move forward with the implementation of various equations,
 - it significantly simplifies the time stepping.

The PR currently only modifies the code to the new data structure (and cleans up some typedefs on the way). In a follow-up we will need to adjust this further.