### PR TITLE
AMR preparation, part I: Clean up and refactor main loop

### DIFF
--- a/prm/benchmarks/euler-mach10-double-mach-reflection.prm
+++ b/prm/benchmarks/euler-mach10-double-mach-reflection.prm
@@ -19,12 +19,12 @@
 
 
 subsection A - TimeLoop
-  set basename                     = mach10-dbmr
+  set basename           = mach10-dbmr
 
-  set enable output full           = true
+  set enable output full = true
 
-  set final time                   = 0.20
-  set output granularity           = 0.01
+  set final time         = 0.20
+  set timer granularity  = 0.01
 end
 
 

--- a/prm/benchmarks/euler-mach3-cylinder-2d.prm
+++ b/prm/benchmarks/euler-mach3-cylinder-2d.prm
@@ -20,12 +20,12 @@
 ##
 
 subsection A - TimeLoop
-  set basename                     = mach3-cylinder-2d
+  set basename           = mach3-cylinder-2d
 
-  set enable output full           = true
+  set enable output full = true
 
-  set final time                   = 5.00
-  set output granularity           = 0.10
+  set final time         = 5.00
+  set timer granularity  = 0.10
 end
 
 

--- a/prm/benchmarks/euler-mach3-cylinder-3d.prm
+++ b/prm/benchmarks/euler-mach3-cylinder-3d.prm
@@ -26,24 +26,24 @@
 ##
 
 subsection A - TimeLoop
-  set basename                     = mach3-cylinder-3d
+  set basename                          = mach3-cylinder-3d
 
-  set enable checkpointing         = false
-  set enable output full           = false
+  set enable checkpointing              = false
+  set enable output full                = false
 
   #
   # Output reduced vtks only containing hexahedra that intersect with the
   # cutplanes x, y, z, and x^2+y^2-0.25*0.25 (as configured down below in
   # the "subsection I - VTUOutput").
   #
-  set enable output levelsets      = true
+  set enable output levelsets           = true
 
-  set final time                   = 5.00
-  set output granularity           = 0.10
+  set final time                        = 5.00
+  set timer granularity                 = 0.10
 
-  set output checkpoint multiplier = 1
-  set output full multiplier       = 10
-  set output levelsets multiplier  = 1
+  set timer checkpoint multiplier       = 1
+  set timer output full multiplier      = 10
+  set timer output levelsets multiplier = 1
 end
 
 

--- a/prm/benchmarks/euler-mach3-forward-facing-step.prm
+++ b/prm/benchmarks/euler-mach3-forward-facing-step.prm
@@ -23,12 +23,12 @@
 ##
 
 subsection A - TimeLoop
-  set basename                     = mach3-step
+  set basename           = mach3-step
 
-  set enable output full           = true
+  set enable output full = true
 
-  set final time                   = 4.00
-  set output granularity           = 0.10
+  set final time         = 4.00
+  set timer granularity  = 0.10
 end
 
 

--- a/prm/benchmarks/navier_stokes-daru-tenaud-shocktube.prm
+++ b/prm/benchmarks/navier_stokes-daru-tenaud-shocktube.prm
@@ -26,16 +26,16 @@
 ##
 
 subsection A - TimeLoop
-  set basename                     = shocktube-graded
+  set basename                            = shocktube-graded
 
-  set enable compute quantities    = true
-  set enable output full           = true
+  set enable compute quantities           = true
+  set enable output full                  = true
 
-  set final time                   = 1.00
-  set output granularity           = 0.01
+  set final time                          = 1.00
+  set timer granularity                   = 0.01
 
-  set output full multiplier       = 100
-  set output quantities multiplier = 1
+  set timer output full multiplier        = 100
+  set timer compute quantities multiplier = 1
 end
 
 subsection B - Equation

--- a/prm/benchmarks/scalar_conservation-kpp.prm
+++ b/prm/benchmarks/scalar_conservation-kpp.prm
@@ -16,12 +16,12 @@
 
 
 subsection A - TimeLoop
-  set basename                      = kpp
+  set basename                        = kpp
 
-  set enable output full            = true
+  set enable output full              = true
 
-  set final time                    = 1.00
-  set output granularity            = 1.00
+  set final time                      = 1.00
+  set timer granularity               = 1.00
 end
 
 

--- a/prm/benchmarks/shallow_water-G3-S2-experiment.prm
+++ b/prm/benchmarks/shallow_water-G3-S2-experiment.prm
@@ -24,18 +24,16 @@
 ##
 
 subsection A - TimeLoop
-  set basename                      = output-G2-S2
-  set final time                    = 50
+  set basename                            = output-G2-S2
 
-  set enable output full            = true
-  set output granularity            = 0.1
-  set output full multiplier        = 100 # Change to 1 for nice movie
+  set enable output full                  = true
+  set enable compute quantities           = true
 
-  set enable compute quantities     = true
-  set output quantities multiplier  = 100 
+  set final time                          = 50
+  set timer granularity                   = 0.1
 
-  set terminal show rank throughput = true
-  set terminal update interval      = 5
+  set timer output full multiplier        = 100 # Change to 1 for nice movie
+  set timer compute quantities multiplier = 100
 end
 
 subsection B - Equation

--- a/prm/todo/ideal-blast.prm
+++ b/prm/todo/ideal-blast.prm
@@ -1,9 +1,10 @@
 subsection A - TimeLoop
-  set basename                     = wc-blast-ideal
-  set enable output full           = true
-  set final time                   = 0.038
-  set output granularity           = 0.001
-  set terminal update interval     = 5
+  set basename           = wc-blast-ideal
+
+  set enable output full = true
+
+  set final time         = 0.038
+  set timer granularity  = 0.001
 end
 
 subsection B - Equation

--- a/prm/verification/euler-isentropic_vortex-erk22.prm
+++ b/prm/verification/euler-isentropic_vortex-erk22.prm
@@ -17,14 +17,14 @@
 subsection A - TimeLoop
   set basename             = isentropic_vortex-erk22
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = rho, m_1, m_2, E
 
+  set enable output full   = true
+
   set final time           = 2.0
-  set output granularity   = 2.0
+  set timer granularity    = 2.0
 end
 
 subsection B - Equation

--- a/prm/verification/euler-isentropic_vortex-erk33.prm
+++ b/prm/verification/euler-isentropic_vortex-erk33.prm
@@ -17,14 +17,14 @@
 subsection A - TimeLoop
   set basename             = isentropic_vortex-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = rho, m_1, m_2, E
 
+  set enable output full   = true
+
   set final time           = 2.0
-  set output granularity   = 2.0
+  set timer granularity    = 2.0
 end
 
 subsection B - Equation

--- a/prm/verification/euler-isentropic_vortex-ssprk33.prm
+++ b/prm/verification/euler-isentropic_vortex-ssprk33.prm
@@ -17,14 +17,14 @@
 subsection A - TimeLoop
   set basename             = isentropic_vortex-ssprk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = rho, m_1, m_2, E
 
+  set enable output full   = true
+
   set final time           = 2.0
-  set output granularity   = 2.0
+  set timer granularity    = 2.0
 end
 
 subsection B - Equation

--- a/prm/verification/euler-leblanc-erk33.prm
+++ b/prm/verification/euler-leblanc-erk33.prm
@@ -17,14 +17,14 @@
 subsection A - TimeLoop
   set basename             = leblanc-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = rho, m, E
 
+  set enable output full   = true
+
   set final time           = 0.66666666666667
-  set output granularity   = 0.66666666666667
+  set timer granularity    = 0.66666666666667
 end
 
 

--- a/prm/verification/euler-rarefaction_erk33.prm
+++ b/prm/verification/euler-rarefaction_erk33.prm
@@ -23,14 +23,14 @@
 subsection A - TimeLoop
   set basename             = rarefaction-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = rho, m, E
 
+  set enable output full   = true
+
   set final time           = 0.30558
-  set output granularity   = 0.30558
+  set timer granularity    = 0.30558
 end
 
 

--- a/prm/verification/euler-shock_front_erk33.prm
+++ b/prm/verification/euler-shock_front_erk33.prm
@@ -16,14 +16,14 @@
 subsection A - TimeLoop
   set basename             = shock_front-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = rho, m, E
 
+  set enable output full   = true
+
   set final time           = 0.25
-  set output granularity   = 0.25
+  set timer granularity    = 0.25
 end
 
 

--- a/prm/verification/euler-smooth_wave-erk33.prm
+++ b/prm/verification/euler-smooth_wave-erk33.prm
@@ -15,14 +15,14 @@
 subsection A - TimeLoop
   set basename             = smooth_wave-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = rho, m, E
 
+  set enable output full   = true
+
   set final time           = 0.60
-  set output granularity   = 0.60
+  set timer granularity    = 0.60
 end
 
 

--- a/prm/verification/linear_transport-time_stepping.prm
+++ b/prm/verification/linear_transport-time_stepping.prm
@@ -23,13 +23,13 @@
 subsection A - TimeLoop
   set basename             = linear_transport-time_stepping
 
-  set enable output full   = false
-
   set enable compute error = true
   set error normalize      = true
 
+  set enable output full   = false
+
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 end
 
 

--- a/prm/verification/navier_stokes-becker_solution-erk33.prm
+++ b/prm/verification/navier_stokes-becker_solution-erk33.prm
@@ -14,14 +14,14 @@
 subsection A - TimeLoop
   set basename             = becker_solution-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = rho, m, E
 
+  set enable output full   = true
+
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 end
 
 

--- a/prm/verification/shallow_water-paraboloid_1d-erk33.prm
+++ b/prm/verification/shallow_water-paraboloid_1d-erk33.prm
@@ -18,14 +18,14 @@
 subsection A - TimeLoop
   set basename             = paraboloid_1d-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = h
 
+  set enable output full   = true
+
   set final time           = 1345.71
-  set output granularity   = 1345.71
+  set timer granularity    = 1345.71
 end
 
 subsection B - Equation

--- a/prm/verification/shallow_water-paraboloid_2d-erk33.prm
+++ b/prm/verification/shallow_water-paraboloid_2d-erk33.prm
@@ -18,14 +18,14 @@
 subsection A - TimeLoop
   set basename             = paraboloid_2d-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = h
 
+  set enable output full   = true
+
   set final time           = 13.45710440
-  set output granularity   = 13.45710440
+  set timer granularity    = 13.45710440
 end
 
 subsection B - Equation

--- a/prm/verification/shallow_water-ritter_dam_break-erk33.prm
+++ b/prm/verification/shallow_water-ritter_dam_break-erk33.prm
@@ -17,14 +17,14 @@
 subsection A - TimeLoop
   set basename             = ritter_dam_break-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = h
 
+  set enable output full   = true
+
   set final time           = 6.0
-  set output granularity   = 6.0
+  set timer granularity    = 6.0
 end
 
 subsection B - Equation

--- a/prm/verification/shallow_water-smooth_vortex-erk33.prm
+++ b/prm/verification/shallow_water-smooth_vortex-erk33.prm
@@ -17,14 +17,14 @@
 subsection A - TimeLoop
   set basename             = smooth_vortex-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = h, m_1, m_2
 
+  set enable output full   = true
+
   set final time           = 2.0
-  set output granularity   = 2.0
+  set timer granularity    = 2.0
 end
 
 subsection B - Equation

--- a/source/equation_dispatch.h
+++ b/source/equation_dispatch.h
@@ -124,7 +124,7 @@ namespace ryujin
     /**
      * A structure that holds two Signals for equations:
      *  - one for creating and running the appropriate timeloop
-     *  - the other signal is used to create default parameter files.
+     *  - the other signal is used for creating default parameter files.
      */
     struct Signals {
       boost::signals2::signal<void()> create_parameter_files;
@@ -161,7 +161,7 @@ namespace ryujin
 
   /**
    * Create default parameter files for the specified equation Description,
-   * dimension and number type. This function is called form the respective
+   * dimension and number type. This function is called from the respective
    * equation driver.
    */
   template <typename Description, int dim, typename Number>
@@ -207,8 +207,8 @@ namespace ryujin
 
 
   /**
-   * A small Dispatch struct templated by an equation descriptions that
-   * registers the call backs.
+   * A small Dispatch struct templated in Description that registers the
+   * call backs.
    */
   template <typename Description, typename Number>
   struct Dispatch {

--- a/source/initial_values.template.h
+++ b/source/initial_values.template.h
@@ -247,6 +247,22 @@ namespace ryujin
     }
 
     U.update_ghost_values();
+
+#ifdef DEBUG
+    /* Poison constrained degrees of freedom: */
+    {
+      const unsigned int n_owned = offline_data_->n_locally_owned();
+      const auto &partitioner = offline_data_->scalar_partitioner();
+      for (unsigned int i = 0; i < n_owned; ++i) {
+        if (offline_data_->affine_constraints().is_constrained(
+                partitioner->local_to_global(i)))
+          U.write_tensor(dealii::Tensor<1, dim + 2, Number>() *
+                             std::numeric_limits<Number>::signaling_NaN(),
+                         i);
+      }
+    }
+#endif
+
     return U;
   }
 

--- a/source/main.cc
+++ b/source/main.cc
@@ -104,10 +104,10 @@ int main(int argc, char *argv[])
   if (!std::filesystem::exists(parameter_file)) {
     if (dealii::Utilities::MPI::this_mpi_process(mpi_communicator) == 0) {
       std::cout << "[INFO] Default parameter file »" << parameter_file
-                << "« not found.\n[INFO] Creating template parameter files..."
-                << std::endl;
+                << "« not found.\n[INFO] Creating template parameter files for "
+                << "you. Please modify and rename one of the templates to »"
+                << parameter_file << "«." << std::endl;
       ryujin::EquationDispatch::create_parameter_files();
-      std::filesystem::copy("default_parameters-euler-2d.prm", parameter_file);
     }
 
     MPI_Barrier(mpi_communicator);

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -118,7 +118,6 @@ namespace ryujin
     std::string base_name_;
 
     Number t_final_;
-    std::vector<Number> t_refinements_;
 
     Number output_granularity_;
 

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -118,19 +118,20 @@ namespace ryujin
     std::string base_name_;
 
     Number t_final_;
-
-    Number output_granularity_;
+    Number timer_granularity_;
 
     bool enable_checkpointing_;
     bool enable_output_full_;
     bool enable_output_levelsets_;
     bool enable_compute_error_;
     bool enable_compute_quantities_;
+    bool enable_mesh_adaptivity_;
 
-    unsigned int output_checkpoint_multiplier_;
-    unsigned int output_full_multiplier_;
-    unsigned int output_levelsets_multiplier_;
-    unsigned int output_quantities_multiplier_;
+    unsigned int timer_checkpoint_multiplier_;
+    unsigned int timer_output_full_multiplier_;
+    unsigned int timer_output_levelsets_multiplier_;
+    unsigned int timer_compute_quantities_multiplier_;
+    unsigned int timer_mesh_adaptivity_multiplier_;
 
     std::vector<std::string> error_quantities_;
     bool error_normalize_;

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -81,9 +81,9 @@ namespace ryujin
      */
     //@{
 
-    void compute_error(const StateVector &state_vector, Number t);
+    void compute_error(StateVector &state_vector, Number t);
 
-    void output(const StateVector &state_vector,
+    void output(StateVector &state_vector,
                 const std::string &name,
                 const Number t,
                 const unsigned int cycle);

--- a/tests/euler/verification-isentropic_vortex-2d-erk33-l5.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-erk33-l5.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l5
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler/verification-isentropic_vortex-2d-erk33-l6.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-erk33-l6.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l6
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler/verification-isentropic_vortex-2d-erk33-l7.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-erk33-l7.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l7
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler/verification-isentropic_vortex-2d-ssprk33-l5.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-ssprk33-l5.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l5
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler/verification-isentropic_vortex-2d-ssprk33-l6.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-ssprk33-l6.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l6
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler/verification-isentropic_vortex-2d-ssprk33-l7.prm
+++ b/tests/euler/verification-isentropic_vortex-2d-ssprk33-l7.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l7
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler/verification-leblanc-1d-erk33-l6.prm
+++ b/tests/euler/verification-leblanc-1d-erk33-l6.prm
@@ -5,7 +5,7 @@ subsection A - TimeLoop
   set error quantities     = rho, m, E
 
   set final time           = 0.66666666666667
-  set output granularity   = 0.66666666666667
+  set timer granularity    = 0.66666666666667
 
   set terminal update interval  = 0
 end

--- a/tests/euler/verification-rarefaction-1d-erk33-l6.prm
+++ b/tests/euler/verification-rarefaction-1d-erk33-l6.prm
@@ -5,7 +5,7 @@ subsection A - TimeLoop
   set error quantities     = rho, m, E
 
   set final time           = 0.30558
-  set output granularity   = 0.30558
+  set timer granularity    = 0.30558
 
   set terminal update interval  = 0
 end

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l5.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l5.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l5
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l6.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l6
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l7.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-erk33-l7.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l7
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l5.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l5.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l5
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l6.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l6.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l6
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l7.prm
+++ b/tests/euler_aeos/verification-isentropic_vortex-pge-2d-ssprk33-l7.prm
@@ -1,14 +1,11 @@
 subsection A - TimeLoop
   set basename                  = validation-euler-l7
 
-  set enable output full        = false
-  set enable compute quantities = false
-
   set enable compute error      = true
 
   set final time                = 2.0
 
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
   set terminal update interval  = 0
 end
 

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.prm
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6-strict.prm
@@ -5,7 +5,7 @@ subsection A - TimeLoop
   set error quantities     = rho, m, E
 
   set final time           = 0.66666666666667
-  set output granularity   = 0.66666666666667
+  set timer granularity    = 0.66666666666667
 
   set terminal update interval  = 0
 end

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
@@ -5,7 +5,7 @@ subsection A - TimeLoop
   set error quantities     = rho, m, E
 
   set final time           = 0.66666666666667
-  set output granularity   = 0.66666666666667
+  set timer granularity    = 0.66666666666667
 
   set terminal update interval  = 0
 end

--- a/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
@@ -5,7 +5,7 @@ subsection A - TimeLoop
   set error quantities     = rho, m, E
 
   set final time           = 0.30558
-  set output granularity   = 0.30558
+  set timer granularity    = 0.30558
 
   set terminal update interval  = 0
 end

--- a/tests/navier_stokes/gmg_energy.prm
+++ b/tests/navier_stokes/gmg_energy.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/gmg_velocity.prm
+++ b/tests/navier_stokes/gmg_velocity.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/gmg_velocity_energy.prm
+++ b/tests/navier_stokes/gmg_velocity_energy.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l5-2d.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l5-2d.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m_1, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l5.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l5.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l6.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l6.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/verification-becker_solution-erk_33-l7.prm
+++ b/tests/navier_stokes/verification-becker_solution-erk_33-l7.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l5-2d.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l5-2d.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m_1, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l5.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l5.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l6.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l6.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/navier_stokes/verification-becker_solution-ssprk_33-l7.prm
+++ b/tests/navier_stokes/verification-becker_solution-ssprk_33-l7.prm
@@ -5,7 +5,8 @@ subsection A - TimeLoop
   set error quantities          = rho, m, E
 
   set final time                = 2.0
-  set output granularity        = 2.0
+  set timer granularity         = 2.0
+
   set terminal update interval  = 0
 end
 

--- a/tests/scalar_conservation/verification-linear_transport-erk11.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk11.prm
@@ -1,13 +1,11 @@
 subsection A - TimeLoop
   set basename             = verification
 
-  set enable output full   = false
-
   set enable compute error = true
   set error normalize      = true
 
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 
   set terminal update interval  = 0
 end

--- a/tests/scalar_conservation/verification-linear_transport-erk22.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk22.prm
@@ -1,13 +1,11 @@
 subsection A - TimeLoop
   set basename             = verification
 
-  set enable output full   = false
-
   set enable compute error = true
   set error normalize      = true
 
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 
   set terminal update interval  = 0
 end

--- a/tests/scalar_conservation/verification-linear_transport-erk33.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk33.prm
@@ -1,13 +1,11 @@
 subsection A - TimeLoop
   set basename             = verification
 
-  set enable output full   = false
-
   set enable compute error = true
   set error normalize      = true
 
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 
   set terminal update interval  = 0
 end

--- a/tests/scalar_conservation/verification-linear_transport-erk43.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk43.prm
@@ -1,13 +1,11 @@
 subsection A - TimeLoop
   set basename             = verification
 
-  set enable output full   = false
-
   set enable compute error = true
   set error normalize      = true
 
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 
   set terminal update interval  = 0
 end

--- a/tests/scalar_conservation/verification-linear_transport-erk54.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk54.prm
@@ -1,13 +1,11 @@
 subsection A - TimeLoop
   set basename             = verification
 
-  set enable output full   = false
-
   set enable compute error = true
   set error normalize      = true
 
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 
   set terminal update interval  = 0
 end

--- a/tests/scalar_conservation/verification-linear_transport-ssprk22.prm
+++ b/tests/scalar_conservation/verification-linear_transport-ssprk22.prm
@@ -1,13 +1,11 @@
 subsection A - TimeLoop
   set basename             = verification
 
-  set enable output full   = false
-
   set enable compute error = true
   set error normalize      = true
 
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 
   set terminal update interval  = 0
 end

--- a/tests/scalar_conservation/verification-linear_transport-ssprk33.prm
+++ b/tests/scalar_conservation/verification-linear_transport-ssprk33.prm
@@ -1,13 +1,11 @@
 subsection A - TimeLoop
   set basename             = verification
 
-  set enable output full   = false
-
   set enable compute error = true
   set error normalize      = true
 
   set final time           = 2.00
-  set output granularity   = 2.00
+  set timer granularity    = 2.00
 
   set terminal update interval  = 0
 end

--- a/tests/shallow_water/verification-paraboloid_1d-erk33-l7.output
+++ b/tests/shallow_water/verification-paraboloid_1d-erk33-l7.output
@@ -5,10 +5,6 @@
 [INFO] preparing compute kernels
 [INFO] interpolating initial values
 [INFO] entering main loop
-[INFO] scheduling output
-[INFO] scheduling output
-[INFO] scheduling output
-[INFO] scheduling output
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 3201
 t     = 1345.774540174449

--- a/tests/shallow_water/verification-paraboloid_1d-erk33-l7.prm
+++ b/tests/shallow_water/verification-paraboloid_1d-erk33-l7.prm
@@ -18,14 +18,12 @@
 subsection A - TimeLoop
   set basename             = paraboloid_1d-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = h
 
   set final time           = 1345.71
-  set output granularity   = 1345.71
+  set timer granularity    = 1345.71
 
   set terminal update interval  = 0
 end

--- a/tests/shallow_water/verification-ritter_dam_break-erk33-l7.output
+++ b/tests/shallow_water/verification-ritter_dam_break-erk33-l7.output
@@ -5,13 +5,9 @@
 [INFO] preparing compute kernels
 [INFO] interpolating initial values
 [INFO] entering main loop
-[INFO] scheduling output
-[INFO] scheduling output
-[INFO] scheduling output
-[INFO] scheduling output
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 3201
-t     = 6.002065094435731
-Linf  = 0.001137042397958594
-L1    = 2.035435119886289e-05
-L2    = 6.232415634990906e-05
+t     = 6.002065094435738
+Linf  = 0.001137142985470178
+L1    = 2.034821089657167e-05
+L2    = 6.232030880580931e-05

--- a/tests/shallow_water/verification-ritter_dam_break-erk33-l7.prm
+++ b/tests/shallow_water/verification-ritter_dam_break-erk33-l7.prm
@@ -17,14 +17,12 @@
 subsection A - TimeLoop
   set basename             = ritter_dam_break-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = h
 
   set final time           = 6.0
-  set output granularity   = 6.0
+  set timer granularity    = 6.0
 
   set terminal update interval  = 0
 end

--- a/tests/shallow_water/verification-smooth_vortex-erk33-l6.output
+++ b/tests/shallow_water/verification-smooth_vortex-erk33-l6.output
@@ -5,13 +5,9 @@
 [INFO] preparing compute kernels
 [INFO] interpolating initial values
 [INFO] entering main loop
-[INFO] scheduling output
-[INFO] scheduling output
-[INFO] scheduling output
-[INFO] scheduling output
 Normalized consolidated Linf, L1, and L2 errors at final time 
 #dofs = 4225
 t     = 2.001005728507654
-Linf  = 0.03571394823663543
-L1    = 0.0006325612013500107
-L2    = 0.003420776846038924
+Linf  = 0.03571394823661699
+L1    = 0.0006325612013505061
+L2    = 0.003420776846038435

--- a/tests/shallow_water/verification-smooth_vortex-erk33-l6.prm
+++ b/tests/shallow_water/verification-smooth_vortex-erk33-l6.prm
@@ -17,14 +17,12 @@
 subsection A - TimeLoop
   set basename             = smooth_vortex-erk33
 
-  set enable output full   = true
-
   set enable compute error = true
   set error normalize      = true
   set error quantities     = h, m_1, m_2
 
   set final time           = 2.0
-  set output granularity   = 2.0
+  set timer granularity    = 2.0
 
   set terminal update interval  = 0
 end

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.output
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.output
@@ -5,13 +5,9 @@
 [INFO] preparing compute kernels
 [INFO] interpolating initial values
 [INFO] entering main loop
-[INFO] scheduling output
-[INFO] scheduling output
-[INFO] scheduling output
-[INFO] scheduling output
 Normalized consolidated Linf, L1, and L2 errors at final time
 #dofs = 513
 t     = 1.000593578808362
-Linf  = 2.073541977120867e-14
-L1    = 3.827527652098191e-15
-L2    = 4.904868710241667e-15
+Linf  = 2.388278346583212e-14
+L1    = 4.287451614926996e-15
+L2    = 5.452329602107318e-15

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.prm
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.prm
@@ -17,13 +17,12 @@
 subsection A - TimeLoop
   set basename                      = steady_incline_1d-erk33-l9
 
-  set final time                    = 1
-  set enable output full            = true
-  set output granularity            = 1
-
   set enable compute error          = true
   set error quantities              = h, m
   set error normalize               = true
+
+  set final time                    = 1.0
+  set timer granularity             = 1.0
 
   set terminal update interval      = 0
 


### PR DESCRIPTION
This pull request renames a couple of configuration options which might be slightly annoying. But we want to repurpose the old `output granularity` timer now also for mesh adaptivity and the configuration option name becomes awkward. 

Apart from renaming some configuration options I take the opportunity and simplify some logic in the main loop.