### PR TITLE
Add debug asserts for verifying that the c_ij matrix is correctly assembled

### DIFF
--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -777,10 +777,11 @@ namespace ryujin
 #ifdef DEAL_II_WITH_TRILINOS
       ScalarVector one(scalar_partitioner_);
       one = 1.;
+      affine_constraints_assembly.set_zero(one);
 
       ScalarVector local_lumped_mass_matrix(scalar_partitioner_);
       mass_matrix_tmp.vmult(local_lumped_mass_matrix, one);
-      lumped_mass_matrix_.compress(VectorOperation::add);
+      local_lumped_mass_matrix.compress(VectorOperation::add);
 
       for (unsigned int i = 0; i < scalar_partitioner_->locally_owned_size();
            ++i) {
@@ -796,6 +797,7 @@ namespace ryujin
 
       dealii::Vector<Number> one(mass_matrix_tmp.m());
       one = 1.;
+      affine_constraints_assembly.set_zero(one);
 
       dealii::Vector<Number> local_lumped_mass_matrix(mass_matrix_tmp.m());
       mass_matrix_tmp.vmult(local_lumped_mass_matrix, one);

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -127,6 +127,22 @@ namespace ryujin
 
     affine_constraints_.close();
 
+#ifdef DEBUG
+    {
+      /* Check that constraints are consistent in parallel: */
+      const std::vector<IndexSet> &locally_owned_dofs =
+          Utilities::MPI::all_gather(mpi_communicator_,
+                                     dof_handler.locally_owned_dofs());
+      const IndexSet locally_active =
+          dealii::DoFTools::extract_locally_active_dofs(dof_handler);
+      Assert(affine_constraints_.is_consistent_in_parallel(locally_owned_dofs,
+                                                           locally_active,
+                                                           mpi_communicator_,
+                                                           /*verbose*/ true),
+             ExcInternalError());
+    }
+#endif
+
     sparsity_pattern_.reinit(
         dof_handler.n_dofs(), dof_handler.n_dofs(), locally_relevant);
 


### PR DESCRIPTION
This PR adds a couple of expensive checks run in debug mode that verifies that the local view of the `cij_matrix_` object is consistent. We are currently triggering some of these asserts with local refinement.

@kronbichler *ping*