### PR TITLE
`Euler/EulerAEOS`: adjust bounds relaxation

### DIFF
--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -354,8 +354,10 @@ namespace ryujin
       rho_min = std::max((Number(1.) - r_i) * rho_min, rho_min - relaxation);
       rho_max = std::min((Number(1.) + r_i) * rho_max, rho_max + relaxation);
 
-      s_min = std::max((Number(1.) - r_i) * s_min,
-                       Number(2.) * s_min - s_interp_max);
+      const auto entropy_relaxation =
+          parameters.relaxation_factor() * (s_interp_max - s_min);
+
+      s_min = std::max((Number(1.) - r_i) * s_min, s_min - entropy_relaxation);
 
       return relaxed_bounds;
     }

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -407,8 +407,10 @@ namespace ryujin
       rho_min = std::max((Number(1.) - r_i) * rho_min, rho_min - relaxation);
       rho_max = std::min((Number(1.) + r_i) * rho_max, rho_max + relaxation);
 
-      s_min = std::max((Number(1.) - r_i) * s_min,
-                       Number(2.) * s_min - s_interp_max);
+      const auto entropy_relaxation =
+          parameters.relaxation_factor() * (s_interp_max - s_min);
+
+      s_min = std::max((Number(1.) - r_i) * s_min, s_min - entropy_relaxation);
 
       /*
        * If we have a maximum compressibility constant, b, the maximum

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.mpirun=4.output
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.mpirun=4.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 1601
-t     = 0.6672120772838556
-Linf  = 0.2567704307146476
-L1    = 0.01174812314062443
-L2    = 0.03031110237849881
+t     = 0.6672156833726536
+Linf  = 0.2565920535637815
+L1    = 0.01172977710684317
+L2    = 0.03029397951275109

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.mpirun=4.output
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.mpirun=4.output
@@ -7,7 +7,7 @@
 [INFO] entering main loop
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 1601
-t     = 0.6667479617426518
-Linf  = 0.2186056381773273
-L1    = 0.01210486853418129
-L2    = 0.02611629816974879
+t     = 0.6666667374733917
+Linf  = 0.2157758337954887
+L1    = 0.01209329301782065
+L2    = 0.02606498438294566


### PR DESCRIPTION
Rarefaction test with the following modified configuration:
```
subsection F - HyperbolicModule
  subsection indicator
    set evc factor = 0
  end
  subsection limiter
    set relaxation factor = 8
  end
end
```

Gives the following:
```
dG Q0:

  #dofs     L1 error           L2 error          Linf error
-------  -----------  ----  -----------  ----  ------------  ----
    480  0.00036784         0.00114338          0.00744729
    960  0.000152845  1.27  0.000578076  0.98   0.0043167    0.79
   1920  6.02823e-05  1.34  0.000293923  0.98   0.00294078   0.55
   3840  2.45248e-05  1.3   0.000148139  0.99   0.0017988    0.71
   7680  9.78767e-06  1.33  7.45329e-05  0.99   0.00114078   0.66
  15360  3.96989e-06  1.3   3.74914e-05  0.99   0.000726011  0.65

dG Q1:

    #dofs     L1 error           L2 error          Linf error
-------  -----------  ----  -----------  ----  ------------  ----
    480  0.000121355        0.000595037         0.00657075
    960  3.34748e-05  1.86  0.000195041  1.61   0.00230066   1.51
   1920  1.08239e-05  1.63  8.25699e-05  1.24   0.00113458   1.02
   3840  3.63697e-06  1.57  3.82027e-05  1.11   0.000833202  0.45
   7680  1.2732e-06   1.51  1.76683e-05  1.11   0.000503623  0.73
  15360  4.37014e-07  1.54  7.88767e-06  1.16   0.000266896  0.92

dG Q2:

  #dofs     L1 error           L2 error          Linf error
-------  -----------  ----  -----------  ----  ------------  ----
    480  0.000121463        0.000403639         0.00281927
    960  3.98714e-05  1.61  0.000184564  1.13   0.00210431   0.42
   1920  1.42045e-05  1.49  7.35847e-05  1.33   0.00122835   0.78
   3840  4.31629e-06  1.72  2.82562e-05  1.38   0.000694897  0.82
   7680  1.54158e-06  1.49  1.18576e-05  1.25   0.000366999  0.92
  15360  4.65581e-07  1.73  4.63454e-06  1.36   0.000191473  0.94

dG Q3:

  #dofs     L1 error           L2 error          Linf error
-------  -----------  ----  -----------  ----  ------------  ----
    480  8.83567e-05        0.000370671         0.00376933
    960  2.80144e-05  1.66  0.000163161  1.18   0.00206618   0.87
   1920  9.96338e-06  1.49  8.18881e-05  0.99   0.0012367    0.74
   3840  2.65668e-06  1.91  2.88573e-05  1.5    0.000583785  1.08
   7680  8.94486e-07  1.57  1.32047e-05  1.13   0.00028733   1.02
  15360  2.19311e-07  2.03  4.50773e-06  1.55   0.000142231  1.01
```

For reference, continuous finite elements with the same configuration give:
```
cG Q1:

  #dofs     L1 error           L2 error          Linf error
-------  -----------  ----  -----------  ----  ------------  ----
    481  7.98885e-05        0.000314489         0.00373006
    961  2.20354e-05  1.86  0.000136469  1.2    0.00217014   0.78
   1921  6.99139e-06  1.66  5.15182e-05  1.41   0.000847452  1.36
   3841  2.08835e-06  1.74  2.32012e-05  1.15   0.000579166  0.55
   7681  7.05225e-07  1.57  1.02818e-05  1.17   0.000315929  0.87
  15361  2.22717e-07  1.66  4.67195e-06  1.14   0.000214816  0.56
```
