### PR TITLE
`Euler`/`EulerAeos::Indicator`: remove all indicator variants except entropy-viscosity commutator

### DIFF
--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -14,30 +14,6 @@
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/vectorization.h>
 
-
-namespace ryujin
-{
-  namespace Euler
-  {
-    enum class IndicatorStrategy {
-      /** Indicator returns constant 0 */
-      galerkin,
-      /** The classical entropy viscosity commutator */
-      evc,
-      /** Entropy viscosity with more aggressive denominator split */
-      evc_fullsplit,
-    };
-  }
-} // namespace ryujin
-
-#ifndef DOXYGEN
-DECLARE_ENUM(ryujin::Euler::IndicatorStrategy,
-             LIST({ryujin::Euler::IndicatorStrategy::galerkin, "galerkin"},
-                  {ryujin::Euler::IndicatorStrategy::evc, "entropy viscosity"},
-                  {ryujin::Euler::IndicatorStrategy::evc_fullsplit,
-                   "entropy viscosity full split"}));
-#endif
-
 namespace ryujin
 {
   namespace Euler
@@ -49,25 +25,15 @@ namespace ryujin
       IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
-        indicator_strategy_ = IndicatorStrategy::evc;
-        add_parameter(
-            "indicator strategy",
-            indicator_strategy_,
-            "The chosen indicator strategy. Possible values are: galerkin, "
-            "entropy viscosity, entropy viscosity full split");
-
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
                       evc_factor_,
                       "Factor for scaling the entropy viscocity commuator");
       }
 
-      ACCESSOR_READ_ONLY(indicator_strategy);
-
       ACCESSOR_READ_ONLY(evc_factor);
 
     private:
-      IndicatorStrategy indicator_strategy_;
       ScalarNumber evc_factor_;
     };
 
@@ -207,9 +173,6 @@ namespace ryujin
       Number left = 0.;
       state_type right;
 
-      Number left_absolute = 0.;
-      Number right_value = 0.;
-      Number right_absolute = 0.;
       //@}
     };
 
@@ -225,10 +188,7 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline void
     Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
     {
-      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
-        return;
-
-      /* entropy viscosity commutator: */
+      /* Entropy viscosity commutator: */
 
       const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -245,10 +205,6 @@ namespace ryujin
 
       left = 0.;
       right = 0.;
-
-      left_absolute = 0.;
-      right_value = 0.;
-      right_absolute = 0.;
     }
 
 
@@ -258,10 +214,7 @@ namespace ryujin
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
-      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
-        return;
-
-      /* entropy viscosity commutator: */
+      /* Entropy viscosity commutator: */
 
       const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -277,25 +230,10 @@ namespace ryujin
       const auto entropy_flux =
           (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
 
-      if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
-        /* Entropy viscosity commutator with aggressive denominator split: */
-
-        left += entropy_flux;
-        left_absolute += std::abs(entropy_flux);
-        for (unsigned int k = 0; k < problem_dimension; ++k) {
-          const auto component = d_eta_i[k] * (f_j[k] - f_i[k]) * c_ij;
-          right_value += component;
-          right_absolute += std::abs(component);
-        }
-
-      } else {
-        /* Entropy viscosity commutator with conservative denominator split: */
-
-        left += entropy_flux;
-        for (unsigned int k = 0; k < problem_dimension; ++k) {
-          const auto component = (f_j[k] - f_i[k]) * c_ij;
-          right[k] += component;
-        }
+      left += entropy_flux;
+      for (unsigned int k = 0; k < problem_dimension; ++k) {
+        const auto component = (f_j[k] - f_i[k]) * c_ij;
+        right[k] += component;
       }
     }
 
@@ -304,35 +242,19 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline Number
     Indicator<dim, Number>::alpha(const Number hd_i) const
     {
-      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
-        return Number(0.);
+      /* Entropy viscosity commutator: */
 
-      if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
-        /* Entropy viscosity commutator with aggressive denominator split: */
-
-        Number numerator = left - right_value;
-        Number denominator = left_absolute + right_absolute;
-
-        const auto quotient =
-            std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
-
-        return std::min(Number(1.), parameters.evc_factor() * quotient);
-
-      } else {
-        /* Entropy viscosity commutator with conservative denominator split: */
-
-        Number numerator = left;
-        Number denominator = std::abs(left);
-        for (unsigned int k = 0; k < problem_dimension; ++k) {
-          numerator -= d_eta_i[k] * right[k];
-          denominator += std::abs(d_eta_i[k] * right[k]);
-        }
-
-        const auto quotient =
-            std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
-
-        return std::min(Number(1.), parameters.evc_factor() * quotient);
+      Number numerator = left;
+      Number denominator = std::abs(left);
+      for (unsigned int k = 0; k < problem_dimension; ++k) {
+        numerator -= d_eta_i[k] * right[k];
+        denominator += std::abs(d_eta_i[k] * right[k]);
       }
+
+      const auto quotient =
+          std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
+
+      return std::min(Number(1.), parameters.evc_factor() * quotient);
     }
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -19,31 +19,6 @@ namespace ryujin
 {
   namespace EulerAEOS
   {
-    enum class IndicatorStrategy {
-      /** Indicator returns constant 0 */
-      galerkin,
-      /** The classical entropy viscosity commutator */
-      evc,
-      /** Entropy viscosity with more aggressive denominator split */
-      evc_fullsplit,
-    };
-  }
-} // namespace ryujin
-
-#ifndef DOXYGEN
-DECLARE_ENUM(ryujin::EulerAEOS::IndicatorStrategy,
-             LIST({ryujin::EulerAEOS::IndicatorStrategy::galerkin, "galerkin"},
-                  {ryujin::EulerAEOS::IndicatorStrategy::evc,
-                   "entropy viscosity"},
-                  {ryujin::EulerAEOS::IndicatorStrategy::evc_fullsplit,
-                   "entropy viscosity full split"}));
-#endif
-
-
-namespace ryujin
-{
-  namespace EulerAEOS
-  {
     template <typename ScalarNumber = double>
     class IndicatorParameters : public dealii::ParameterAcceptor
     {
@@ -51,25 +26,15 @@ namespace ryujin
       IndicatorParameters(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
-        indicator_strategy_ = IndicatorStrategy::evc;
-        add_parameter(
-            "indicator strategy",
-            indicator_strategy_,
-            "The chosen indicator strategy. Possible values are: galerkin, "
-            "entropy viscosity, entropy viscosity full split");
-
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
                       evc_factor_,
                       "Factor for scaling the entropy viscocity commuator");
       }
 
-      ACCESSOR_READ_ONLY(indicator_strategy);
-
       ACCESSOR_READ_ONLY(evc_factor);
 
     private:
-      IndicatorStrategy indicator_strategy_;
       ScalarNumber evc_factor_;
     };
 
@@ -210,9 +175,6 @@ namespace ryujin
       Number left = 0.;
       state_type right;
 
-      Number left_absolute = 0.;
-      Number right_value = 0.;
-      Number right_absolute = 0.;
       //@}
     };
 
@@ -228,10 +190,7 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline void
     Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
     {
-      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
-        return;
-
-      /* entropy viscosity commutator: */
+      /* Entropy viscosity commutator: */
 
       const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -252,10 +211,6 @@ namespace ryujin
 
       left = 0.;
       right = 0.;
-
-      left_absolute = 0.;
-      right_value = 0.;
-      right_absolute = 0.;
     }
 
 
@@ -265,10 +220,7 @@ namespace ryujin
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
-      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
-        return;
-
-      /* entropy viscosity commutator: */
+      /* Entropy viscosity commutator: */
 
       const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -285,25 +237,10 @@ namespace ryujin
       const auto entropy_flux =
           (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
 
-      if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
-        /* Entropy viscosity commutator with aggressive denominator split: */
-
-        left += entropy_flux;
-        left_absolute += std::abs(entropy_flux);
-        for (unsigned int k = 0; k < problem_dimension; ++k) {
-          const auto component = d_eta_i[k] * (f_j[k] - f_i[k]) * c_ij;
-          right_value += component;
-          right_absolute += std::abs(component);
-        }
-
-      } else {
-        /* Entropy viscosity commutator with conservative denominator split: */
-
-        left += entropy_flux;
-        for (unsigned int k = 0; k < problem_dimension; ++k) {
-          const auto component = (f_j[k] - f_i[k]) * c_ij;
-          right[k] += component;
-        }
+      left += entropy_flux;
+      for (unsigned int k = 0; k < problem_dimension; ++k) {
+        const auto component = (f_j[k] - f_i[k]) * c_ij;
+        right[k] += component;
       }
     }
 
@@ -312,36 +249,19 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline Number
     Indicator<dim, Number>::alpha(const Number hd_i) const
     {
-      if (parameters.indicator_strategy() == IndicatorStrategy::galerkin)
-        return Number(0.);
+      /* Entropy viscosity commutator: */
 
-      if (parameters.indicator_strategy() == IndicatorStrategy::evc_fullsplit) {
-        /* Entropy viscosity commutator with aggressive denominator split: */
-
-        Number numerator = left - right_value;
-        Number denominator = left_absolute + right_absolute;
-
-        const auto quotient =
-            std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
-
-        return std::min(Number(1.), parameters.evc_factor() * quotient);
-
-      } else {
-        /* Entropy viscosity commutator with conservative denominator split: */
-
-        Number numerator = left;
-        Number denominator = std::abs(left);
-        for (unsigned int k = 0; k < problem_dimension; ++k) {
-          numerator -= d_eta_i[k] * right[k];
-          denominator += std::abs(d_eta_i[k] * right[k]);
-        }
-
-        const auto quotient =
-            std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
-
-        return std::min(Number(1.), parameters.evc_factor() * quotient);
+      Number numerator = left;
+      Number denominator = std::abs(left);
+      for (unsigned int k = 0; k < problem_dimension; ++k) {
+        numerator -= d_eta_i[k] * right[k];
+        denominator += std::abs(d_eta_i[k] * right[k]);
       }
-    }
 
+      const auto quotient =
+          std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
+
+      return std::min(Number(1.), parameters.evc_factor() * quotient);
+    }
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-leblanc-pge-1d-erk33-l6.prm
@@ -48,7 +48,7 @@ end
 
 subsection F - HyperbolicModule
   subsection indicator
-    set indicator strategy = galerkin
+    set evc factor = 0.
   end
 
   subsection limiter

--- a/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
+++ b/tests/euler_aeos/verification-rarefaction-pge-1d-erk33-l6.prm
@@ -47,7 +47,7 @@ end
 
 subsection F - HyperbolicModule
   subsection indicator
-    set indicator strategy = galerkin
+    set evc factor = 0.
   end
 
   subsection limiter


### PR DESCRIPTION
Adding the full split variant and a dedicated "Galerkin" variant was a terrible choice. These aggressive indicators only work for cG/dG Q1 discretizations...

Let's remove them.
