### PR TITLE
`Discretization`: Remove mesh repartitioning

### DIFF
--- a/prm/benchmarks/euler-mach10-double-mach-reflection.prm
+++ b/prm/benchmarks/euler-mach10-double-mach-reflection.prm
@@ -39,7 +39,6 @@ subsection C - Discretization
   set geometry            = wall
 
   set mesh refinement     = 7
-  set mesh repartitioning = false
 
   subsection wall
     set height        = 1

--- a/prm/benchmarks/euler-mach3-cylinder-2d.prm
+++ b/prm/benchmarks/euler-mach3-cylinder-2d.prm
@@ -40,7 +40,6 @@ subsection C - Discretization
   set geometry            = cylinder
 
   set mesh refinement     = 8
-  set mesh repartitioning = false
 
   subsection cylinder
     set height          = 2

--- a/prm/benchmarks/euler-mach3-cylinder-3d.prm
+++ b/prm/benchmarks/euler-mach3-cylinder-3d.prm
@@ -58,7 +58,6 @@ subsection C - Discretization
   set geometry            = cylinder
 
   set mesh refinement     = 6
-  set mesh repartitioning = false
 
   subsection cylinder
     set height          = 2

--- a/prm/benchmarks/euler-mach3-forward-facing-step.prm
+++ b/prm/benchmarks/euler-mach3-forward-facing-step.prm
@@ -43,7 +43,6 @@ subsection C - Discretization
   set geometry            = step
 
   set mesh refinement     = 3
-  set mesh repartitioning = false
 
   subsection step
     set height        = 1

--- a/prm/benchmarks/navier_stokes-daru-tenaud-shocktube.prm
+++ b/prm/benchmarks/navier_stokes-daru-tenaud-shocktube.prm
@@ -52,7 +52,6 @@ end
 subsection C - Discretization
   set geometry            = rectangular domain
   set mesh refinement     = 10
-  set mesh repartitioning = true
 
   subsection rectangular domain
     set boundary condition bottom = no slip

--- a/prm/benchmarks/scalar_conservation-kpp.prm
+++ b/prm/benchmarks/scalar_conservation-kpp.prm
@@ -36,7 +36,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 10
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition bottom = dirichlet

--- a/prm/todo/ideal-blast.prm
+++ b/prm/todo/ideal-blast.prm
@@ -25,7 +25,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
   set mesh distortion     = 0
   set mesh refinement     = 10
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left  = slip

--- a/prm/verification/linear_transport-time_stepping.prm
+++ b/prm/verification/linear_transport-time_stepping.prm
@@ -50,7 +50,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 11
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left   = periodic

--- a/source/discretization.h
+++ b/source/discretization.h
@@ -358,7 +358,6 @@ namespace ryujin
 
     bool mesh_writeout_;
     double mesh_distortion_;
-    bool mesh_repartitioning_;
 
     //@}
     /**

--- a/source/discretization.template.h
+++ b/source/discretization.template.h
@@ -74,11 +74,6 @@ namespace ryujin
     add_parameter(
         "mesh distortion", mesh_distortion_, "Strength of mesh distortion");
 
-    mesh_repartitioning_ = false;
-    add_parameter("mesh repartitioning",
-                  mesh_repartitioning_,
-                  "try to equalize workload by repartitioning the mesh");
-
     Geometries::populate_geometry_list<dim>(geometry_list_, subsection);
   }
 
@@ -120,47 +115,6 @@ namespace ryujin
       std::ofstream file(base_name + "-coarse_grid.msh");
       grid_out.write_msh(triangulation, file);
 #endif
-    }
-
-    if constexpr (have_distributed_triangulation<dim>) {
-      if (mesh_repartitioning_) {
-        /*
-         * Try to partition the mesh equilibrating the workload. The usual mesh
-         * partitioning heuristic that tries to partition the mesh such that
-         * every MPI rank has roughly the same number of locally owned degrees
-         * of freedom does not work well in our case due to the fact that
-         * boundary dofs are not SIMD parallelized. (In fact, every dof with
-         * "non-standard connectivity" is not SIMD parallelized. Those are
-         * however exceedingly rare (point irregularities in 2D, line
-         * irregularities in 3D) and we simply ignore them.)
-         *
-         * For the mesh partitioning scheme we have to supply an additional
-         * weight that gets added to the default weight of a cell which is
-         * 1000. Asymptotically we have one boundary dof per boundary cell (in
-         * any dimension). A rough benchmark reveals that the speedup due to
-         * SIMD vectorization is typically less than VectorizedArray::size() /
-         * 2. Boundary dofs are more expensive due to certain special treatment
-         * (additional symmetrization of d_ij, boundary fixup) so it should be
-         * safe to assume that the cost incurred is at least
-         * VectorizedArray::size() / 2.
-         */
-        constexpr auto speedup = dealii::VectorizedArray<NUMBER>::size() / 2u;
-        constexpr unsigned int weight = 1000u;
-
-#if DEAL_II_VERSION_GTE(9, 5, 0)
-        triangulation.signals.weight.connect(
-#else
-        triangulation.signals.cell_weight.connect(
-#endif
-            [](const auto &cell, const auto /*status*/) -> unsigned int {
-              if (cell->at_boundary())
-                return weight * (speedup == 0u ? 0u : speedup - 1u);
-              else
-                return 0u;
-            });
-
-        triangulation.repartition();
-      }
     }
 
     triangulation.refine_global(refinement_);

--- a/tests/scalar_conservation/verification-linear_transport-erk11.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk11.prm
@@ -28,7 +28,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 9
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left   = periodic

--- a/tests/scalar_conservation/verification-linear_transport-erk22.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk22.prm
@@ -28,7 +28,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 9
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left   = periodic

--- a/tests/scalar_conservation/verification-linear_transport-erk33.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk33.prm
@@ -28,7 +28,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 9
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left   = periodic

--- a/tests/scalar_conservation/verification-linear_transport-erk43.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk43.prm
@@ -28,7 +28,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 9
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left   = periodic

--- a/tests/scalar_conservation/verification-linear_transport-erk54.prm
+++ b/tests/scalar_conservation/verification-linear_transport-erk54.prm
@@ -28,7 +28,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 9
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left   = periodic

--- a/tests/scalar_conservation/verification-linear_transport-ssprk22.prm
+++ b/tests/scalar_conservation/verification-linear_transport-ssprk22.prm
@@ -28,7 +28,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 9
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left   = periodic

--- a/tests/scalar_conservation/verification-linear_transport-ssprk33.prm
+++ b/tests/scalar_conservation/verification-linear_transport-ssprk33.prm
@@ -28,7 +28,6 @@ subsection C - Discretization
   set geometry            = rectangular domain
 
   set mesh refinement     = 9
-  set mesh repartitioning = false
 
   subsection rectangular domain
     set boundary condition left   = periodic


### PR DESCRIPTION
This logic is just plain faulty. Let's remove it for now.