### PR TITLE
enable 'exact' end times.

### DIFF
--- a/source/hyperbolic_module.cc
+++ b/source/hyperbolic_module.cc
@@ -13,7 +13,7 @@
       const std::array<NUMBER, stages>,                                        \
       StateVector &,                                                           \
       NUMBER,                                                                  \
-      NUMBER) const
+      std::atomic<NUMBER>) const
 
 namespace ryujin
 {

--- a/source/hyperbolic_module.cc
+++ b/source/hyperbolic_module.cc
@@ -12,6 +12,7 @@
       std::array<std::reference_wrapper<const StateVector>, stages>,           \
       const std::array<NUMBER, stages>,                                        \
       StateVector &,                                                           \
+      NUMBER,                                                                  \
       NUMBER) const
 
 namespace ryujin

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -156,9 +156,10 @@ namespace ryujin
      * was performed.
      *
      * The time step is performed with either tau_max (if @p tau is set to
-     * 0), or tau (if @p tau is nonzero). Here, tau_max is the computed
-     * maximal time step size and @p tau is the last parameter of the
-     * function.
+     * 0), or tau (if @p tau is nonzero). Here, tau_max is the minimum of
+     * the specified parameter @p tau_max and the computed maximal time
+     * step size according to the CFL condition. @p tau is the last
+     * parameter of the function.
      *
      * The function takes an optional array of states @p stage_U together
      * with a an array of weights @p stage_weights to construct a

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -211,13 +211,14 @@ namespace ryujin
      * prior to calling the step function.
      */
     template <int stages>
-    Number step(const StateVector &old_state_vector,
-                std::array<std::reference_wrapper<const StateVector>, stages>
-                    stage_state_vectors,
-                const std::array<Number, stages> stage_weights,
-                StateVector &new_state_vector,
-                Number tau = Number(0.),
-                Number tau_max_0 = std::numeric_limits<Number>::max()) const;
+    Number step(
+        const StateVector &old_state_vector,
+        std::array<std::reference_wrapper<const StateVector>, stages>
+            stage_state_vectors,
+        const std::array<Number, stages> stage_weights,
+        StateVector &new_state_vector,
+        Number tau = Number(0.),
+        std::atomic<Number> tau_max = std::numeric_limits<Number>::max()) const;
 
     /**
      * Sets the relative CFL number used for computing an appropriate

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -216,7 +216,8 @@ namespace ryujin
                     stage_state_vectors,
                 const std::array<Number, stages> stage_weights,
                 StateVector &new_state_vector,
-                Number tau = Number(0.)) const;
+                Number tau = Number(0.),
+                Number tau_max_0 = std::numeric_limits<Number>::max()) const;
 
     /**
      * Sets the relative CFL number used for computing an appropriate

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -240,7 +240,7 @@ namespace ryujin
       const std::array<Number, stages> stage_weights,
       StateVector &new_state_vector,
       Number tau /*= 0.*/,
-      Number tau_max_0 /*std::numeric_limits<Number>::max()*/) const
+      std::atomic<Number> tau_max /*std::numeric_limits<Number>::max()*/) const
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "HyperbolicModule<Description, dim, Number>::step()"
@@ -428,8 +428,6 @@ namespace ryujin
      * Step 3: Compute diagonal of d_ij, and maximal time-step size.
      * -------------------------------------------------------------------------
      */
-
-    std::atomic<Number> tau_max{tau_max_0};
 
     {
       Scope scope(computing_timer_,

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -239,7 +239,8 @@ namespace ryujin
           stage_state_vectors,
       const std::array<Number, stages> stage_weights,
       StateVector &new_state_vector,
-      Number tau /*= 0.*/) const
+      Number tau /*= 0.*/,
+      Number tau_max_0 /*std::numeric_limits<Number>::max()*/) const
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "HyperbolicModule<Description, dim, Number>::step()"
@@ -428,7 +429,7 @@ namespace ryujin
      * -------------------------------------------------------------------------
      */
 
-    std::atomic<Number> tau_max{std::numeric_limits<Number>::max()};
+    std::atomic<Number> tau_max{tau_max_0};
 
     {
       Scope scope(computing_timer_,

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -222,7 +222,8 @@ namespace ryujin
     /**
      * Given a reference to a previous state vector U performs an explicit
      * time step (and store the result in U). The function returns the
-     * chosen time step size tau.
+     * chosen time step size tau. The time step size tau is selected such
+     * that $t + tau <= t_final$.
      *
      * @note This function switches between different Runge-Kutta methods
      * depending on chosen runtime parameters.
@@ -253,11 +254,8 @@ namespace ryujin
      * Given a reference to a previous state vector U performs an explicit
      * second-order strong-stability preserving Runge-Kutta SSPRK(2,2;1/2)
      * time step (and store the result in U). The function returns the
-     * chosen time step size tau.
-     *
-     * If the parameter @p tau is set to a nonzero value then the
-     * supplied value is used for time stepping instead of the computed
-     * maximal time step size.
+     * chosen time step size tau, which is guaranteed to be less than or
+     * equal to the parameter @p tau_max.
      */
     Number step_ssprk_22(StateVector &state_vector, Number t, Number tau_max);
 
@@ -265,39 +263,41 @@ namespace ryujin
      * Given a reference to a previous state vector U performs an explicit
      * third-order strong-stability preserving Runge-Kutta SSPRK(3,3;1/3)
      * time step (and store the result in U). The function returns the
-     * chosen time step size tau.
-     *
-     * If the parameter @p tau is set to a nonzero value then the
-     * supplied value is used for time stepping instead of the computed
-     * maximal time step size.
+     * chosen time step size tau, which is guaranteed to be less than or
+     * equal to the parameter @p tau_max.
      */
     Number step_ssprk_33(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * first-order Euler step ERK(1,1;1) time step (and store the result
-     * in U). The function returns the chosen time step size tau.
+     * in U). The function returns the chosen time step size tau, which is
+     * guaranteed to be less than or equal to the parameter @p tau_max.
      */
     Number step_erk_11(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * second-order Runge-Kutta ERK(2,2;1) time step (and store the result
-     * in U). The function returns the chosen time step size tau.
+     * in U). The function returns the chosen time step size tau, which is
+     * guaranteed to be less than or equal to the parameter @p tau_max.
      */
     Number step_erk_22(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * third-order Runge-Kutta ERK(3,3;1) time step (and store the result
-     * in U). The function returns the chosen time step size tau.
+     * in U). The function returns the chosen time step size tau, which is
+     * guaranteed to be less than or equal to the parameter @p tau_max.
      */
     Number step_erk_33(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * 4 stage third-order Runge-Kutta ERK(4,3;1) time step (and store the
-     * result in U). The function returns the chosen time step size tau.
+     * result in U). The function returns the chosen time step size tau,
+     * which is guaranteed to be less than or equal to the parameter @p
+     * tau_max.
      */
     Number step_erk_43(StateVector &state_vector, Number t, Number tau_max);
 
@@ -305,7 +305,8 @@ namespace ryujin
      * Given a reference to a previous state vector U performs an explicit
      * 4 stage fourth-order Runge-Kutta ERK(5,4;1) time step (and store
      * the result in U). The function returns the chosen time step size
-     * tau.
+     * tau, which is guaranteed to be less than or equal to the parameter
+     * @p tau_max.
      */
     Number step_erk_54(StateVector &state_vector, Number t, Number tau_max);
 
@@ -314,7 +315,8 @@ namespace ryujin
      * explicit implicit Strang split using a third-order Runge-Kutta
      * ERK(3,3;1/3) time step and an implicit Crank-Nicolson step (and
      * store the result in U). The function returns the chosen time step
-     * size tau.
+     * size tau, which is guaranteed to be less than or equal to the
+     * parameter @p tau_max.
      */
     Number step_strang_ssprk_33_cn(StateVector &state_vector,
                                    Number t,
@@ -325,7 +327,8 @@ namespace ryujin
      * explicit implicit Strang split using a third-order Runge-Kutta
      * ERK(3,3;1) time step and an implicit Crank-Nicolson step (and store
      * the result in U). The function returns the chosen time step size
-     * tau.
+     * tau, which is guaranteed to be less than or equal to the parameter
+     * @p tau_max.
      */
     Number
     step_strang_erk_33_cn(StateVector &state_vector, Number t, Number tau_max);
@@ -335,7 +338,8 @@ namespace ryujin
      * explicit implicit Strang split using a third-order Runge-Kutta
      * ERK(4,3;1) time step and an implicit Crank-Nicolson step (and store
      * the result in U). The function returns the chosen time step size
-     * tau.
+     * tau, which is guaranteed to be less than or equal to the parameter
+     * @p tau_max.
      */
     Number
     step_strang_erk_43_cn(StateVector &state_vector, Number t, Number tau_max);

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -231,7 +231,9 @@ namespace ryujin
      * adaptation and recovery strategies for invariant domain violations
      * are used.
      */
-    Number step(StateVector &state_vector, Number t);
+    Number step(StateVector &state_vector,
+                Number t,
+                Number t_final = std::numeric_limits<Number>::max());
 
     /**
      * The selected time-stepping scheme.
@@ -257,7 +259,7 @@ namespace ryujin
      * supplied value is used for time stepping instead of the computed
      * maximal time step size.
      */
-    Number step_ssprk_22(StateVector &state_vector, Number t);
+    Number step_ssprk_22(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
@@ -269,35 +271,35 @@ namespace ryujin
      * supplied value is used for time stepping instead of the computed
      * maximal time step size.
      */
-    Number step_ssprk_33(StateVector &state_vector, Number t);
+    Number step_ssprk_33(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * first-order Euler step ERK(1,1;1) time step (and store the result
      * in U). The function returns the chosen time step size tau.
      */
-    Number step_erk_11(StateVector &state_vector, Number t);
+    Number step_erk_11(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * second-order Runge-Kutta ERK(2,2;1) time step (and store the result
      * in U). The function returns the chosen time step size tau.
      */
-    Number step_erk_22(StateVector &state_vector, Number t);
+    Number step_erk_22(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * third-order Runge-Kutta ERK(3,3;1) time step (and store the result
      * in U). The function returns the chosen time step size tau.
      */
-    Number step_erk_33(StateVector &state_vector, Number t);
+    Number step_erk_33(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
      * 4 stage third-order Runge-Kutta ERK(4,3;1) time step (and store the
      * result in U). The function returns the chosen time step size tau.
      */
-    Number step_erk_43(StateVector &state_vector, Number t);
+    Number step_erk_43(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs an explicit
@@ -305,7 +307,7 @@ namespace ryujin
      * the result in U). The function returns the chosen time step size
      * tau.
      */
-    Number step_erk_54(StateVector &state_vector, Number t);
+    Number step_erk_54(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs a combined
@@ -314,7 +316,9 @@ namespace ryujin
      * store the result in U). The function returns the chosen time step
      * size tau.
      */
-    Number step_strang_ssprk_33_cn(StateVector &state_vector, Number t);
+    Number step_strang_ssprk_33_cn(StateVector &state_vector,
+                                   Number t,
+                                   Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs a combined
@@ -323,7 +327,8 @@ namespace ryujin
      * the result in U). The function returns the chosen time step size
      * tau.
      */
-    Number step_strang_erk_33_cn(StateVector &state_vector, Number t);
+    Number
+    step_strang_erk_33_cn(StateVector &state_vector, Number t, Number tau_max);
 
     /**
      * Given a reference to a previous state vector U performs a combined
@@ -332,7 +337,8 @@ namespace ryujin
      * the result in U). The function returns the chosen time step size
      * tau.
      */
-    Number step_strang_erk_43_cn(StateVector &state_vector, Number t);
+    Number
+    step_strang_erk_43_cn(StateVector &state_vector, Number t, Number tau_max);
 
   private:
     //@}

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -259,7 +259,7 @@ namespace ryujin
     /* Step 1: T0 = U_old + tau * L(U_old) at t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max);
 
     /* Step 2: T1 = T0 + tau L(T0) at time t + tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -282,7 +282,7 @@ namespace ryujin
     /* Step 1: T0 = U_old + tau * L(U_old) at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max);
 
     /* Step 2: T1 = T0 + tau L(T0) at time t + tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -314,7 +314,7 @@ namespace ryujin
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max);
 
     state_vector.swap(temp_[0]);
     return tau;
@@ -332,7 +332,7 @@ namespace ryujin
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(.0), tau_max / efficiency_);
+        state_vector, {}, {}, temp_[0], Number(.0), tau_max / 2.);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -355,7 +355,7 @@ namespace ryujin
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / 3.);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + 1*tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -387,7 +387,7 @@ namespace ryujin
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / 4.);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + 1*tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -441,7 +441,7 @@ namespace ryujin
     /* Step 1: at time t -> t + 1*tau*/
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / 5.);
 
     /* Step 2: at time t -> 1*tau -> t + 2*tau*/
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -498,12 +498,7 @@ namespace ryujin
 
     hyperbolic_module_->prepare_state_vector(/*!*/ state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector,
-        {},
-        {},
-        temp_[0],
-        Number(0.0),
-        tau_max / efficiency_);
+        /*!*/ state_vector, {}, {}, temp_[0], Number(0.0), tau_max / 2.);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<0>(temp_[0], {}, {}, temp_[1], tau);
@@ -532,7 +527,7 @@ namespace ryujin
     sadd(temp_[0], Number(2.0 / 3.0), Number(1.0 / 3.0), /*!*/ temp_[2]);
 
     state_vector.swap(temp_[0]);
-    return 2.0 * tau;
+    return 2. * tau;
   }
 
 
@@ -551,12 +546,7 @@ namespace ryujin
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector,
-        {},
-        {},
-        temp_[0],
-        Number(0.),
-        tau_max / efficiency_);
+        /*!*/ state_vector, {}, {}, temp_[0], Number(0.), tau_max / 6.);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<1>(
@@ -612,12 +602,7 @@ namespace ryujin
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector,
-        {},
-        {},
-        temp_[0],
-        Number(0.),
-        tau_max / efficiency_);
+        /*!*/ state_vector, {}, {}, temp_[0], Number(0.), tau_max / 8.);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<1>(

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -185,36 +185,38 @@ namespace ryujin
 
 
   template <typename Description, int dim, typename Number>
-  Number
-  TimeIntegrator<Description, dim, Number>::step(StateVector &state_vector,
-                                                 Number t)
+  Number TimeIntegrator<Description, dim, Number>::step(
+      StateVector &state_vector,
+      Number t,
+      Number t_final /*=std::numeric_limits<Number>::max()*/)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step()" << std::endl;
 #endif
+    Number tau_max = t_final - t;
 
     const auto single_step = [&]() {
       switch (time_stepping_scheme_) {
       case TimeSteppingScheme::ssprk_22:
-        return step_ssprk_22(state_vector, t);
+        return step_ssprk_22(state_vector, t, tau_max);
       case TimeSteppingScheme::ssprk_33:
-        return step_ssprk_33(state_vector, t);
+        return step_ssprk_33(state_vector, t, tau_max);
       case TimeSteppingScheme::erk_11:
-        return step_erk_11(state_vector, t);
+        return step_erk_11(state_vector, t, tau_max);
       case TimeSteppingScheme::erk_22:
-        return step_erk_22(state_vector, t);
+        return step_erk_22(state_vector, t, tau_max);
       case TimeSteppingScheme::erk_33:
-        return step_erk_33(state_vector, t);
+        return step_erk_33(state_vector, t, tau_max);
       case TimeSteppingScheme::erk_43:
-        return step_erk_43(state_vector, t);
+        return step_erk_43(state_vector, t, tau_max);
       case TimeSteppingScheme::erk_54:
-        return step_erk_54(state_vector, t);
+        return step_erk_54(state_vector, t, tau_max);
       case TimeSteppingScheme::strang_ssprk_33_cn:
-        return step_strang_ssprk_33_cn(state_vector, t);
+        return step_strang_ssprk_33_cn(state_vector, t, tau_max);
       case TimeSteppingScheme::strang_erk_33_cn:
-        return step_strang_erk_33_cn(state_vector, t);
+        return step_strang_erk_33_cn(state_vector, t, tau_max);
       case TimeSteppingScheme::strang_erk_43_cn:
-        return step_strang_erk_43_cn(state_vector, t);
+        return step_strang_erk_43_cn(state_vector, t, tau_max);
       default:
         __builtin_unreachable();
       }
@@ -250,14 +252,14 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_ssprk_22(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
     /* SSP-RK2, see @cite Shu1988, Eq. 2.15. */
 
     /* Step 1: T0 = U_old + tau * L(U_old) at t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
-    Number tau =
-        hyperbolic_module_->template step<0>(state_vector, {}, {}, temp_[0]);
+    Number tau = hyperbolic_module_->template step<0>(
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Step 2: T1 = T0 + tau L(T0) at time t + tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -273,14 +275,14 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_ssprk_33(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
     /* SSP-RK3, see @cite Shu1988, Eq. 2.18. */
 
     /* Step 1: T0 = U_old + tau * L(U_old) at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
-    Number tau =
-        hyperbolic_module_->template step<0>(state_vector, {}, {}, temp_[0]);
+    Number tau = hyperbolic_module_->template step<0>(
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Step 2: T1 = T0 + tau L(T0) at time t + tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -303,7 +305,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_erk_11(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_11()" << std::endl;
@@ -311,8 +313,8 @@ namespace ryujin
 
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
-    Number tau =
-        hyperbolic_module_->template step<0>(state_vector, {}, {}, temp_[0]);
+    Number tau = hyperbolic_module_->template step<0>(
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     state_vector.swap(temp_[0]);
     return tau;
@@ -321,7 +323,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_erk_22(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_22()" << std::endl;
@@ -329,8 +331,8 @@ namespace ryujin
 
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
-    Number tau =
-        hyperbolic_module_->template step<0>(state_vector, {}, {}, temp_[0]);
+    Number tau = hyperbolic_module_->template step<0>(
+        state_vector, {}, {}, temp_[0], Number(.0), tau_max / efficiency_);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -344,7 +346,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_erk_33(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_33()" << std::endl;
@@ -352,8 +354,8 @@ namespace ryujin
 
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
-    Number tau =
-        hyperbolic_module_->template step<0>(state_vector, {}, {}, temp_[0]);
+    Number tau = hyperbolic_module_->template step<0>(
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + 1*tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -376,7 +378,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_erk_43(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_43()" << std::endl;
@@ -384,8 +386,8 @@ namespace ryujin
 
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
-    Number tau =
-        hyperbolic_module_->template step<0>(state_vector, {}, {}, temp_[0]);
+    Number tau = hyperbolic_module_->template step<0>(
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + 1*tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -413,7 +415,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_erk_54(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_54()" << std::endl;
@@ -438,8 +440,8 @@ namespace ryujin
 
     /* Step 1: at time t -> t + 1*tau*/
     hyperbolic_module_->prepare_state_vector(state_vector, t);
-    Number tau =
-        hyperbolic_module_->template step<0>(state_vector, {}, {}, temp_[0]);
+    Number tau = hyperbolic_module_->template step<0>(
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Step 2: at time t -> 1*tau -> t + 2*tau*/
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -483,7 +485,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_strang_ssprk_33_cn(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
     // FIXME: avoid code duplication with step_ssprk_33
 
@@ -496,7 +498,12 @@ namespace ryujin
 
     hyperbolic_module_->prepare_state_vector(/*!*/ state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector, {}, {}, temp_[0]);
+        /*!*/ state_vector,
+        {},
+        {},
+        temp_[0],
+        Number(0.0),
+        tau_max / efficiency_);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<0>(temp_[0], {}, {}, temp_[1], tau);
@@ -531,7 +538,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_strang_erk_33_cn(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
     // FIXME: refactor to avoid code duplication with step_erk_33
 
@@ -544,7 +551,12 @@ namespace ryujin
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector, {}, {}, temp_[0]);
+        /*!*/ state_vector,
+        {},
+        {},
+        temp_[0],
+        Number(0.),
+        tau_max / efficiency_);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<1>(
@@ -587,7 +599,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_strang_erk_43_cn(
-      StateVector &state_vector, Number t)
+      StateVector &state_vector, Number t, Number tau_max)
   {
     // FIXME: refactor to avoid code duplication with step_erk_43
 
@@ -600,7 +612,12 @@ namespace ryujin
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector, {}, {}, temp_[0]);
+        /*!*/ state_vector,
+        {},
+        {},
+        temp_[0],
+        Number(0.),
+        tau_max / efficiency_);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<1>(

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -156,6 +156,7 @@ namespace ryujin
     std::string debug_filename_;
 
     Number t_final_;
+    bool enforce_t_final_;
     Number timer_granularity_;
 
     bool enable_checkpointing_;


### PR DESCRIPTION
This allows users to specify that they want to end at 'exactly' the end time that was specified for the simulation.

To do this, the user needs only to specify t_final in `time_integrator::step([..], t, t_final)`.

If this is not important, all that needs to be done is call `time_integrator::step([...], t)` 

All tests pass except for 
```     
66 - shallow_water/verification-paraboloid_1d-erk33-l7.release (Failed)
68 - shallow_water/verification-smooth_vortex-erk33-l6.release (Failed)
69 - shallow_water/verification-steady_incline-erk33-l9.release (Failed)
```

On the current state of the development branch, the above tests fail as well as test 
```
4 - common/sparsity_pattern_simd_01.mpirun=4.release (Failed)
```
 so maybe this PR does not contribute to the issue. Do we need to fix these at all?