### PR TITLE
`HyperbolicModule`: add missing sources to affine shift

### DIFF
--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -590,13 +590,13 @@ namespace ryujin
 
           limiter.reset(i, U_i, flux_i);
 
-          /*
-           * Workaround: For shallow water we need to accumulate an affine
-           * shift over the stencil first before we can compute limiter
-           * bounds.
-           */
-
           [[maybe_unused]] state_type affine_shift;
+
+          /*
+           * Workaround: For shallow water we need to accumulate an
+           * additional contribution to the affine shift over the stencil
+           * before we can compute limiter bounds.
+           */
 
           const unsigned int *js = sparsity_simd.columns(i);
           if constexpr (shallow_water) {
@@ -615,6 +615,10 @@ namespace ryujin
             }
 
             affine_shift *= tau * m_i_inv;
+          }
+
+          if constexpr (View::have_source_terms) {
+            affine_shift += tau * /* m_i_inv * m_i */ S_i;
           }
 
           js = sparsity_simd.columns(i);

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -699,7 +699,8 @@ namespace ryujin
               F_iH += d_ijH * (U_j - U_i);
               P_ij += (d_ijH - d_ij) * (U_j - U_i);
 
-              limiter.accumulate(js, U_j, flux_j, scaled_c_ij, beta_ij);
+              limiter.accumulate(
+                  js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
             }
 
             if constexpr (View::have_source_terms) {

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -84,7 +84,8 @@ namespace ryujin
        *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, beta_ij);
+       *     limiter.accumulate(
+       *       js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
        *   }
        *   limiter.bounds(hd_i);
        * }
@@ -129,7 +130,8 @@ namespace ryujin
                       const state_type &U_j,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-                      const Number beta_ij);
+                      const Number beta_ij,
+                      const state_type &affine_shift);
 
       /**
        * Return the computed bounds (with relaxation applied).
@@ -225,7 +227,8 @@ namespace ryujin
         const state_type &U_j,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-        const Number beta_ij)
+        const Number beta_ij,
+        const state_type &affine_shift)
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -237,7 +240,8 @@ namespace ryujin
 
       const auto U_ij_bar =
           ScalarNumber(0.5) * (U_i + U_j) -
-          ScalarNumber(0.5) * contract(add(flux_j, -flux_i), scaled_c_ij);
+          ScalarNumber(0.5) * contract(add(flux_j, -flux_i), scaled_c_ij) +
+          affine_shift;
 
       const auto u_ij_bar = view.state(U_ij_bar);
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -277,11 +277,12 @@ namespace ryujin
       const auto f_star_ij = view.f(U_star_ij);
       const auto f_star_ji = view.f(U_star_ji);
 
-      auto U_ij_bar = ScalarNumber(0.5) *
-                      (U_star_ij + U_star_ji +
-                       contract(add(f_star_ij, -f_star_ji), scaled_c_ij));
-
-      U_ij_bar += affine_shift;
+      /* bar state shifted by an affine shift: */
+      const auto U_ij_bar =
+          ScalarNumber(0.5) *
+              (U_star_ij + U_star_ji +
+               contract(add(f_star_ij, -f_star_ji), scaled_c_ij)) +
+          affine_shift;
 
       /* Bounds: */
 

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -73,7 +73,8 @@ namespace ryujin
        *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, beta_ij);
+       *     limiter.accumulate(
+       *       js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
        *   }
        *   limiter.bounds(hd_i);
        * }
@@ -121,7 +122,8 @@ namespace ryujin
                       const state_type & /*U_j*/,
                       const flux_contribution_type & /*flux_j*/,
                       const dealii::Tensor<1, dim, Number> & /*scaled_c_ij*/,
-                      const Number & /*beta_ij*/)
+                      const Number & /*beta_ij*/,
+                      const state_type & /*affine_shift*/)
       {
         // empty
       }


### PR DESCRIPTION
In reference to #91. We need to also incorporate source terms into the affine shift used for computing limiter bounds.

@ejtovar *ping*