### PR TITLE
`SparsityPatternSIMD`: Bugfix: make MPI rank matching more robust

### DIFF
--- a/source/sparse_matrix_simd.template.h
+++ b/source/sparse_matrix_simd.template.h
@@ -203,10 +203,16 @@ namespace ryujin
       for (unsigned int p = 0; p < partitioner->import_targets().size(); ++p) {
 
         /*
-         * Match up processor index between receive and import targets. If
+         * Match up the rank index between receive and import targets. If
          * we do not find a match, which can happen for locally refined
-         * meshes - then set p_match equal to receive_targests.size().
+         * meshes, then we set p_match equal to receive_targests.size().
+         *
+         * When trying to match the next processor index we consequently
+         * have to reset p_match to 0 again. This assumes that processor
+         * indices are sorted in the receive_targets and ghost_targets
+         * vectors.
          */
+        p_match = (p_match == receive_targets.size() ? 0 : p_match);
         while (p_match < receive_targets.size() &&
                receive_targets[p_match].first !=
                    partitioner->import_targets()[p].first)


### PR DESCRIPTION
With locally refined meshes and hanging node constraints we might end up in a situation where an MPI rank in the import_targets set does not show up in the ghost_targets set. This is not a problem as we "minimize" the sparsity pattern in (ghosted) locally owned rows to only contain entries that we have in the locally relevant ranges of the tansposed locally owned rows.

BUT, for the next MPI rank we have to try to match up from index 0 again.

@kronbichler *ping*

Closes #136