### PR TITLE
dG Infrastructure, Part 5

### DIFF
--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -136,8 +136,7 @@ namespace ryujin
        *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(
-       *       js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
+       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
        *   }
        *   limiter.bounds(hd_i);
        * }
@@ -182,7 +181,6 @@ namespace ryujin
                       const state_type &U_j,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-                      const Number beta_ij,
                       const state_type &affine_shift);
 
       /**
@@ -292,7 +290,6 @@ namespace ryujin
         const state_type &U_j,
         const flux_contribution_type & /*flux_j*/,
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-        const Number beta_ij,
         const state_type &affine_shift)
     {
       // TODO: Currently we only apply the affine_shift to U_ij_bar (which
@@ -327,6 +324,8 @@ namespace ryujin
 
       /* Relaxation: */
 
+      /* Use a uniform weight. */
+      const auto beta_ij = Number(1.);
       rho_relaxation_numerator += beta_ij * (rho_i + rho_j);
       rho_relaxation_denominator += std::abs(beta_ij);
 

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -138,8 +138,7 @@ namespace ryujin
        *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(
-       *       js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
+       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
        *   }
        *   limiter.bounds(hd_i);
        * }
@@ -184,7 +183,6 @@ namespace ryujin
                       const state_type &U_j,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-                      const Number beta_ij,
                       const state_type &affine_shift);
 
       /**
@@ -305,7 +303,6 @@ namespace ryujin
         const state_type &U_j,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-        const Number beta_ij,
         const state_type &affine_shift)
     {
       // TODO: Currently we only apply the affine_shift to U_ij_bar (which
@@ -338,6 +335,8 @@ namespace ryujin
 
       /* Density relaxation: */
 
+      /* Use a uniform weight. */
+      const auto beta_ij = Number(1.);
       rho_relaxation_numerator += beta_ij * (rho_i + rho_j);
       rho_relaxation_denominator += std::abs(beta_ij);
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -178,7 +178,6 @@ namespace ryujin
     const auto &lumped_mass_matrix_inverse =
         offline_data_->lumped_mass_matrix_inverse();
     const auto &mass_matrix = offline_data_->mass_matrix();
-    const auto &betaij_matrix = offline_data_->betaij_matrix();
     const auto &cij_matrix = offline_data_->cij_matrix();
     const auto &incidence_matrix = offline_data_->incidence_matrix();
 
@@ -667,9 +666,6 @@ namespace ryujin
                 T(100. * std::numeric_limits<Number>::min());
             const auto scaled_c_ij = c_ij / std::max(d_ij, regularization);
 
-            const auto beta_ij =
-                betaij_matrix.template get_entry<T>(i, col_idx);
-
             const auto flux_j = view.flux_contribution(
                 old_precomputed, initial_precomputed_, js, U_j);
 
@@ -695,12 +691,8 @@ namespace ryujin
               F_iH += d_ijH * (U_star_ji - U_star_ij);
               P_ij += (d_ijH - d_ij) * (U_star_ji - U_star_ij);
 
-              limiter.accumulate(U_j,
-                                 U_star_ij,
-                                 U_star_ji,
-                                 scaled_c_ij,
-                                 beta_ij,
-                                 affine_shift);
+              limiter.accumulate(
+                  U_j, U_star_ij, U_star_ji, scaled_c_ij, affine_shift);
 
             } else {
 
@@ -708,8 +700,7 @@ namespace ryujin
               F_iH += d_ijH * (U_j - U_i);
               P_ij += (d_ijH - d_ij) * (U_j - U_i);
 
-              limiter.accumulate(
-                  js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
+              limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
             }
 
             if constexpr (View::have_source_terms) {

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -211,13 +211,6 @@ namespace ryujin
     ACCESSOR_READ_ONLY(level_lumped_mass_matrix)
 
     /**
-     * The stiffness matrix \f$(beta_{ij})\f$:
-     *   \f$\beta_{ij} = \nabla\varphi_{j}\cdot\nabla\varphi_{i}\f$
-     * (SIMD storage, local numbering)
-     */
-    ACCESSOR_READ_ONLY(betaij_matrix)
-
-    /**
      * The \f$(c_{ij})\f$ matrix. (SIMD storage, local numbering)
      */
     ACCESSOR_READ_ONLY(cij_matrix)
@@ -307,7 +300,6 @@ namespace ryujin
 
     std::vector<ScalarVectorFloat> level_lumped_mass_matrix_;
 
-    SparseMatrixSIMD<Number> betaij_matrix_;
     SparseMatrixSIMD<Number, dim> cij_matrix_;
     SparseMatrixSIMD<Number> incidence_matrix_;
 

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -92,8 +92,7 @@ namespace ryujin
        *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(
-       *       js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
+       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
        *   }
        *   limiter.bounds(hd_i);
        * }
@@ -138,7 +137,6 @@ namespace ryujin
                       const state_type &U_j,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-                      const Number beta_ij,
                       const state_type &affine_shift);
 
       /**
@@ -243,7 +241,6 @@ namespace ryujin
         const state_type &U_j,
         const flux_contribution_type &flux_j,
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-        const Number beta_ij,
         const state_type &affine_shift)
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -268,6 +265,8 @@ namespace ryujin
 
       /* Relaxation: */
 
+      /* Use a uniform weight. */
+      const auto beta_ij = Number(1.);
       u_relaxation_numerator += beta_ij * (u_i + u_j);
       u_relaxation_denominator += std::abs(beta_ij);
     }

--- a/source/scratch_data.h
+++ b/source/scratch_data.h
@@ -80,7 +80,6 @@ namespace ryujin
     bool is_locally_owned_;
     std::vector<dealii::types::global_dof_index> local_dof_indices_;
     dealii::FullMatrix<Number> cell_mass_matrix_;
-    dealii::FullMatrix<Number> cell_betaij_matrix_;
     std::array<dealii::FullMatrix<Number>, dim> cell_cij_matrix_;
     Number cell_measure_;
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -128,8 +128,7 @@ namespace ryujin
        *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(
-       *       js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
+       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
        *   }
        *   limiter.bounds(hd_i);
        * }
@@ -174,7 +173,6 @@ namespace ryujin
                       const state_type &U_star_ij,
                       const state_type &U_star_ji,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-                      const Number &beta_ij,
                       const state_type &affine_shift);
 
       /**
@@ -283,7 +281,6 @@ namespace ryujin
         const state_type &U_star_ij,
         const state_type &U_star_ji,
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
-        const Number &beta_ij,
         const state_type &affine_shift)
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -317,6 +314,9 @@ namespace ryujin
       v2_max = std::max(v2_max, v2_bar_ij);
 
       /* Relaxation: */
+
+      /* Use a uniform weight. */
+      const auto beta_ij = Number(1.);
 
       relaxation_denominator += std::abs(beta_ij);
 

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -81,8 +81,7 @@ namespace ryujin
        *   limiter.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(
-       *       js, U_j, flux_j, scaled_c_ij, beta_ij, affine_shift);
+       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
        *   }
        *   limiter.bounds(hd_i);
        * }
@@ -130,7 +129,6 @@ namespace ryujin
                       const state_type & /*U_j*/,
                       const flux_contribution_type & /*flux_j*/,
                       const dealii::Tensor<1, dim, Number> & /*scaled_c_ij*/,
-                      const Number & /*beta_ij*/,
                       const state_type & /*affine_shift*/)
       {
         // empty

--- a/tests/euler/verification-leblanc-1d-erk33-l6.mpirun=4.output
+++ b/tests/euler/verification-leblanc-1d-erk33-l6.mpirun=4.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 1601
-t     = 0.6666710799840403
-Linf  = 0.223327758337916
-L1    = 0.01167712778564185
-L2    = 0.03259114292545372
+t     = 0.6666710022008712
+Linf  = 0.2233117555967211
+L1    = 0.01167724325117752
+L2    = 0.03259102542735855

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.mpirun=4.output
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.mpirun=4.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 1601
-t     = 0.6672118542702864
-Linf  = 0.2567636420440007
-L1    = 0.01174817452200292
-L2    = 0.03031087112473869
+t     = 0.6672120772838556
+Linf  = 0.2567704307146476
+L1    = 0.01174812314062443
+L2    = 0.03031110237849881

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.mpirun=4.output
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.mpirun=4.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 1601
-t     = 0.6667468172888714
-Linf  = 0.2185679687183667
-L1    = 0.01210462732452911
-L2    = 0.02611568221818898
+t     = 0.6667479617426518
+Linf  = 0.2186056381773273
+L1    = 0.01210486853418129
+L2    = 0.02611629816974879

--- a/tests/navier_stokes/gmg_energy.threads=1.output
+++ b/tests/navier_stokes/gmg_energy.threads=1.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 33
-t     = 2.004535889054672
-Linf  = 0.04084463599862329
-L1    = 0.0183706251851103
-L2    = 0.02059439631122319
+t     = 2.004535220810037
+Linf  = 0.04082272044473351
+L1    = 0.01836514905926472
+L2    = 0.0205867472660186

--- a/tests/navier_stokes/gmg_velocity.threads=1.output
+++ b/tests/navier_stokes/gmg_velocity.threads=1.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 33
-t     = 2.004535889054673
-Linf  = 0.04084463599829601
-L1    = 0.01837062518506944
-L2    = 0.02059439631115979
+t     = 2.004535220810038
+Linf  = 0.04082272044436447
+L1    = 0.01836514905921422
+L2    = 0.02058674726594371

--- a/tests/navier_stokes/gmg_velocity_energy.threads=1.output
+++ b/tests/navier_stokes/gmg_velocity_energy.threads=1.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 33
-t     = 2.004535889054673
-Linf  = 0.04084463599818494
-L1    = 0.01837062518505302
-L2    = 0.02059439631113712
+t     = 2.004535220810036
+Linf  = 0.04082272044430105
+L1    = 0.01836514905920651
+L2    = 0.02058674726593233

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l5-2d.threads=1.output
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l5-2d.threads=1.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 1089
-t     = 2.002270050174344
-Linf  = 0.03534370405977035
-L1    = 0.01658417508255035
-L2    = 0.01859795804909001
+t     = 2.002269000319735
+Linf  = 0.03525554316118422
+L1    = 0.01656112032714321
+L2    = 0.01857266749925769

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l5-2d.threads=1.output
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l5-2d.threads=1.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 1089
-t     = 2.002241214359738
-Linf  = 0.03638324281637868
-L1    = 0.0168754121608014
-L2    = 0.01895581504590826
+t     = 2.0022405716229
+Linf  = 0.03634873416606362
+L1    = 0.0168662782271009
+L2    = 0.01894535333821928

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l5.threads=1.output
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l5.threads=1.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 65
-t     = 2.000575461749416
-Linf  = 0.01130262744180634
-L1    = 0.004178088148084418
-L2    = 0.005422525866028632
+t     = 2.000575342070921
+Linf  = 0.01130630462624738
+L1    = 0.004178999983998387
+L2    = 0.00542251612514292

--- a/tests/shallow_water/verification-paraboloid_1d-erk33-l7.output
+++ b/tests/shallow_water/verification-paraboloid_1d-erk33-l7.output
@@ -11,7 +11,7 @@
 [INFO] scheduling output
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 3201
-t     = 1345.767149162498
-Linf  = 0.0001131206979416342
-L1    = 1.528984553877238e-05
-L2    = 1.873803758115697e-05
+t     = 1345.774540174449
+Linf  = 0.0001164820398633047
+L1    = 1.540791689488111e-05
+L2    = 1.889066598391606e-05


### PR DESCRIPTION
Remove `beta_ij` matrix and use a uniform weight for computing bounds relaxations.

@kronbichler *ping* <s>I you have a minute, would you mind to instrument this pull request and compare it to the base branch? I do see a 2.5% performance improvement with clang on my laptop. (Which might be explained with less cache pressure in the already overburdened "step 4" of the hyperbolic update.) I am asking because 2.5% is huge.</s> And now I dropped back to standard performance.
