### PR TITLE
TimeLoop: avoid an integer wrap around when padding the statistics header

### DIFF
--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -1266,15 +1266,15 @@ namespace ryujin
     if (mpi_rank_ != 0)
       return;
 
-    const auto header_size = header.size();
-    const auto padded_header = std::string((34 - header_size) / 2, ' ') +
-                               header +
-                               std::string((35 - header_size) / 2, ' ');
+    const int header_size = header.size();
+    const auto padded_header =
+        std::string(std::max(0, 34 - header_size) / 2, ' ') + header +
+        std::string(std::max(0, 35 - header_size) / 2, ' ');
 
-    const auto secondary_size = secondary.size();
-    const auto padded_secondary = std::string((34 - secondary_size) / 2, ' ') +
-                                  secondary +
-                                  std::string((35 - secondary_size) / 2, ' ');
+    const int secondary_size = secondary.size();
+    const auto padded_secondary =
+        std::string(std::max(0, 34 - secondary_size) / 2, ' ') + secondary +
+        std::string(std::max(0, 35 - secondary_size) / 2, ' ');
 
     /* clang-format off */
     stream << "\n";


### PR DESCRIPTION
Normally we cannot trigger this because the formatted strings are always small enough. But under exceptional circumstances (i.e. when writing a new PDE module and having a bug that crashes the computation) we can occasionally run into this. Just fix it so that we can crash somewhere else.