### PR TITLE
EulerAEOS: support trivial equation of state

### DIFF
--- a/source/euler_aeos/riemann_solver.h
+++ b/source/euler_aeos/riemann_solver.h
@@ -119,7 +119,7 @@ namespace ryujin
        *
        * Cost: 0x pow, 1x division, 1x sqrt
        */
-      Number c(const Number gamma_Z) const;
+      Number c(const Number &gamma_Z) const;
 
       /**
        * FIXME

--- a/tests/euler_aeos/verification-zero_pressure-1d-erk33-l4.output
+++ b/tests/euler_aeos/verification-zero_pressure-1d-erk33-l4.output
@@ -1,0 +1,12 @@
+[INFO] initiating flux capacitor
+[INFO] dispatching to driver »euler aeos« with dim=1
+[INFO] initializing data structures
+[INFO] creating mesh and interpolating initial values
+[INFO] preparing compute kernels
+[INFO] entering main loop
+Normalized consolidated Linf, L1, and L2 errors at final time 
+#dofs = 401
+t     = 0.66666666666667
+Linf  = 2.203619837762918
+L1    = 1.963229218374023
+L2    = 1.978080475933407

--- a/tests/euler_aeos/verification-zero_pressure-1d-erk33-l4.prm
+++ b/tests/euler_aeos/verification-zero_pressure-1d-erk33-l4.prm
@@ -1,0 +1,72 @@
+subsection A - TimeLoop
+  set basename             = zero_pressure-erk33
+
+  set enable compute error = true
+  set error quantities     = rho, m, E
+
+  set enforce final time        = true
+
+  set final time           = 0.66666666666667
+  set timer granularity    = 0.66666666666667
+
+  set terminal update interval  = 0
+end
+
+
+subsection B - Equation
+  set dimension             = 1
+  set equation              = euler aeos
+  set compute strict bounds = true
+  set equation of state     = function
+
+  subsection function
+    set pressure                 = 0.0
+    set specific internal energy = 0.0
+  end
+end
+
+
+subsection C - Discretization
+  set geometry        = rectangular domain
+  set mesh refinement = 4
+
+  subsection rectangular domain
+    set boundary condition left   = dirichlet
+    set boundary condition right  = dirichlet
+
+    set position bottom left      = 0
+    set position top right        = 1
+    set subdivisions x            = 25
+  end
+end
+
+
+subsection E - InitialValues
+  set configuration = leblanc
+
+  set direction     = 1
+  # for cG put the discontinuity right in the center of a cell
+  set position      = 0.326732673267
+end
+
+
+subsection F - HyperbolicModule
+  subsection indicator
+    set evc factor = 0.
+  end
+
+  subsection limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 1
+  end
+end
+
+
+subsection H - TimeIntegrator
+  set cfl min               = 0.10
+  set cfl max               = 0.10
+  set cfl recovery strategy = none
+  set time stepping scheme  = erk 33
+end

--- a/tests/euler_aeos/verification-zero_pressure-strict-1d-erk33-l4.output
+++ b/tests/euler_aeos/verification-zero_pressure-strict-1d-erk33-l4.output
@@ -1,0 +1,12 @@
+[INFO] initiating flux capacitor
+[INFO] dispatching to driver »euler aeos« with dim=1
+[INFO] initializing data structures
+[INFO] creating mesh and interpolating initial values
+[INFO] preparing compute kernels
+[INFO] entering main loop
+Normalized consolidated Linf, L1, and L2 errors at final time 
+#dofs = 401
+t     = 0.66666666666667
+Linf  = 2.203619837762918
+L1    = 1.963229218374023
+L2    = 1.978080475933407

--- a/tests/euler_aeos/verification-zero_pressure-strict-1d-erk33-l4.prm
+++ b/tests/euler_aeos/verification-zero_pressure-strict-1d-erk33-l4.prm
@@ -1,0 +1,72 @@
+subsection A - TimeLoop
+  set basename             = zero_pressure-erk33
+
+  set enable compute error = true
+  set error quantities     = rho, m, E
+
+  set enforce final time        = true
+
+  set final time           = 0.66666666666667
+  set timer granularity    = 0.66666666666667
+
+  set terminal update interval  = 0
+end
+
+
+subsection B - Equation
+  set dimension             = 1
+  set equation              = euler aeos
+  set compute strict bounds = false
+  set equation of state     = function
+
+  subsection function
+    set pressure                 = 0.0
+    set specific internal energy = 0.0
+  end
+end
+
+
+subsection C - Discretization
+  set geometry        = rectangular domain
+  set mesh refinement = 4
+
+  subsection rectangular domain
+    set boundary condition left   = dirichlet
+    set boundary condition right  = dirichlet
+
+    set position bottom left      = 0
+    set position top right        = 1
+    set subdivisions x            = 25
+  end
+end
+
+
+subsection E - InitialValues
+  set configuration = leblanc
+
+  set direction     = 1
+  # for cG put the discontinuity right in the center of a cell
+  set position      = 0.326732673267
+end
+
+
+subsection F - HyperbolicModule
+  subsection indicator
+    set evc factor = 0.
+  end
+
+  subsection limiter
+    set iterations            = 2
+    set newton max iterations = 2
+    set newton tolerance      = 1e-10
+    set relaxation factor     = 1
+  end
+end
+
+
+subsection H - TimeIntegrator
+  set cfl min               = 0.10
+  set cfl max               = 0.10
+  set cfl recovery strategy = none
+  set time stepping scheme  = erk 33
+end


### PR DESCRIPTION
The following pull request adds support for the "pressureless" equation of state `p = 0`.

For this we need to avoid division by zero in the `RiemannSolver` module. The fixes add a performance penalty of about 0.8%.
