### PR TITLE
Change the debug output to match new function name.

### DIFF
--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -99,7 +99,7 @@ namespace ryujin
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "HyperbolicModule<Description, dim, "
-                 "Number>::apply_boundary_conditions()"
+                 "Number>::prepare_state_vector()"
               << std::endl;
 #endif
 


### PR DESCRIPTION
HyperbolicModule::apply_boundary_conditions has been renamed to HyperbolicModule::prepare_state_vector(), so the debug output should reflect this.