### PR TITLE
Quantities: simplify convoluted cycle logic

### DIFF
--- a/source/quantities.h
+++ b/source/quantities.h
@@ -68,9 +68,7 @@ namespace ryujin
      *
      * The string parameter @p name is used as base name for output files.
      */
-    void prepare(const std::string &name,
-                 unsigned int cycle,
-                 unsigned int output_granularity);
+    void prepare(const std::string &name, unsigned int cycle);
 
     /**
      * Takes a state vector @p U at time t (obtained at the end of a full

--- a/source/quantities.h
+++ b/source/quantities.h
@@ -68,7 +68,7 @@ namespace ryujin
      *
      * The string parameter @p name is used as base name for output files.
      */
-    void prepare(const std::string &name, unsigned int cycle);
+    void prepare(const std::string &name);
 
     /**
      * Takes a state vector @p U at time t (obtained at the end of a full
@@ -209,6 +209,10 @@ namespace ryujin
      * @name Internal methods
      */
     //@{
+
+    bool mesh_files_have_been_written_;
+
+    void write_mesh_files(unsigned int cycle);
 
     void clear_statistics();
 

--- a/source/quantities.template.h
+++ b/source/quantities.template.h
@@ -88,10 +88,8 @@ namespace ryujin
 
 
   template <typename Description, int dim, typename Number>
-  void
-  Quantities<Description, dim, Number>::prepare(const std::string &name,
-                                                unsigned int cycle,
-                                                unsigned int output_granularity)
+  void Quantities<Description, dim, Number>::prepare(const std::string &name,
+                                                     unsigned int cycle)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "Quantities<dim, Number>::prepare()" << std::endl;
@@ -208,10 +206,8 @@ namespace ryujin
 
       if (Utilities::MPI::this_mpi_process(mpi_communicator_) == 0) {
 
-        std::ofstream output(
-            base_name_ + "-" + name + "-R" +
-            Utilities::to_string(cycle + output_granularity, 4) +
-            "-points.dat");
+        std::ofstream output(base_name_ + "-" + name + "-R" +
+                             Utilities::to_string(cycle, 4) + "-points.dat");
 
         output << std::scientific << std::setprecision(14);
 
@@ -292,10 +288,8 @@ namespace ryujin
 
       if (Utilities::MPI::this_mpi_process(mpi_communicator_) == 0) {
 
-        std::ofstream output(
-            base_name_ + "-" + name + "-R" +
-            Utilities::to_string(cycle + output_granularity, 4) +
-            "-points.dat");
+        std::ofstream output(base_name_ + "-" + name + "-R" +
+                             Utilities::to_string(cycle, 4) + "-points.dat");
 
         output << std::scientific << std::setprecision(14);
 

--- a/source/quantities.template.h
+++ b/source/quantities.template.h
@@ -615,13 +615,16 @@ namespace ryujin
           auto &[val_old, val_new, val_sum, t_old, t_new, t_sum] =
               statistics[name];
 
-          std::stringstream time_stamp;
-          time_stamp << std::scientific << std::setprecision(14);
-          time_stamp << "# averaged from t = " << t_new - t_sum
-                     << " to t = " << t_new << std::endl;
+          /* Check whether we have accumulated any statistics yet: */
+          if (t_sum != Number(0.)) {
+            std::stringstream time_stamp;
+            time_stamp << std::scientific << std::setprecision(14);
+            time_stamp << "# averaged from t = " << t_new - t_sum
+                       << " to t = " << t_new << std::endl;
 
-          internal_write_out(
-              file_name, time_stamp.str(), val_sum, Number(1.) / t_sum);
+            internal_write_out(
+                file_name, time_stamp.str(), val_sum, Number(1.) / t_sum);
+          }
         }
 
         /*

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -412,7 +412,7 @@ namespace ryujin
       compute_error(state_vector, t);
     }
 
-    if (debug_filename_ != "") {
+    if (mpi_rank_ == 0 && debug_filename_ != "") {
       std::ifstream f(debug_filename_);
       if (f.is_open())
         std::cout << f.rdbuf();

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -241,8 +241,7 @@ namespace ryujin
       mesh_adaptor_.prepare(/*needs current timepoint*/ t);
       postprocessor_.prepare();
       vtu_output_.prepare();
-      quantities_.prepare(
-          base_name_, timer_cycle, timer_compute_quantities_multiplier_);
+      quantities_.prepare(base_name_, timer_cycle);
       print_mpi_partition(logfile_);
     };
 
@@ -270,8 +269,7 @@ namespace ryujin
         }
 
         /* Workaround: Reinitialize quantities with correct output cycle: */
-        quantities_.prepare(
-            base_name_, timer_cycle, timer_compute_quantities_multiplier_);
+        quantities_.prepare(base_name_, timer_cycle);
 
       } else {
 

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -359,8 +359,7 @@ namespace ryujin
         }
 
         if (enable_compute_quantities_ &&
-            (timer_cycle % timer_compute_quantities_multiplier_ == 0) &&
-            (timer_cycle > 0)) {
+            (timer_cycle % timer_compute_quantities_multiplier_ == 0)) {
           Scope scope(computing_timer_,
                       "time step [X]   - write out quantities");
           quantities_.write_out(state_vector, t, timer_cycle);

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -241,7 +241,7 @@ namespace ryujin
       mesh_adaptor_.prepare(/*needs current timepoint*/ t);
       postprocessor_.prepare();
       vtu_output_.prepare();
-      quantities_.prepare(base_name_, timer_cycle);
+      quantities_.prepare(base_name_);
       print_mpi_partition(logfile_);
     };
 
@@ -267,9 +267,6 @@ namespace ryujin
           t = 0.;
           timer_cycle = 0;
         }
-
-        /* Workaround: Reinitialize quantities with correct output cycle: */
-        quantities_.prepare(base_name_, timer_cycle);
 
       } else {
 

--- a/tests/euler/check-mass-conservation_01.prm
+++ b/tests/euler/check-mass-conservation_01.prm
@@ -9,7 +9,7 @@ subsection A - TimeLoop
 
   set terminal update interval  = 0
 
-  set debug filename            = test-interior-R0001-space_averaged_time_series.dat
+  set debug filename            = test-interior-R0000-space_averaged_time_series.dat
 end
 
 subsection B - Equation

--- a/tests/euler/check-mass-conservation_02.prm
+++ b/tests/euler/check-mass-conservation_02.prm
@@ -9,7 +9,7 @@ subsection A - TimeLoop
 
   set terminal update interval  = 0
 
-  set debug filename            = test-interior-R0001-space_averaged_time_series.dat
+  set debug filename            = test-interior-R0000-space_averaged_time_series.dat
 end
 
 subsection B - Equation


### PR DESCRIPTION
This PR addresses some long standing logic issues we have in the Quantities object when it comes to computing the correct cycle number. Simplify the logic by deferring the writout of mesh files to the first time we output an instantaneous or time-averaged vector field. That way we know the correct cycle number without playing a guessing game.
