### PR TITLE
`MeshAdaptor`: update configuration file options

### DIFF
--- a/prm/benchmarks/euler-mach10-double-mach-reflection.prm
+++ b/prm/benchmarks/euler-mach10-double-mach-reflection.prm
@@ -70,7 +70,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set use mpi io     = true
   set schlieren beta = 10
 end

--- a/prm/benchmarks/euler-mach3-cylinder-2d.prm
+++ b/prm/benchmarks/euler-mach3-cylinder-2d.prm
@@ -73,7 +73,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set use mpi io     = true
   set schlieren beta = 10
 end

--- a/prm/benchmarks/euler-mach3-cylinder-3d.prm
+++ b/prm/benchmarks/euler-mach3-cylinder-3d.prm
@@ -34,7 +34,7 @@ subsection A - TimeLoop
   #
   # Output reduced vtks only containing hexahedra that intersect with the
   # cutplanes x, y, z, and x^2+y^2-0.25*0.25 (as configured down below in
-  # the "subsection I - VTUOutput").
+  # the "subsection J - VTUOutput").
   #
   set enable output levelsets           = true
 
@@ -91,7 +91,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds      = x, y, z, x^2+y^2-0.25*0.25
 
   set use mpi io     = true

--- a/prm/benchmarks/euler-mach3-forward-facing-step.prm
+++ b/prm/benchmarks/euler-mach3-forward-facing-step.prm
@@ -76,7 +76,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set use mpi io     = true
   set schlieren beta = 10
 end

--- a/prm/benchmarks/navier_stokes-daru-tenaud-shocktube.prm
+++ b/prm/benchmarks/navier_stokes-daru-tenaud-shocktube.prm
@@ -105,13 +105,13 @@ subsection H - TimeIntegrator
   set time stepping scheme  = strang erk 33 cn
 end
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set schlieren beta = 10
   set use mpi io     = true
 end
 
 
-subsection J - Quantities
+subsection K - Quantities
   set boundary manifolds = lower_boundary : y : time_averaged space_averaged
   set interior manifolds =
 end

--- a/prm/benchmarks/scalar_conservation-kpp.prm
+++ b/prm/benchmarks/scalar_conservation-kpp.prm
@@ -78,7 +78,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set schlieren quantities =
   set use mpi io           = true
 end

--- a/prm/benchmarks/shallow_water-G3-S2-experiment.prm
+++ b/prm/benchmarks/shallow_water-G3-S2-experiment.prm
@@ -109,7 +109,7 @@ subsection H - TimeIntegrator
   set time stepping scheme  = erk 43
 end
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds                  = 
   set schlieren beta             = 10
   set schlieren quantities       = h
@@ -118,7 +118,7 @@ subsection I - VTUOutput
   set vtu output quantities      = h, m_1, m_2, bathymetry, alpha, v_1
 end
 
-subsection J - Quantities
+subsection K - Quantities
   set clear statistics on writeout = true
   set interior manifolds = lineout-x : x - 2.40 : instantaneous, \
                            lineout-y : y - 0.   : instantaneous  

--- a/prm/todo/ideal-blast.prm
+++ b/prm/todo/ideal-blast.prm
@@ -68,7 +68,7 @@ subsection H - TimeIntegrator
   set time stepping scheme  = erk 33
 end
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds                  = 
   set schlieren beta             = 10
   set schlieren quantities       = 

--- a/prm/verification/euler-leblanc-erk33.prm
+++ b/prm/verification/euler-leblanc-erk33.prm
@@ -78,7 +78,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds      =
   set use mpi io     = true
   set schlieren beta = 10

--- a/prm/verification/euler-rarefaction_erk33.prm
+++ b/prm/verification/euler-rarefaction_erk33.prm
@@ -83,7 +83,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds      =
   set use mpi io     = true
   set schlieren beta = 10

--- a/prm/verification/euler-shock_front_erk33.prm
+++ b/prm/verification/euler-shock_front_erk33.prm
@@ -76,7 +76,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds      =
   set use mpi io     = true
   set schlieren beta = 10

--- a/prm/verification/euler-smooth_wave-erk33.prm
+++ b/prm/verification/euler-smooth_wave-erk33.prm
@@ -75,7 +75,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds      =
   set use mpi io     = true
   set schlieren beta = 10

--- a/prm/verification/navier_stokes-becker_solution-erk33.prm
+++ b/prm/verification/navier_stokes-becker_solution-erk33.prm
@@ -93,7 +93,7 @@ subsection H - TimeIntegrator
 end
 
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds      =
   set use mpi io     = true
   set schlieren beta = 10

--- a/source/mesh_adaptor.h
+++ b/source/mesh_adaptor.h
@@ -87,8 +87,8 @@ namespace ryujin
     void prepare(const Number t);
 
     /**
-     * Analyze the given StateVector and decide - depending on adaptation
-     * strategy - whether a mesh adaptation cycle should be performed.
+     * Analyze the given StateVector with the configured adaptation strategy
+     * and decide whether a mesh adaptation cycle should be performed.
      */
     void analyze(const StateVector &state_vector,
                  const Number t,

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -134,7 +134,6 @@ namespace ryujin
     unsigned int timer_output_full_multiplier_;
     unsigned int timer_output_levelsets_multiplier_;
     unsigned int timer_compute_quantities_multiplier_;
-    unsigned int timer_mesh_adaptivity_multiplier_;
 
     std::vector<std::string> error_quantities_;
     bool error_normalize_;

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -58,17 +58,17 @@ namespace ryujin
                        offline_data_,
                        hyperbolic_system_,
                        parabolic_system_,
-                       "/I - VTUOutput")
+                       "/J - VTUOutput")
       , vtu_output_(mpi_communicator_,
                     offline_data_,
                     hyperbolic_module_,
                     postprocessor_,
-                    "/I - VTUOutput")
+                    "/J - VTUOutput")
       , quantities_(mpi_communicator_,
                     offline_data_,
                     hyperbolic_system_,
                     parabolic_system_,
-                    "/J - Quantities")
+                    "/K - Quantities")
       , mpi_rank_(dealii::Utilities::MPI::this_mpi_process(mpi_communicator_))
       , n_mpi_processes_(
             dealii::Utilities::MPI::n_mpi_processes(mpi_communicator_))

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -157,13 +157,6 @@ namespace ryujin
         "Multiplicative modifier applied to \"timer granularity\" that "
         "determines the writeout granularity for quantities of interest");
 
-    timer_mesh_adaptivity_multiplier_ = 1;
-    add_parameter(
-        "timer mesh adaptivity multiplier",
-        timer_compute_quantities_multiplier_,
-        "Multiplicative modifier applied to \"timer granularity\" that "
-        "determines the call granularity to MeshAdaptor::analyze()");
-
     std::copy(std::begin(View::component_names),
               std::end(View::component_names),
               std::back_inserter(error_quantities_));
@@ -320,6 +313,27 @@ namespace ryujin
         quantities_.accumulate(state_vector, t);
       }
 
+      /* Peform a adaptation: */
+
+      if (enable_mesh_adaptivity_) {
+        {
+          Scope scope(computing_timer_,
+                      "time step [X]   - analyze for mesh adaptation");
+
+          mesh_adaptor_.analyze(state_vector, t, cycle);
+        }
+
+        if (mesh_adaptor_.need_mesh_adaptation() && t < t_final_) {
+          Scope scope(computing_timer_, "(re)initialize data structures");
+          print_info("performing mesh adaptation");
+
+          mesh_adaptor_.adapt_mesh_and_transfer_state_vector(
+              discretization_.triangulation(),
+              state_vector,
+              prepare_compute_kernels);
+        }
+      }
+
       /*
        * Perform various tasks whenever we reach a timer tick:
        */
@@ -350,22 +364,6 @@ namespace ryujin
           Scope scope(computing_timer_,
                       "time step [X]   - write out quantities");
           quantities_.write_out(state_vector, t, timer_cycle);
-        }
-
-        if (enable_mesh_adaptivity_) {
-          Scope scope(computing_timer_,
-                      "time step [X]   - analyze for mesh adaptation");
-          mesh_adaptor_.analyze(state_vector, t, timer_cycle);
-        }
-
-        if (mesh_adaptor_.need_mesh_adaptation() && t < t_final_) {
-          Scope scope(computing_timer_, "(re)initialize data structures");
-          print_info("performing mesh adaptation");
-
-          mesh_adaptor_.adapt_mesh_and_transfer_state_vector(
-              discretization_.triangulation(),
-              state_vector,
-              prepare_compute_kernels);
         }
 
         ++timer_cycle;

--- a/tests/euler/check-mass-conservation_01.prm
+++ b/tests/euler/check-mass-conservation_01.prm
@@ -43,6 +43,6 @@ subsection H - TimeIntegrator
   set time stepping scheme  = ssprk 33
 end
 
-subsection J - Quantities
+subsection K - Quantities
   set interior manifolds           = interior : 0. : space_averaged
 end

--- a/tests/euler/check-mass-conservation_02.prm
+++ b/tests/euler/check-mass-conservation_02.prm
@@ -37,6 +37,6 @@ subsection H - TimeIntegrator
   set time stepping scheme  = ssprk 33
 end
 
-subsection J - Quantities
+subsection K - Quantities
   set interior manifolds           = interior : 0. : space_averaged
 end

--- a/tests/shallow_water/verification-steady_incline-erk33-l9.prm
+++ b/tests/shallow_water/verification-steady_incline-erk33-l9.prm
@@ -76,7 +76,7 @@ subsection H - TimeIntegrator
   set time stepping scheme  = erk 33
 end
 
-subsection I - VTUOutput
+subsection J - VTUOutput
   set manifolds                  = 
   set schlieren beta             = 10
   set schlieren quantities       = h


### PR DESCRIPTION
This is a breaking change for configuration files. In order to properly put in the MeshAdaptor we need to shift two section names. Furthermore, decouple the analyze() function from the timer ticks in the TimeLoop.
