### PR TITLE
dG Infrastructure, Part X

### DIFF
--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -225,6 +225,9 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline void
     Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
     {
+      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
+        return;
+
       /* entropy viscosity commutator: */
 
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -275,6 +278,7 @@ namespace ryujin
           (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
 
       if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
+        /* Entropy viscosity commutator with aggressive denominator split: */
 
         left_absolute += std::abs(entropy_flux);
         for (unsigned int k = 0; k < problem_dimension; ++k) {
@@ -299,7 +303,8 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline Number
     Indicator<dim, Number>::alpha(const Number hd_i) const
     {
-      using ScalarNumber = typename get_value_type<Number>::type;
+      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
+        return Number(0.);
 
       if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
         /* Entropy viscosity commutator with aggressive denominator split: */

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -19,6 +19,29 @@ namespace ryujin
 {
   namespace Euler
   {
+    enum class IndicatorStrategy {
+      /** Indicator returns constant 0 */
+      galerkin,
+      /** The classical entropy viscosity commutator */
+      evc,
+      /** Entropy viscosity with more aggressive denominator split */
+      evc_fullsplit,
+    };
+  }
+} // namespace ryujin
+
+#ifndef DOXYGEN
+DECLARE_ENUM(ryujin::Euler::IndicatorStrategy,
+             LIST({ryujin::Euler::IndicatorStrategy::galerkin, "galerkin"},
+                  {ryujin::Euler::IndicatorStrategy::evc, "entropy viscosity"},
+                  {ryujin::Euler::IndicatorStrategy::evc_fullsplit,
+                   "aggressive entropy viscosity"}));
+#endif
+
+namespace ryujin
+{
+  namespace Euler
+  {
     template <typename ScalarNumber = double>
     class IndicatorParameters : public dealii::ParameterAcceptor
     {
@@ -26,15 +49,25 @@ namespace ryujin
       IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
+        indicator_strategy_ = IndicatorStrategy::evc;
+        add_parameter(
+            "indicator strategy",
+            indicator_strategy_,
+            "The chosen indicator strategy. Possible values are: galerkin, "
+            "entropy viscosity, aggressive entropy viscosity");
+
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
                       evc_factor_,
                       "Factor for scaling the entropy viscocity commuator");
       }
 
+      ACCESSOR_READ_ONLY(indicator_strategy);
+
       ACCESSOR_READ_ONLY(evc_factor);
 
     private:
+      IndicatorStrategy indicator_strategy_;
       ScalarNumber evc_factor_;
     };
 
@@ -174,6 +207,9 @@ namespace ryujin
       Number left = 0.;
       state_type right;
 
+      Number left_absolute = 0.;
+      Number right_value = 0.;
+      Number right_absolute = 0.;
       //@}
     };
 
@@ -206,6 +242,10 @@ namespace ryujin
 
       left = 0.;
       right = 0.;
+
+      left_absolute = 0.;
+      right_value = 0.;
+      right_absolute = 0.;
     }
 
 
@@ -215,6 +255,9 @@ namespace ryujin
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
+      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
+        return;
+
       /* entropy viscosity commutator: */
 
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -228,9 +271,27 @@ namespace ryujin
       const auto m_j = view.momentum(U_j);
       const auto f_j = view.f(U_j);
 
-      left += (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
-      for (unsigned int k = 0; k < problem_dimension; ++k)
-        right[k] += (f_j[k] - f_i[k]) * c_ij;
+      const auto entropy_flux =
+          (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
+
+      if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
+
+        left_absolute += std::abs(entropy_flux);
+        for (unsigned int k = 0; k < problem_dimension; ++k) {
+          const auto component = d_eta_i[k] * (f_j[k] - f_i[k]) * c_ij;
+          right_value += component;
+          right_absolute += std::abs(component);
+        }
+
+      } else {
+        /* Entropy viscosity commutator with conservative denominator split: */
+
+        left += entropy_flux;
+        for (unsigned int k = 0; k < problem_dimension; ++k) {
+          const auto component = (f_j[k] - f_i[k]) * c_ij;
+          right[k] += component;
+        }
+      }
     }
 
 
@@ -240,17 +301,32 @@ namespace ryujin
     {
       using ScalarNumber = typename get_value_type<Number>::type;
 
-      Number numerator = left;
-      Number denominator = std::abs(left);
-      for (unsigned int k = 0; k < problem_dimension; ++k) {
-        numerator -= d_eta_i[k] * right[k];
-        denominator += std::abs(d_eta_i[k] * right[k]);
+      if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
+        /* Entropy viscosity commutator with aggressive denominator split: */
+
+        Number numerator = left - right_value;
+        Number denominator = left_absolute + right_absolute;
+
+        const auto quotient =
+            std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
+
+        return std::min(Number(1.), parameters.evc_factor() * quotient);
+
+      } else {
+        /* Entropy viscosity commutator with conservative denominator split: */
+
+        Number numerator = left;
+        Number denominator = std::abs(left);
+        for (unsigned int k = 0; k < problem_dimension; ++k) {
+          numerator -= d_eta_i[k] * right[k];
+          denominator += std::abs(d_eta_i[k] * right[k]);
+        }
+
+        const auto quotient =
+            std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
+
+        return std::min(Number(1.), parameters.evc_factor() * quotient);
       }
-
-      const auto quotient =
-          std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
-
-      return std::min(Number(1.), parameters.evc_factor() * quotient);
     }
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -19,6 +19,31 @@ namespace ryujin
 {
   namespace EulerAEOS
   {
+    enum class IndicatorStrategy {
+      /** Indicator returns constant 0 */
+      galerkin,
+      /** The classical entropy viscosity commutator */
+      evc,
+      /** Entropy viscosity with more aggressive denominator split */
+      evc_fullsplit,
+    };
+  }
+} // namespace ryujin
+
+#ifndef DOXYGEN
+DECLARE_ENUM(ryujin::EulerAEOS::IndicatorStrategy,
+             LIST({ryujin::EulerAEOS::IndicatorStrategy::galerkin, "galerkin"},
+                  {ryujin::EulerAEOS::IndicatorStrategy::evc,
+                   "entropy viscosity"},
+                  {ryujin::EulerAEOS::IndicatorStrategy::evc_fullsplit,
+                   "aggressive entropy viscosity"}));
+#endif
+
+
+namespace ryujin
+{
+  namespace EulerAEOS
+  {
     template <typename ScalarNumber = double>
     class IndicatorParameters : public dealii::ParameterAcceptor
     {
@@ -26,15 +51,25 @@ namespace ryujin
       IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
+        indicator_strategy_ = IndicatorStrategy::evc;
+        add_parameter(
+            "indicator strategy",
+            indicator_strategy_,
+            "The chosen indicator strategy. Possible values are: galerkin, "
+            "entropy viscosity, aggressive entropy viscosity");
+
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
                       evc_factor_,
                       "Factor for scaling the entropy viscocity commuator");
       }
 
+      ACCESSOR_READ_ONLY(indicator_strategy);
+
       ACCESSOR_READ_ONLY(evc_factor);
 
     private:
+      IndicatorStrategy indicator_strategy_;
       ScalarNumber evc_factor_;
     };
 
@@ -166,17 +201,18 @@ namespace ryujin
       const Parameters &parameters;
       const PrecomputedVector &precomputed_values;
 
-
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;
       flux_type f_i;
       state_type d_eta_i;
+      Number gamma_min;
 
       Number left = 0.;
       state_type right;
 
-      Number gamma_min;
-
+      Number left_absolute = 0.;
+      Number right_value = 0.;
+      Number right_absolute = 0.;
       //@}
     };
 
@@ -192,12 +228,12 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline void
     Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
-      if (!view.compute_strict_bounds())
+      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
         return;
 
       /* entropy viscosity commutator: */
+
+      const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[p_i, gamma_min_i, s_i, new_eta_i] =
           precomputed_values.template get_tensor<Number, precomputed_type>(i);
@@ -216,6 +252,10 @@ namespace ryujin
 
       left = 0.;
       right = 0.;
+
+      left_absolute = 0.;
+      right_value = 0.;
+      right_absolute = 0.;
     }
 
 
@@ -225,12 +265,12 @@ namespace ryujin
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
-      if (!view.compute_strict_bounds())
+      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
         return;
 
       /* entropy viscosity commutator: */
+
+      const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto eta_j = view.surrogate_harten_entropy(U_j, gamma_min);
 
@@ -242,9 +282,28 @@ namespace ryujin
       const auto surrogate_p_j = view.surrogate_pressure(U_j, gamma_min);
       const auto f_j = view.f(U_j, surrogate_p_j);
 
-      left += (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
-      for (unsigned int k = 0; k < problem_dimension; ++k)
-        right[k] += (f_j[k] - f_i[k]) * c_ij;
+      const auto entropy_flux =
+          (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
+
+      if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
+        /* Entropy viscosity commutator with aggressive denominator split: */
+
+        left_absolute += std::abs(entropy_flux);
+        for (unsigned int k = 0; k < problem_dimension; ++k) {
+          const auto component = d_eta_i[k] * (f_j[k] - f_i[k]) * c_ij;
+          right_value += component;
+          right_absolute += std::abs(component);
+        }
+
+      } else {
+        /* Entropy viscosity commutator with conservative denominator split: */
+
+        left += entropy_flux;
+        for (unsigned int k = 0; k < problem_dimension; ++k) {
+          const auto component = (f_j[k] - f_i[k]) * c_ij;
+          right[k] += component;
+        }
+      }
     }
 
 
@@ -252,22 +311,35 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline Number
     Indicator<dim, Number>::alpha(const Number hd_i) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
-      if (!view.compute_strict_bounds())
+      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
         return Number(0.);
 
-      Number numerator = left;
-      Number denominator = std::abs(left);
-      for (unsigned int k = 0; k < problem_dimension; ++k) {
-        numerator -= d_eta_i[k] * right[k];
-        denominator += std::abs(d_eta_i[k] * right[k]);
+      if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
+        /* Entropy viscosity commutator with aggressive denominator split: */
+
+        Number numerator = left - right_value;
+        Number denominator = left_absolute + right_absolute;
+
+        const auto quotient =
+            std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
+
+        return std::min(Number(1.), parameters.evc_factor() * quotient);
+
+      } else {
+        /* Entropy viscosity commutator with conservative denominator split: */
+
+        Number numerator = left;
+        Number denominator = std::abs(left);
+        for (unsigned int k = 0; k < problem_dimension; ++k) {
+          numerator -= d_eta_i[k] * right[k];
+          denominator += std::abs(d_eta_i[k] * right[k]);
+        }
+
+        const auto quotient =
+            std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
+
+        return std::min(Number(1.), parameters.evc_factor() * quotient);
       }
-
-      const auto quotient =
-          std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
-
-      return std::min(Number(1.), parameters.evc_factor() * quotient);
     }
 
   } // namespace EulerAEOS

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -247,6 +247,11 @@ namespace ryujin
 
   private:
     /**
+     * Private methods used in prepare()
+     */
+    //@{
+
+    /**
      * Set up affine constraints and sparsity pattern. Internally used in
      * setup().
      */
@@ -337,6 +342,17 @@ namespace ryujin
         const ITERATOR1 &begin,
         const ITERATOR2 &end,
         const dealii::Utilities::MPI::Partitioner &partitioner) const;
+
+    //@}
+    /**
+     * @name Run time options
+     */
+    //@{
+
+    double incidence_relaxation_even_;
+    double incidence_relaxation_odd_;
+
+    //@}
   };
 
 } /* namespace ryujin */

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
@@ -49,6 +49,10 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
+  subsection indicator
+    set indicator strategy = galerkin
+  end
+
   subsection limiter
     set iterations            = 2
     set newton max iterations = 2

--- a/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
@@ -48,6 +48,10 @@ end
 subsection F - HyperbolicModule
   set cfl with boundary dofs        = true
 
+  subsection indicator
+    set indicator strategy = galerkin
+  end
+
   subsection limiter
     set iterations            = 2
     set newton max iterations = 2


### PR DESCRIPTION
Alright, this is the last bit we need for initial dG support. The pull request does two things:
 - First, it exposes the "relaxation order" r used for the incidence matrix for collocated degrees of freedom, roughly speaking: ((h_i + h_j)/2)^r
 - Second, it introduces a configuration parameter for the `Indicator` (currently implemented for Euler and EulerAEOS) that allows to switch to a more aggressive split for the denominator. Using this split recovers expected convergence rates for the isentropic vortex, rarefaction and LeBlanc. Furthermore, nonsmooth problems such as the Mach 3 Cylinder show a comparable resolution for dG Q1 versus cG Q1 for the same number of degrees of freedom (i.e. dG computed on a once coarsened mesh compared to cG).

Let's get this in. I will follow up with
 - some test vectors for the testsuite and some test vectors for the `benchmarks` category for dG Q0 and dG Q1.
 - implementing the same Indicator logic for shallow water and scalar conservation (which still need some testing).

