### PR TITLE
`MPIEnsemble: add class and refactor code

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -15,6 +15,7 @@ configure_file(
 set(COMMON_SOURCE_FILES
   discretization.cc
   equation_dispatch.cc
+  mpi_ensemble.cc
   multicomponent_vector.cc
   offline_data.cc
   simd.cc

--- a/source/discretization.h
+++ b/source/discretization.h
@@ -9,6 +9,7 @@
 
 #include "convenience_macros.h"
 #include "geometry.h"
+#include "mpi_ensemble.h"
 #include "patterns_conversion.h"
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -42,6 +43,9 @@ namespace ryujin
    * Boundary::dirichlet face neighboring a Boundary::no_slip face have to
    * ensure that they prescribe a state compatible with the no slip
    * condition, etc.
+   *
+   * @note Data structures in OfflineData are initialized with the ensemble
+   * subrange communicator stored in MPIEnsemble.
    *
    * @ingroup Mesh
    */
@@ -221,7 +225,7 @@ namespace ryujin
     /**
      * Constructor.
      */
-    Discretization(const MPI_Comm &mpi_communicator,
+    Discretization(const MPIEnsemble &mpi_ensemble,
                    const std::string &subsection = "/Discretization");
 
     /**
@@ -316,7 +320,7 @@ namespace ryujin
     ACCESSOR_READ_ONLY(face_nodal_quadrature)
 
   protected:
-    const MPI_Comm &mpi_communicator_;
+    const MPIEnsemble &mpi_ensemble_;
 
     std::unique_ptr<Triangulation> triangulation_;
     std::unique_ptr<const dealii::Mapping<dim>> mapping_;

--- a/source/discretization.template.h
+++ b/source/discretization.template.h
@@ -74,7 +74,7 @@ namespace ryujin
       const auto settings =
           Triangulation::Settings::construct_multigrid_hierarchy;
       triangulation_ = std::make_unique<Triangulation>(
-          mpi_ensemble_.subrange_communicator(), smoothing, settings);
+          mpi_ensemble_.ensemble_communicator(), smoothing, settings);
 
     } else {
       const auto settings = static_cast<typename Triangulation::Settings>(
@@ -82,7 +82,7 @@ namespace ryujin
           Triangulation::construct_multigrid_hierarchy);
       /* Beware of the boolean: */
       triangulation_ =
-          std::make_unique<Triangulation>(mpi_ensemble_.subrange_communicator(),
+          std::make_unique<Triangulation>(mpi_ensemble_.ensemble_communicator(),
                                           smoothing,
                                           /*artificial cells*/ true,
                                           settings);
@@ -106,7 +106,7 @@ namespace ryujin
     }
 
     if (mesh_writeout_ && dealii::Utilities::MPI::this_mpi_process(
-                              mpi_ensemble_.subrange_communicator()) == 0) {
+                              mpi_ensemble_.ensemble_communicator()) == 0) {
 #ifdef DEAL_II_GMSH_WITH_API
       GridOut grid_out;
       grid_out.write_msh(triangulation, base_name + "-coarse_grid.msh");

--- a/source/discretization.template.h
+++ b/source/discretization.template.h
@@ -23,29 +23,11 @@ namespace ryujin
   using namespace dealii;
 
   template <int dim>
-  Discretization<dim>::Discretization(const MPI_Comm &mpi_communicator,
+  Discretization<dim>::Discretization(const MPIEnsemble &mpi_ensemble,
                                       const std::string &subsection)
       : ParameterAcceptor(subsection)
-      , mpi_communicator_(mpi_communicator)
+      , mpi_ensemble_(mpi_ensemble)
   {
-    const auto smoothing =
-        dealii::Triangulation<dim>::limit_level_difference_at_vertices;
-
-    if constexpr (have_distributed_triangulation<dim>) {
-      const auto settings =
-          Triangulation::Settings::construct_multigrid_hierarchy;
-      triangulation_ = std::make_unique<Triangulation>(
-          mpi_communicator_, smoothing, settings);
-
-    } else {
-      const auto settings = static_cast<typename Triangulation::Settings>(
-          Triangulation::partition_auto |
-          Triangulation::construct_multigrid_hierarchy);
-      /* Beware of the boolean: */
-      triangulation_ = std::make_unique<Triangulation>(
-          mpi_communicator_, smoothing, /*artificial cells*/ true, settings);
-    }
-
     /* Options: */
 
     ansatz_ = Ansatz::cg_q1;
@@ -85,8 +67,28 @@ namespace ryujin
     std::cout << "Discretization<dim>::prepare()" << std::endl;
 #endif
 
+    const auto smoothing =
+        dealii::Triangulation<dim>::limit_level_difference_at_vertices;
+
+    if constexpr (have_distributed_triangulation<dim>) {
+      const auto settings =
+          Triangulation::Settings::construct_multigrid_hierarchy;
+      triangulation_ = std::make_unique<Triangulation>(
+          mpi_ensemble_.subrange_communicator(), smoothing, settings);
+
+    } else {
+      const auto settings = static_cast<typename Triangulation::Settings>(
+          Triangulation::partition_auto |
+          Triangulation::construct_multigrid_hierarchy);
+      /* Beware of the boolean: */
+      triangulation_ =
+          std::make_unique<Triangulation>(mpi_ensemble_.subrange_communicator(),
+                                          smoothing,
+                                          /*artificial cells*/ true,
+                                          settings);
+    }
+
     auto &triangulation = *triangulation_;
-    triangulation.clear();
 
     {
       bool initialized = false;
@@ -103,8 +105,8 @@ namespace ryujin
                      geometry_ + "\""));
     }
 
-    if (mesh_writeout_ &&
-        dealii::Utilities::MPI::this_mpi_process(mpi_communicator_) == 0) {
+    if (mesh_writeout_ && dealii::Utilities::MPI::this_mpi_process(
+                              mpi_ensemble_.subrange_communicator()) == 0) {
 #ifdef DEAL_II_GMSH_WITH_API
       GridOut grid_out;
       grid_out.write_msh(triangulation, base_name + "-coarse_grid.msh");

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -9,6 +9,7 @@
 
 #include "convenience_macros.h"
 #include "initial_values.h"
+#include "mpi_ensemble.h"
 #include "offline_data.h"
 #include "sparse_matrix_simd.h"
 #include "state_vector.h"
@@ -32,9 +33,14 @@ namespace ryujin
    * The invariant domain violation is detected in the limiter and
    * typically implies that the low-order update is already out of bounds.
    *
+   * @note Data structures in HyperbolicModule are initialized with the
+   * ensemble subrange communicator stored in MPIEnsemble. However, the
+   * time step size constraint (i.e. tau_max) is synchronized over the
+   * entire global communicator.
+   *
    * @ingroup HyperbolicModule
    */
-  enum class IDViolationStrategy {
+  enum class IDViolationStrategy : std::uint8_t {
     /**
      * Warn about an invariant domain violation but take no further
      * action.
@@ -108,7 +114,7 @@ namespace ryujin
      * Constructor
      */
     HyperbolicModule(
-        const MPI_Comm &mpi_communicator,
+        const MPIEnsemble &mpi_ensemble,
         std::map<std::string, dealii::Timer> &computing_timer,
         const OfflineData<dim, Number> &offline_data,
         const HyperbolicSystem &hyperbolic_system,
@@ -300,7 +306,7 @@ namespace ryujin
      */
     //@{
 
-    const MPI_Comm &mpi_communicator_;
+    const MPIEnsemble &mpi_ensemble_;
     std::map<std::string, dealii::Timer> &computing_timer_;
 
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -7,6 +7,7 @@
 
 #include "hyperbolic_module.h"
 #include "introspection.h"
+#include "mpi_ensemble.h"
 #include "openmp.h"
 #include "scope.h"
 #include "simd.h"
@@ -26,7 +27,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   HyperbolicModule<Description, dim, Number>::HyperbolicModule(
-      const MPI_Comm &mpi_communicator,
+      const MPIEnsemble &mpi_ensemble,
       std::map<std::string, dealii::Timer> &computing_timer,
       const OfflineData<dim, Number> &offline_data,
       const HyperbolicSystem &hyperbolic_system,
@@ -37,7 +38,7 @@ namespace ryujin
       , indicator_parameters_(subsection + "/indicator")
       , limiter_parameters_(subsection + "/limiter")
       , riemann_solver_parameters_(subsection + "/riemann solver")
-      , mpi_communicator_(mpi_communicator)
+      , mpi_ensemble_(mpi_ensemble)
       , computing_timer_(computing_timer)
       , offline_data_(&offline_data)
       , hyperbolic_system_(&hyperbolic_system)
@@ -567,8 +568,15 @@ namespace ryujin
       Scope scope(computing_timer_,
                   "time step [H] _ - synchronization barriers");
 
-      /* MPI Barrier: */
-      tau_max.store(Utilities::MPI::min(tau_max.load(), mpi_communicator_));
+      /*
+       * MPI Barrier: Synchronize the maximal time-step size. This has to
+       * happen either over the global, or the local subrange communicator:
+       */
+      tau_max.store(
+          Utilities::MPI::min(tau_max.load(),
+                              mpi_ensemble_.global_tau_max()
+                                  ? mpi_ensemble_.world_communicator()
+                                  : mpi_ensemble_.subrange_communicator()));
 
       AssertThrow(
           !std::isnan(tau_max) && !std::isinf(tau_max) && tau_max > 0.,
@@ -1191,8 +1199,18 @@ namespace ryujin
       Scope scope(computing_timer_,
                   "time step [H] _ - synchronization barriers");
 
-      restart_needed.store(
-          Utilities::MPI::logical_or(restart_needed.load(), mpi_communicator_));
+      /*
+       * Synchronize whether we have to restart the time step. Even though
+       * the restart condition itself only affects the local ensemble we
+       * nevertheless need to synchronize the boolean in case we perform
+       * synchronized global time steps. (Otherwise different ensembles
+       * might end up with a different time step.)
+       */
+      restart_needed.store(Utilities::MPI::logical_or(
+          restart_needed.load(),
+          mpi_ensemble_.global_tau_max()
+              ? mpi_ensemble_.world_communicator()
+              : mpi_ensemble_.subrange_communicator()));
     }
 
     if (restart_needed) {

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -572,11 +572,8 @@ namespace ryujin
        * MPI Barrier: Synchronize the maximal time-step size. This has to
        * happen either over the global, or the local subrange communicator:
        */
-      tau_max.store(
-          Utilities::MPI::min(tau_max.load(),
-                              mpi_ensemble_.global_tau_max()
-                                  ? mpi_ensemble_.world_communicator()
-                                  : mpi_ensemble_.subrange_communicator()));
+      tau_max.store(Utilities::MPI::min(
+          tau_max.load(), mpi_ensemble_.synchronization_communicator()));
 
       AssertThrow(
           !std::isnan(tau_max) && !std::isinf(tau_max) && tau_max > 0.,
@@ -1207,10 +1204,7 @@ namespace ryujin
        * might end up with a different time step.)
        */
       restart_needed.store(Utilities::MPI::logical_or(
-          restart_needed.load(),
-          mpi_ensemble_.global_tau_max()
-              ? mpi_ensemble_.world_communicator()
-              : mpi_ensemble_.subrange_communicator()));
+          restart_needed.load(), mpi_ensemble_.synchronization_communicator()));
     }
 
     if (restart_needed) {

--- a/source/mesh_adaptor.h
+++ b/source/mesh_adaptor.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "mpi_ensemble.h"
 #include "offline_data.h"
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -114,7 +115,7 @@ namespace ryujin
     /**
      * Constructor.
      */
-    MeshAdaptor(const MPI_Comm &mpi_communicator,
+    MeshAdaptor(const MPIEnsemble &mpi_ensemble,
                 const OfflineData<dim, Number> &offline_data,
                 const HyperbolicSystem &hyperbolic_system,
                 const ParabolicSystem &parabolic_system,
@@ -171,7 +172,7 @@ namespace ryujin
      */
     //@{
 
-    const MPI_Comm &mpi_communicator_;
+    const MPIEnsemble &mpi_ensemble_;
 
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;
     dealii::SmartPointer<const HyperbolicSystem> hyperbolic_system_;

--- a/source/mesh_adaptor.template.h
+++ b/source/mesh_adaptor.template.h
@@ -13,13 +13,13 @@ namespace ryujin
 {
   template <typename Description, int dim, typename Number>
   MeshAdaptor<Description, dim, Number>::MeshAdaptor(
-      const MPI_Comm &mpi_communicator,
+      const MPIEnsemble &mpi_ensemble,
       const OfflineData<dim, Number> &offline_data,
       const HyperbolicSystem &hyperbolic_system,
       const ParabolicSystem &parabolic_system,
       const std::string &subsection /*= "MeshAdaptor"*/)
       : ParameterAcceptor(subsection)
-      , mpi_communicator_(mpi_communicator)
+      , mpi_ensemble_(mpi_ensemble)
       , offline_data_(&offline_data)
       , hyperbolic_system_(&hyperbolic_system)
       , parabolic_system_(&parabolic_system)

--- a/source/mpi_ensemble.cc
+++ b/source/mpi_ensemble.cc
@@ -9,54 +9,113 @@ namespace ryujin
 {
   MPIEnsemble::MPIEnsemble(const MPI_Comm &mpi_communicator)
       : world_communicator_(mpi_communicator)
-      , n_ensembles_(1)
+      , world_rank_(0)
+      , n_world_ranks_(1)
       , ensemble_(0)
-      , subrange_communicator_(mpi_communicator)
+      , n_ensembles_(1)
+      , ensemble_rank_(0)
+      , n_ensemble_ranks_(1)
       , global_tau_max_(true)
   {
   }
 
-  void MPIEnsemble::prepare(const int n_ensembles /* = 1 */,
-                            const bool global_tau_max /* = true */)
+  MPIEnsemble::~MPIEnsemble()
   {
-    const auto n_world_ranks =
-        dealii::Utilities::MPI::n_mpi_processes(world_communicator_);
+    MPI_Group_free(&world_group_);
+    for (auto &it : subrange_groups_)
+      MPI_Group_free(&it);
+    MPI_Group_free(&subrange_leader_group_);
 
-    AssertThrow(n_ensembles > 0, dealii::ExcInternalError());
-    AssertThrow(n_world_ranks % n_ensembles == 0,
-                dealii::ExcMessage(
-                    "The total number of (world) MPI ranks must be a multiple "
-                    "of the number of ensembles. But we are scheduled with " +
-                    std::to_string(n_world_ranks) + " for running " +
-                    std::to_string(n_ensembles) + " ensembles."));
+    MPI_Comm_free(&subrange_communicator_);
+    MPI_Comm_free(&subrange_leader_communicator_);
+    MPI_Comm_free(&peer_communicator_);
+  }
 
+  void MPIEnsemble::prepare(
+      const int n_ensembles /* = 1 */,
+      const bool global_tau_max /* = true */,
+      const bool require_uniform_ensemble_partition /* = true */)
+  {
     n_ensembles_ = n_ensembles;
     global_tau_max_ = global_tau_max;
 
-    const auto world_rank =
-        dealii::Utilities::MPI::this_mpi_process(world_communicator_);
+    world_rank_ = dealii::Utilities::MPI::this_mpi_process(world_communicator_);
+    n_world_ranks_ =
+        dealii::Utilities::MPI::n_mpi_processes(world_communicator_);
 
-    // FIXME: we should use a smarter binning strategy...
-    ensemble_ = world_rank % n_ensembles_;
+    AssertThrow(n_ensembles_ > 0, dealii::ExcInternalError());
+    if (require_uniform_ensemble_partition)
+      AssertThrow(
+          n_world_ranks_ % n_ensembles_ == 0,
+          dealii::ExcMessage(
+              "The total number of (world) MPI ranks must be a multiple "
+              "of the number of ensembles. But we are scheduled with " +
+              std::to_string(n_world_ranks_) + " for running " +
+              std::to_string(n_ensembles_) + " ensembles."));
 
-    MPI_Comm_split(
-        world_communicator_, ensemble_, world_rank, &subrange_communicator_);
+    ensemble_ = world_rank_ % n_ensembles_;
 
-    const auto subrange_rank =
+    /*
+     * For each ensemble we create an MPI group with a ensemble-local
+     * communicator. This allows to do ensemble-independent time-stepping.
+     */
+
+    auto ierr = MPI_Comm_group(world_communicator_, &world_group_);
+    AssertThrowMPI(ierr);
+
+    /* subrange communicator: */
+
+    subrange_groups_.resize(n_ensembles_);
+    for (int ensemble = 0; ensemble < n_ensembles_; ++ensemble) {
+      int ranges[1][3]{{ensemble, n_world_ranks_ - 1, n_ensembles_}}; // NOLINT
+      ierr = MPI_Group_range_incl(
+          world_group_, 1, ranges, &subrange_groups_[ensemble]);
+      AssertThrowMPI(ierr);
+    }
+
+    ierr = MPI_Comm_create_group(world_communicator_,
+                                 subrange_groups_[ensemble_],
+                                 ensemble_,
+                                 &subrange_communicator_);
+    AssertThrowMPI(ierr);
+
+    /* subrange leader communicator: */
+
+    ensemble_rank_ =
         dealii::Utilities::MPI::this_mpi_process(subrange_communicator_);
-
-    MPI_Comm_split(
-        world_communicator_, subrange_rank, ensemble_, &peer_communicator_);
-
-#ifdef DEBUG_OUTPUT
-    const auto subrange_rank =
-        dealii::Utilities::MPI::this_mpi_process(subrange_communicator_);
-    const auto n_subrange_ranks =
+    n_ensemble_ranks_ =
         dealii::Utilities::MPI::n_mpi_processes(subrange_communicator_);
-    std::cout << "RANK: (g = " << world_rank << ", l = " << subrange_rank
-              << ") out of (g = " << n_world_ranks
-              << ", l = " << n_subrange_ranks << ") -> COLOR: " << ensemble_
-              << std::endl;
+    AssertThrow(
+        (ensemble_rank_ == 0 && world_rank_ < n_ensembles_) ||
+            (ensemble_rank_ > 0 && world_rank_ >= n_ensembles_),
+        dealii::ExcMessage("MPI Ensemble: Something went horribly wrong: Could "
+                           "not determine subrange leader."));
+
+    int ranges[1][3]{{0, n_ensembles_ - 1, 1}}; // NOLINT
+    ierr =
+        MPI_Group_range_incl(world_group_, 1, ranges, &subrange_leader_group_);
+    AssertThrowMPI(ierr);
+
+    ierr = MPI_Comm_create(world_communicator_,
+                           subrange_leader_group_,
+                           &subrange_leader_communicator_);
+
+    /* peer communicator: */
+
+    ierr = MPI_Comm_split(
+        world_communicator_, ensemble_rank_, ensemble_, &peer_communicator_);
+    AssertThrowMPI(ierr);
+
+#define DEBUG_OUTPUT
+#ifdef DEBUG_OUTPUT
+    const auto peer_rank =
+        dealii::Utilities::MPI::this_mpi_process(peer_communicator_);
+    const auto n_peer_ranks =
+        dealii::Utilities::MPI::n_mpi_processes(peer_communicator_);
+    std::cout << "RANK: (w = " << world_rank_ << ", e = " << ensemble_rank_
+              << ", p = " << peer_rank << ") out of (w = " << n_world_ranks_
+              << ", e = " << n_ensemble_ranks_ << ", p = " << n_peer_ranks
+              << ") -> belongig to ensemble: " << ensemble_ << std::endl;
 #endif
   }
 } /* namespace ryujin */

--- a/source/mpi_ensemble.cc
+++ b/source/mpi_ensemble.cc
@@ -23,7 +23,6 @@ namespace ryujin
         dealii::Utilities::MPI::n_mpi_processes(world_communicator_);
 
     AssertThrow(n_ensembles > 0, dealii::ExcInternalError());
-    AssertThrow(global_tau_max, dealii::ExcNotImplemented());
     AssertThrow(n_world_ranks % n_ensembles == 0,
                 dealii::ExcMessage(
                     "The total number of (world) MPI ranks must be a multiple "
@@ -37,15 +36,19 @@ namespace ryujin
     const auto world_rank =
         dealii::Utilities::MPI::this_mpi_process(world_communicator_);
 
-    // FIXME: use a smarter binning strategy (or add a parameter).
+    // FIXME: we should use a smarter binning strategy...
     ensemble_ = world_rank % n_ensembles_;
 
     MPI_Comm_split(
         world_communicator_, ensemble_, world_rank, &subrange_communicator_);
 
+    const auto subrange_rank =
+        dealii::Utilities::MPI::this_mpi_process(subrange_communicator_);
+
+    MPI_Comm_split(
+        world_communicator_, subrange_rank, ensemble_, &peer_communicator_);
+
 #ifdef DEBUG_OUTPUT
-    const auto n_world_ranks =
-        dealii::Utilities::MPI::n_mpi_processes(world_communicator_);
     const auto subrange_rank =
         dealii::Utilities::MPI::this_mpi_process(subrange_communicator_);
     const auto n_subrange_ranks =

--- a/source/mpi_ensemble.cc
+++ b/source/mpi_ensemble.cc
@@ -44,6 +44,14 @@ namespace ryujin
     AssertThrow(n_ensembles_ > 0, dealii::ExcInternalError());
     ensemble_ = world_rank_ % n_ensembles_;
 
+    AssertThrow(
+        n_world_ranks_ >= n_ensembles_,
+        dealii::ExcMessage(
+            "The number of (global) MPI processes must be equal to or larger "
+            "than the number of ensembles. But we are trying to run " +
+            std::to_string(n_ensembles_) + " ensembles on " +
+            std::to_string(n_world_ranks_) + " MPI processes."));
+
     /*
      * For each ensemble we create an MPI group with a ensemble-local
      * communicator. This allows to do ensemble-independent time-stepping.

--- a/source/mpi_ensemble.cc
+++ b/source/mpi_ensemble.cc
@@ -1,0 +1,59 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2020 - 2024 by the ryujin authors
+//
+
+#include "mpi_ensemble.h"
+
+namespace ryujin
+{
+  MPIEnsemble::MPIEnsemble(const MPI_Comm &mpi_communicator)
+      : world_communicator_(mpi_communicator)
+      , n_ensembles_(1)
+      , ensemble_(0)
+      , subrange_communicator_(mpi_communicator)
+      , global_tau_max_(true)
+  {
+  }
+
+  void MPIEnsemble::prepare(const int n_ensembles /* = 1 */,
+                            const bool global_tau_max /* = true */)
+  {
+    const auto n_world_ranks =
+        dealii::Utilities::MPI::n_mpi_processes(world_communicator_);
+
+    AssertThrow(n_ensembles > 0, dealii::ExcInternalError());
+    AssertThrow(global_tau_max, dealii::ExcNotImplemented());
+    AssertThrow(n_world_ranks % n_ensembles == 0,
+                dealii::ExcMessage(
+                    "The total number of (world) MPI ranks must be a multiple "
+                    "of the number of ensembles. But we are scheduled with " +
+                    std::to_string(n_world_ranks) + " for running " +
+                    std::to_string(n_ensembles) + " ensembles."));
+
+    n_ensembles_ = n_ensembles;
+    global_tau_max_ = global_tau_max;
+
+    const auto world_rank =
+        dealii::Utilities::MPI::this_mpi_process(world_communicator_);
+
+    // FIXME: use a smarter binning strategy (or add a parameter).
+    ensemble_ = world_rank % n_ensembles_;
+
+    MPI_Comm_split(
+        world_communicator_, ensemble_, world_rank, &subrange_communicator_);
+
+#ifdef DEBUG_OUTPUT
+    const auto n_world_ranks =
+        dealii::Utilities::MPI::n_mpi_processes(world_communicator_);
+    const auto subrange_rank =
+        dealii::Utilities::MPI::this_mpi_process(subrange_communicator_);
+    const auto n_subrange_ranks =
+        dealii::Utilities::MPI::n_mpi_processes(subrange_communicator_);
+    std::cout << "RANK: (g = " << world_rank << ", l = " << subrange_rank
+              << ") out of (g = " << n_world_ranks
+              << ", l = " << n_subrange_ranks << ") -> COLOR: " << ensemble_
+              << std::endl;
+#endif
+  }
+} /* namespace ryujin */

--- a/source/mpi_ensemble.h
+++ b/source/mpi_ensemble.h
@@ -28,6 +28,8 @@ namespace ryujin
   public:
     MPIEnsemble(const MPI_Comm &mpi_communicator);
 
+    ~MPIEnsemble();
+
     /**
      * Prepare the MPI ensemble and split the gobal MPI communicator into
      * @p n_ensembles different subranges of comparable size.
@@ -35,7 +37,9 @@ namespace ryujin
      * @pre The total number of mpi ranks must be an integer multiple of
      * n_ensembles.
      */
-    void prepare(const int n_ensembles = 1, const bool global_tau_max = true);
+    void prepare(const int n_ensembles = 1,
+                 const bool global_tau_max = true,
+                 const bool require_uniform_ensemble_partition = true);
 
     /**
      * Return the world communicator.
@@ -43,25 +47,55 @@ namespace ryujin
     ACCESSOR_READ_ONLY_NO_DEREFERENCE(world_communicator);
 
     /**
+     * The (global) world rank of the current MPI process.
+     */
+    ACCESSOR_READ_ONLY(world_rank);
+
+    /**
+     * The total number of (global) MPI processes.
+     */
+    ACCESSOR_READ_ONLY(n_world_ranks);
+
+    /**
+     * Return the ensemble in the interval [0, n_ensembles) that the given
+     * MPI process belongs to.
+     */
+    ACCESSOR_READ_ONLY(ensemble);
+
+    /**
      * Return the total number of ensembles.
      */
     ACCESSOR_READ_ONLY(n_ensembles);
 
     /**
-     * Return the ensemble in the interval [0, n_ensembles) that the given
-     * rank belongs to.
+     * The (local) ensemble rank of the current MPI process.
      */
-    ACCESSOR_READ_ONLY(ensemble);
+    ACCESSOR_READ_ONLY(ensemble_rank);
 
     /**
-     * The corresponding subrange communicator of the ensemble.
+     * The total number of (local) MPI processes belonging to the ensemble.
+     */
+    ACCESSOR_READ_ONLY(n_ensemble_ranks);
+
+    /**
+     * The corresponding subrange communicator of the ensemble. The
+     * communicator is collective over all ranks participating in the
+     * ensemble. I.e., it allows for ensemble-local communication.
      */
     ACCESSOR_READ_ONLY_NO_DEREFERENCE(subrange_communicator);
 
     /**
+     * A communicator spanning over all ensemble leaders that have ensemble
+     * rank 0. This communicator is collective over all ensemble leaders
+     * and invalid for all other ranks.
+     */
+    ACCESSOR_READ_ONLY_NO_DEREFERENCE(subrange_leader_communicator);
+
+    /**
      * A "peer communicator" that groups all kth ranks of each ensemble
      * together. (Suppose the subrange_communicator() groups rows, then the
-     * peer_communicator() groups columns of the ensemble partition).
+     * peer_communicator() groups columns of the ensemble partition). The
+     * peer communicator is collective over all world ranks.
      */
     ACCESSOR_READ_ONLY_NO_DEREFERENCE(peer_communicator);
 
@@ -76,10 +110,19 @@ namespace ryujin
   private:
     const MPI_Comm &world_communicator_;
 
-    int n_ensembles_;
+    int world_rank_;
+    int n_world_ranks_;
     int ensemble_;
+    int n_ensembles_;
+    int ensemble_rank_;
+    int n_ensemble_ranks_;
+
+    MPI_Group world_group_;
+    std::vector<MPI_Group> subrange_groups_;
+    MPI_Group subrange_leader_group_;
 
     MPI_Comm subrange_communicator_;
+    MPI_Comm subrange_leader_communicator_;
     MPI_Comm peer_communicator_;
 
     bool global_tau_max_;

--- a/source/mpi_ensemble.h
+++ b/source/mpi_ensemble.h
@@ -31,6 +31,9 @@ namespace ryujin
     /**
      * Prepare the MPI ensemble and split the gobal MPI communicator into
      * @p n_ensembles different subranges of comparable size.
+     *
+     * @pre The total number of mpi ranks must be an integer multiple of
+     * n_ensembles.
      */
     void prepare(const int n_ensembles = 1, const bool global_tau_max = true);
 
@@ -51,9 +54,16 @@ namespace ryujin
     ACCESSOR_READ_ONLY(ensemble);
 
     /**
-     * The corresponding subrange communicator for the ensemble.
+     * The corresponding subrange communicator of the ensemble.
      */
     ACCESSOR_READ_ONLY_NO_DEREFERENCE(subrange_communicator);
+
+    /**
+     * A "peer communicator" that groups all kth ranks of each ensemble
+     * together. (Suppose the subrange_communicator() groups rows, then the
+     * peer_communicator() groups columns of the ensemble partition).
+     */
+    ACCESSOR_READ_ONLY_NO_DEREFERENCE(peer_communicator);
 
     /**
      * Return whether the ensemble has to be run with a global tau_max
@@ -70,6 +80,7 @@ namespace ryujin
     int ensemble_;
 
     MPI_Comm subrange_communicator_;
+    MPI_Comm peer_communicator_;
 
     bool global_tau_max_;
   };

--- a/source/mpi_ensemble.h
+++ b/source/mpi_ensemble.h
@@ -28,8 +28,10 @@ namespace ryujin
   public:
     MPIEnsemble(const MPI_Comm &mpi_communicator)
         : world_communicator_(mpi_communicator)
+        , n_ensembles_(1)
         , ensemble_(0)
         , subrange_communicator_(mpi_communicator)
+        , global_tau_max_(true)
     {
     }
 
@@ -37,10 +39,11 @@ namespace ryujin
      * Prepare the MPI ensemble and split the gobal MPI communicator into
      * @p n_ensembles different subranges of comparable size.
      */
-    void prepare(const int n_ensembles = 1)
+    void prepare(const int n_ensembles = 1, const bool global_tau_max = true)
     {
       Assert(n_ensembles > 0, dealii::ExcInternalError());
       n_ensembles_ = n_ensembles;
+      global_tau_max_ = global_tau_max;
 
       const auto world_rank =
           dealii::Utilities::MPI::this_mpi_process(world_communicator_);
@@ -81,11 +84,22 @@ namespace ryujin
      */
     ACCESSOR_READ_ONLY_NO_DEREFERENCE(subrange_communicator);
 
+    /**
+     * Return whether the ensemble has to be run with a global tau_max
+     * constraint in which every ensemble member performs an update with
+     * the same time step, or whether synchronization is only performed
+     * over the ensemble.
+     */
+    ACCESSOR_READ_ONLY(global_tau_max);
+
   private:
     const MPI_Comm &world_communicator_;
 
     int n_ensembles_;
     int ensemble_;
+
     MPI_Comm subrange_communicator_;
+
+    bool global_tau_max_;
   };
 } /* namespace ryujin */

--- a/source/mpi_ensemble.h
+++ b/source/mpi_ensemble.h
@@ -26,42 +26,13 @@ namespace ryujin
   class MPIEnsemble final
   {
   public:
-    MPIEnsemble(const MPI_Comm &mpi_communicator)
-        : world_communicator_(mpi_communicator)
-        , n_ensembles_(1)
-        , ensemble_(0)
-        , subrange_communicator_(mpi_communicator)
-        , global_tau_max_(true)
-    {
-    }
+    MPIEnsemble(const MPI_Comm &mpi_communicator);
 
     /**
      * Prepare the MPI ensemble and split the gobal MPI communicator into
      * @p n_ensembles different subranges of comparable size.
      */
-    void prepare(const int n_ensembles = 1, const bool global_tau_max = true)
-    {
-      Assert(n_ensembles > 0, dealii::ExcInternalError());
-      n_ensembles_ = n_ensembles;
-      global_tau_max_ = global_tau_max;
-
-      const auto world_rank =
-          dealii::Utilities::MPI::this_mpi_process(world_communicator_);
-
-      // FIXME: use a smarter binning strategy (or add a parameter).
-      ensemble_ = world_rank % n_ensembles_;
-
-      MPI_Comm_split(
-          world_communicator_, ensemble_, world_rank, &subrange_communicator_);
-
-#ifdef DEBUG_OUTPUT
-      const auto subrange_rank =
-          dealii::Utilities::MPI::this_mpi_process(subrange_communicator_);
-
-      std::cout << "RANK: (" << world_rank << "," << subrange_rank
-                << ") -> COLOR: " << ensemble_ << std::endl;
-#endif
-    }
+    void prepare(const int n_ensembles = 1, const bool global_tau_max = true);
 
     /**
      * Return the world communicator.

--- a/source/mpi_ensemble.h
+++ b/source/mpi_ensemble.h
@@ -1,0 +1,91 @@
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Copyright (C) 2020 - 2024 by the ryujin authors
+//
+
+#pragma once
+
+#include <compile_time_options.h>
+
+#include "convenience_macros.h"
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/utilities.h>
+
+namespace ryujin
+{
+  /**
+   * A class responsible for subdividing a given global MPI communicator
+   * into a set of "ensembles" with a coresponding subrange communicator.
+   *
+   * After @p prepare() is called, all getter functions return valid
+   * references.
+   *
+   * @ingroup Miscellaneous
+   */
+  class MPIEnsemble final
+  {
+  public:
+    MPIEnsemble(const MPI_Comm &mpi_communicator)
+        : world_communicator_(mpi_communicator)
+        , ensemble_(0)
+        , subrange_communicator_(mpi_communicator)
+    {
+    }
+
+    /**
+     * Prepare the MPI ensemble and split the gobal MPI communicator into
+     * @p n_ensembles different subranges of comparable size.
+     */
+    void prepare(const int n_ensembles = 1)
+    {
+      Assert(n_ensembles > 0, dealii::ExcInternalError());
+      n_ensembles_ = n_ensembles;
+
+      const auto world_rank =
+          dealii::Utilities::MPI::this_mpi_process(world_communicator_);
+
+      // FIXME: use a smarter binning strategy (or add a parameter).
+      ensemble_ = world_rank % n_ensembles_;
+
+      MPI_Comm_split(
+          world_communicator_, ensemble_, world_rank, &subrange_communicator_);
+
+#ifdef DEBUG_OUTPUT
+      const auto subrange_rank =
+          dealii::Utilities::MPI::this_mpi_process(subrange_communicator_);
+
+      std::cout << "RANK: (" << world_rank << "," << subrange_rank
+                << ") -> COLOR: " << ensemble_ << std::endl;
+#endif
+    }
+
+    /**
+     * Return the world communicator.
+     */
+    ACCESSOR_READ_ONLY_NO_DEREFERENCE(world_communicator);
+
+    /**
+     * Return the total number of ensembles.
+     */
+    ACCESSOR_READ_ONLY(n_ensembles);
+
+    /**
+     * Return the ensemble in the interval [0, n_ensembles) that the given
+     * rank belongs to.
+     */
+    ACCESSOR_READ_ONLY(ensemble);
+
+    /**
+     * The corresponding subrange communicator for the ensemble.
+     */
+    ACCESSOR_READ_ONLY_NO_DEREFERENCE(subrange_communicator);
+
+  private:
+    const MPI_Comm &world_communicator_;
+
+    int n_ensembles_;
+    int ensemble_;
+    MPI_Comm subrange_communicator_;
+  };
+} /* namespace ryujin */

--- a/source/mpi_ensemble.h
+++ b/source/mpi_ensemble.h
@@ -17,6 +17,8 @@ namespace ryujin
   /**
    * A class responsible for subdividing a given global MPI communicator
    * into a set of "ensembles" with a coresponding ensemble communicator.
+   * This allows us to run similar, related hyperbolic systems in parallel
+   * on subranges of the set of (global) MPI processes.
    *
    * After @p prepare() is called, all getter functions return valid
    * references.
@@ -32,7 +34,11 @@ namespace ryujin
 
     /**
      * Prepare the MPI ensemble and split the gobal MPI communicator into
-     * @p n_ensembles different subranges of comparable size.
+     * @p n_ensembles different subranges of comparable size. The boolean
+     * @p global_synchronization indicates whether (global) world
+     * synchronization of time step size and other synchronization state is
+     * performend in the HyperbolicModule and ParabolicModule, or whether
+     * such synchronization remains local to the ensemble.
      *
      * @pre The total number of mpi ranks must be an integer multiple of
      * n_ensembles.
@@ -46,8 +52,7 @@ namespace ryujin
     ACCESSOR_READ_ONLY_NO_DEREFERENCE(world_communicator);
 
     /**
-     * If true, then ensembles run in lock step with a synchronized
-     * tau_max.
+     * If true, then ensembles run in lockstep with a synchronized tau_max.
      */
     ACCESSOR_READ_ONLY(global_synchronization);
 

--- a/source/navier_stokes/parabolic_solver.h
+++ b/source/navier_stokes/parabolic_solver.h
@@ -11,6 +11,7 @@
 
 #include <convenience_macros.h>
 #include <initial_values.h>
+#include <mpi_ensemble.h>
 #include <offline_data.h>
 #include <simd.h>
 #include <sparse_matrix_simd.h>
@@ -147,7 +148,7 @@ namespace ryujin
        * Constructor.
        */
       ParabolicSolver(
-          const MPI_Comm &mpi_communicator,
+          const MPIEnsemble &mpi_ensemble,
           std::map<std::string, dealii::Timer> &computing_timer,
           const HyperbolicSystem &hyperbolic_system,
           const ParabolicSystem &parabolic_system,
@@ -233,7 +234,7 @@ namespace ryujin
       static constexpr unsigned int order_fe = 1;
       static constexpr unsigned int order_quad = 2;
 
-      const MPI_Comm &mpi_communicator_;
+      const MPIEnsemble &mpi_ensemble_;
       std::map<std::string, dealii::Timer> &computing_timer_;
 
       dealii::SmartPointer<const HyperbolicSystem> hyperbolic_system_;

--- a/source/navier_stokes/parabolic_solver.template.h
+++ b/source/navier_stokes/parabolic_solver.template.h
@@ -32,7 +32,7 @@ namespace ryujin
 
     template <typename Description, int dim, typename Number>
     ParabolicSolver<Description, dim, Number>::ParabolicSolver(
-        const MPI_Comm &mpi_communicator,
+        const MPIEnsemble &mpi_ensemble,
         std::map<std::string, dealii::Timer> &computing_timer,
         const HyperbolicSystem &hyperbolic_system,
         const ParabolicSystem &parabolic_system,
@@ -40,7 +40,7 @@ namespace ryujin
         const InitialValues<Description, dim, Number> &initial_values,
         const std::string &subsection /*= "ParabolicSolver"*/)
         : ParameterAcceptor(subsection)
-        , mpi_communicator_(mpi_communicator)
+        , mpi_ensemble_(mpi_ensemble)
         , computing_timer_(computing_timer)
         , hyperbolic_system_(&hyperbolic_system)
         , parabolic_system_(&parabolic_system)
@@ -429,7 +429,9 @@ namespace ryujin
         // .begin() and .end() denote the locally owned index range:
         e_min_old =
             *std::min_element(internal_energy_.begin(), internal_energy_.end());
-        e_min_old = Utilities::MPI::min(e_min_old, mpi_communicator_);
+
+        e_min_old = Utilities::MPI::min(e_min_old,
+                                        mpi_ensemble_.subrange_communicator());
 
         // FIXME: create a meaningful relaxation based on global mesh size min.
         constexpr Number eps = std::numeric_limits<Number>::epsilon();
@@ -764,7 +766,8 @@ namespace ryujin
           // .begin() and .end() denote the locally owned index range:
           auto e_min_new = *std::min_element(internal_energy_.begin(),
                                              internal_energy_.end());
-          e_min_new = Utilities::MPI::min(e_min_new, mpi_communicator_);
+          e_min_new = Utilities::MPI::min(
+              e_min_new, mpi_ensemble_.subrange_communicator());
 
           if (e_min_new < e_min_old) {
 #ifdef DEBUG_OUTPUT
@@ -834,6 +837,22 @@ namespace ryujin
       }
 
       CALLGRIND_STOP_INSTRUMENTATION;
+
+      {
+        Scope scope(computing_timer_,
+                    "time step [H] _ - synchronization barriers");
+
+        /*
+         * Synchronize whether we have to restart the time step. Even though
+         * the restart condition itself only affects the local ensemble we
+         * nevertheless need to synchronize the boolean in case we perform
+         * synchronized global time steps. (Otherwise different ensembles
+         * might end up with a different time step.)
+         */
+        if (mpi_ensemble_.global_tau_max())
+          restart_needed.store(Utilities::MPI::logical_or(
+              restart_needed.load(), mpi_ensemble_.world_communicator()));
+      }
 
       if (restart_needed) {
         switch (id_violation_strategy) {

--- a/source/navier_stokes/parabolic_solver.template.h
+++ b/source/navier_stokes/parabolic_solver.template.h
@@ -431,7 +431,7 @@ namespace ryujin
             *std::min_element(internal_energy_.begin(), internal_energy_.end());
 
         e_min_old = Utilities::MPI::min(e_min_old,
-                                        mpi_ensemble_.subrange_communicator());
+                                        mpi_ensemble_.ensemble_communicator());
 
         // FIXME: create a meaningful relaxation based on global mesh size min.
         constexpr Number eps = std::numeric_limits<Number>::epsilon();
@@ -767,7 +767,7 @@ namespace ryujin
           auto e_min_new = *std::min_element(internal_energy_.begin(),
                                              internal_energy_.end());
           e_min_new = Utilities::MPI::min(
-              e_min_new, mpi_ensemble_.subrange_communicator());
+              e_min_new, mpi_ensemble_.ensemble_communicator());
 
           if (e_min_new < e_min_old) {
 #ifdef DEBUG_OUTPUT
@@ -849,9 +849,9 @@ namespace ryujin
          * synchronized global time steps. (Otherwise different ensembles
          * might end up with a different time step.)
          */
-        if (mpi_ensemble_.global_tau_max())
-          restart_needed.store(Utilities::MPI::logical_or(
-              restart_needed.load(), mpi_ensemble_.world_communicator()));
+        restart_needed.store(Utilities::MPI::logical_or(
+            restart_needed.load(),
+            mpi_ensemble_.synchronization_communicator()));
       }
 
       if (restart_needed) {

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -9,6 +9,7 @@
 
 #include "convenience_macros.h"
 #include "discretization.h"
+#include "mpi_ensemble.h"
 #include "sparse_matrix_simd.h"
 #include "state_vector.h"
 
@@ -41,6 +42,9 @@ namespace ryujin
    * @note The offline data precomputed in this class is problem
    * independent, it only depends on the chosen geometry and ansatz stored
    * in the Discretization class.
+   *
+   * @note Data structures in OfflineData are initialized with the ensemble
+   * subrange communicator stored in MPIEnsemble.
    *
    * @ingroup Mesh
    */
@@ -82,7 +86,7 @@ namespace ryujin
     /**
      * Constructor
      */
-    OfflineData(const MPI_Comm &mpi_communicator,
+    OfflineData(const MPIEnsemble &mpi_ensemble,
                 const Discretization<dim> &discretization,
                 const std::string &subsection = "/OfflineData");
 
@@ -295,6 +299,14 @@ namespace ryujin
      */
     void create_multigrid_data();
 
+    //@}
+    /**
+     * Private fields
+     */
+    //@{
+
+    const MPIEnsemble &mpi_ensemble_;
+
     std::unique_ptr<dealii::DoFHandler<dim>> dof_handler_;
 
     dealii::AffineConstraints<Number> affine_constraints_;
@@ -339,8 +351,6 @@ namespace ryujin
     Number measure_of_omega_;
 
     dealii::SmartPointer<const Discretization<dim>> discretization_;
-
-    const MPI_Comm &mpi_communicator_;
 
     /**
      * Construct a boundary map for a given set of DoFHandler iterators.

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -1134,7 +1134,7 @@ namespace ryujin
       const auto partitioner = std::make_shared<Utilities::MPI::Partitioner>(
           dof_handler.locally_owned_mg_dofs(level),
           relevant_dofs,
-          lumped_mass_matrix_.get_mpi_communicator());
+          mpi_communicator_);
       level_lumped_mass_matrix_[level].reinit(partitioner);
       std::vector<types::global_dof_index> dof_indices(
           dof_handler.get_fe().dofs_per_cell);

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -36,12 +36,12 @@ namespace ryujin
 
   template <int dim, typename Number>
   OfflineData<dim, Number>::OfflineData(
-      const MPI_Comm &mpi_communicator,
+      const MPIEnsemble &mpi_ensemble,
       const Discretization<dim> &discretization,
       const std::string &subsection /*= "OfflineData"*/)
       : ParameterAcceptor(subsection)
       , discretization_(&discretization)
-      , mpi_communicator_(mpi_communicator)
+      , mpi_ensemble_(mpi_ensemble)
   {
     incidence_relaxation_even_ = 0.5;
     add_parameter("incidence matrix relaxation even degree",
@@ -106,7 +106,7 @@ namespace ryujin
           right.first->index(),
           &dof_handler);
 
-      if constexpr (std::is_same<Number, double>::value) {
+      if constexpr (std::is_same_v<Number, double>) {
         DoFTools::make_periodicity_constraints(
             dof_cell_left->face(left.second),
             dof_cell_right->face(right.second),
@@ -131,14 +131,15 @@ namespace ryujin
     {
       /* Check that constraints are consistent in parallel: */
       const std::vector<IndexSet> &locally_owned_dofs =
-          Utilities::MPI::all_gather(mpi_communicator_,
+          Utilities::MPI::all_gather(mpi_ensemble_.subrange_communicator(),
                                      dof_handler.locally_owned_dofs());
       const IndexSet locally_active =
           dealii::DoFTools::extract_locally_active_dofs(dof_handler);
-      Assert(affine_constraints_.is_consistent_in_parallel(locally_owned_dofs,
-                                                           locally_active,
-                                                           mpi_communicator_,
-                                                           /*verbose*/ true),
+      Assert(affine_constraints_.is_consistent_in_parallel(
+                 locally_owned_dofs,
+                 locally_active,
+                 mpi_ensemble_.subrange_communicator(),
+                 /*verbose*/ true),
              ExcInternalError());
     }
 #endif
@@ -178,7 +179,10 @@ namespace ryujin
      */
 
     SparsityTools::distribute_sparsity_pattern(
-        sparsity_pattern_, locally_owned, mpi_communicator_, locally_relevant);
+        sparsity_pattern_,
+        locally_owned,
+        mpi_ensemble_.subrange_communicator(),
+        locally_relevant);
   }
 
 
@@ -217,8 +221,10 @@ namespace ryujin
      * eliminating hanging node and periodicity constraints (which we do
      * not know at this point because they depend on the renumbering...).
      */
-    DoFRenumbering::export_indices_first(
-        dof_handler, mpi_communicator_, n_locally_owned_, 1);
+    DoFRenumbering::export_indices_first(dof_handler,
+                                         mpi_ensemble_.subrange_communicator(),
+                                         n_locally_owned_,
+                                         1);
 
     /*
      * Group degrees of freedom that have the same stencil size in groups
@@ -242,11 +248,11 @@ namespace ryujin
      * not know at this point because they depend on the renumbering...).
      * We therefore have to update n_export_indices_ later again.
      */
-    n_export_indices_ =
-        DoFRenumbering::export_indices_first(dof_handler,
-                                             mpi_communicator_,
-                                             n_locally_internal_,
-                                             VectorizedArray<Number>::size());
+    n_export_indices_ = DoFRenumbering::export_indices_first(
+        dof_handler,
+        mpi_ensemble_.subrange_communicator(),
+        n_locally_internal_,
+        VectorizedArray<Number>::size());
 
     /*
      * A small lambda to check for stride-level consistency of the internal
@@ -280,7 +286,7 @@ namespace ryujin
         return left || right;
       };
       return Utilities::MPI::all_reduce(
-          local_value, mpi_communicator_, comparator);
+          local_value, mpi_ensemble_.subrange_communicator(), comparator);
     };
 
     /*
@@ -351,7 +357,7 @@ namespace ryujin
     n_locally_relevant_ = locally_relevant.n_elements();
 
     scalar_partitioner_ = std::make_shared<dealii::Utilities::MPI::Partitioner>(
-        locally_owned, locally_relevant, mpi_communicator_);
+        locally_owned, locally_relevant, mpi_ensemble_.subrange_communicator());
 
     hyperbolic_vector_partitioner_ = Vectors::create_vector_partitioner(
         scalar_partitioner_, problem_dimension);
@@ -445,8 +451,9 @@ namespace ryujin
 
     const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
     TrilinosWrappers::SparsityPattern trilinos_sparsity_pattern;
-    trilinos_sparsity_pattern.reinit(
-        locally_owned, sparsity_pattern_, mpi_communicator_);
+    trilinos_sparsity_pattern.reinit(locally_owned,
+                                     sparsity_pattern_,
+                                     mpi_ensemble_.subrange_communicator());
 
     TrilinosWrappers::SparseMatrix mass_matrix_tmp;
     TrilinosWrappers::SparseMatrix mass_matrix_inverse_tmp;
@@ -758,8 +765,8 @@ namespace ryujin
       mass_matrix_inverse_.update_ghost_rows();
     cij_matrix_.update_ghost_rows();
 
-    measure_of_omega_ =
-        Utilities::MPI::sum(measure_of_omega_, mpi_communicator_);
+    measure_of_omega_ = Utilities::MPI::sum(
+        measure_of_omega_, mpi_ensemble_.subrange_communicator());
 
     /*
      * Create lumped mass matrix:
@@ -1007,7 +1014,8 @@ namespace ryujin
     double total_mass = 0.;
     for (unsigned int i = 0; i < n_locally_owned_; ++i)
       total_mass += lumped_mass_matrix_.local_element(i);
-    total_mass = Utilities::MPI::sum(total_mass, mpi_communicator_);
+    total_mass =
+        Utilities::MPI::sum(total_mass, mpi_ensemble_.subrange_communicator());
 
     Assert(std::abs(measure_of_omega_ - total_mass) <
                1.e-12 * measure_of_omega_,
@@ -1134,7 +1142,7 @@ namespace ryujin
       const auto partitioner = std::make_shared<Utilities::MPI::Partitioner>(
           dof_handler.locally_owned_mg_dofs(level),
           relevant_dofs,
-          mpi_communicator_);
+          mpi_ensemble_.subrange_communicator());
       level_lumped_mass_matrix_[level].reinit(partitioner);
       std::vector<types::global_dof_index> dof_indices(
           dof_handler.get_fe().dofs_per_cell);

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -40,8 +40,8 @@ namespace ryujin
       const Discretization<dim> &discretization,
       const std::string &subsection /*= "OfflineData"*/)
       : ParameterAcceptor(subsection)
-      , discretization_(&discretization)
       , mpi_ensemble_(mpi_ensemble)
+      , discretization_(&discretization)
   {
     incidence_relaxation_even_ = 0.5;
     add_parameter("incidence matrix relaxation even degree",

--- a/source/parabolic_module.h
+++ b/source/parabolic_module.h
@@ -11,6 +11,7 @@
 
 #include "convenience_macros.h"
 #include "initial_values.h"
+#include "mpi_ensemble.h"
 #include "offline_data.h"
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -59,7 +60,7 @@ namespace ryujin
      * Constructor.
      */
     ParabolicModule(
-        const MPI_Comm &mpi_communicator,
+        const MPIEnsemble &mpi_ensemble,
         std::map<std::string, dealii::Timer> &computing_timer,
         const OfflineData<dim, Number> &offline_data,
         const HyperbolicSystem &hyperbolic_system,

--- a/source/parabolic_module.template.h
+++ b/source/parabolic_module.template.h
@@ -13,7 +13,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   ParabolicModule<Description, dim, Number>::ParabolicModule(
-      const MPI_Comm &mpi_communicator,
+      const MPIEnsemble &mpi_ensemble,
       std::map<std::string, dealii::Timer> &computing_timer,
       const OfflineData<dim, Number> &offline_data,
       const HyperbolicSystem &hyperbolic_system,
@@ -22,7 +22,7 @@ namespace ryujin
       const std::string &subsection /*= "ParabolicModule"*/)
       : ParameterAcceptor(subsection)
       , id_violation_strategy_(IDViolationStrategy::warn)
-      , parabolic_solver_(mpi_communicator,
+      , parabolic_solver_(mpi_ensemble,
                           computing_timer,
                           hyperbolic_system,
                           parabolic_system,

--- a/source/postprocessor.h
+++ b/source/postprocessor.h
@@ -5,8 +5,9 @@
 
 #pragma once
 
-#include <compile_time_options.h>
-#include <offline_data.h>
+#include "compile_time_options.h"
+#include "mpi_ensemble.h"
+#include "offline_data.h"
 
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/smartpointer.h>
@@ -73,7 +74,7 @@ namespace ryujin
     /**
      * Constructor.
      */
-    Postprocessor(const MPI_Comm &mpi_communicator,
+    Postprocessor(const MPIEnsemble &mpi_ensemble,
                   const OfflineData<dim, Number> &offline_data,
                   const HyperbolicSystem &hyperbolic_system,
                   const ParabolicSystem &parabolic_system,
@@ -153,7 +154,7 @@ namespace ryujin
      */
     //@{
 
-    const MPI_Comm &mpi_communicator_;
+    const MPIEnsemble &mpi_ensemble_;
 
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;
     dealii::SmartPointer<const HyperbolicSystem> hyperbolic_system_;

--- a/source/postprocessor.template.h
+++ b/source/postprocessor.template.h
@@ -241,9 +241,9 @@ namespace ryujin
           q_min = std::min(q_min, std::abs(q));
         }
         q_max = dealii::Utilities::MPI::max(
-            q_max, mpi_ensemble_.subrange_communicator());
+            q_max, mpi_ensemble_.ensemble_communicator());
         q_min = dealii::Utilities::MPI::min(
-            q_min, mpi_ensemble_.subrange_communicator());
+            q_min, mpi_ensemble_.ensemble_communicator());
         Assert(q_max >= q_min, dealii::ExcInternalError());
       }
     }

--- a/source/postprocessor.template.h
+++ b/source/postprocessor.template.h
@@ -17,13 +17,13 @@ namespace ryujin
 {
   template <typename Description, int dim, typename Number>
   Postprocessor<Description, dim, Number>::Postprocessor(
-      const MPI_Comm &mpi_communicator,
+      const MPIEnsemble &mpi_ensemble,
       const OfflineData<dim, Number> &offline_data,
       const HyperbolicSystem &hyperbolic_system,
       const ParabolicSystem &parabolic_system,
       const std::string &subsection /*= "Postprocessor"*/)
       : ParameterAcceptor(subsection)
-      , mpi_communicator_(mpi_communicator)
+      , mpi_ensemble_(mpi_ensemble)
       , offline_data_(&offline_data)
       , hyperbolic_system_(&hyperbolic_system)
       , parabolic_system_(&parabolic_system)
@@ -240,8 +240,10 @@ namespace ryujin
           q_max = std::max(q_max, std::abs(q));
           q_min = std::min(q_min, std::abs(q));
         }
-        q_max = dealii::Utilities::MPI::max(q_max, mpi_communicator_);
-        q_min = dealii::Utilities::MPI::min(q_min, mpi_communicator_);
+        q_max = dealii::Utilities::MPI::max(
+            q_max, mpi_ensemble_.subrange_communicator());
+        q_min = dealii::Utilities::MPI::min(
+            q_min, mpi_ensemble_.subrange_communicator());
         Assert(q_max >= q_min, dealii::ExcInternalError());
       }
     }

--- a/source/quantities.h
+++ b/source/quantities.h
@@ -7,6 +7,7 @@
 
 #include <compile_time_options.h>
 
+#include "mpi_ensemble.h"
 #include "offline_data.h"
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -52,7 +53,7 @@ namespace ryujin
     /**
      * Constructor.
      */
-    Quantities(const MPI_Comm &mpi_communicator,
+    Quantities(const MPIEnsemble &mpi_ensemble,
                const OfflineData<dim, Number> &offline_data,
                const HyperbolicSystem &hyperbolic_system,
                const ParabolicSystem &parabolic_system,
@@ -107,7 +108,7 @@ namespace ryujin
      */
     //@{
 
-    const MPI_Comm &mpi_communicator_;
+    const MPIEnsemble &mpi_ensemble_;
 
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;
     dealii::SmartPointer<const HyperbolicSystem> hyperbolic_system_;

--- a/source/quantities.template.h
+++ b/source/quantities.template.h
@@ -268,10 +268,10 @@ namespace ryujin
        */
 
       const auto received = Utilities::MPI::gather(
-          mpi_ensemble_.subrange_communicator(), interior_map);
+          mpi_ensemble_.ensemble_communicator(), interior_map);
 
       if (Utilities::MPI::this_mpi_process(
-              mpi_ensemble_.subrange_communicator()) == 0) {
+              mpi_ensemble_.ensemble_communicator()) == 0) {
 
         std::ofstream output(base_name_ + "-" + name + "-R" +
                              Utilities::to_string(cycle, 4) + "-points.dat");
@@ -311,10 +311,10 @@ namespace ryujin
        */
 
       const auto received = Utilities::MPI::gather(
-          mpi_ensemble_.subrange_communicator(), boundary_map);
+          mpi_ensemble_.ensemble_communicator(), boundary_map);
 
       if (Utilities::MPI::this_mpi_process(
-              mpi_ensemble_.subrange_communicator()) == 0) {
+              mpi_ensemble_.ensemble_communicator()) == 0) {
 
         std::ofstream output(base_name_ + "-" + name + "-R" +
                              Utilities::to_string(cycle, 4) + "-points.dat");
@@ -411,12 +411,12 @@ namespace ryujin
     /* synchronize MPI ranks (MPI Barrier): */
 
     mass_sum =
-        Utilities::MPI::sum(mass_sum, mpi_ensemble_.subrange_communicator());
+        Utilities::MPI::sum(mass_sum, mpi_ensemble_.ensemble_communicator());
 
     std::get<0>(spatial_average) = Utilities::MPI::sum(
-        std::get<0>(spatial_average), mpi_ensemble_.subrange_communicator());
+        std::get<0>(spatial_average), mpi_ensemble_.ensemble_communicator());
     std::get<1>(spatial_average) = Utilities::MPI::sum(
-        std::get<1>(spatial_average), mpi_ensemble_.subrange_communicator());
+        std::get<1>(spatial_average), mpi_ensemble_.ensemble_communicator());
 
     /* take average: */
 
@@ -442,10 +442,10 @@ namespace ryujin
      */
 
     const auto received =
-        Utilities::MPI::gather(mpi_ensemble_.subrange_communicator(), values);
+        Utilities::MPI::gather(mpi_ensemble_.ensemble_communicator(), values);
 
     if (Utilities::MPI::this_mpi_process(
-            mpi_ensemble_.subrange_communicator()) == 0) {
+            mpi_ensemble_.ensemble_communicator()) == 0) {
 
       std::ofstream output(file_name);
       output << std::scientific << std::setprecision(14);
@@ -473,7 +473,7 @@ namespace ryujin
       bool append)
   {
     if (Utilities::MPI::this_mpi_process(
-            mpi_ensemble_.subrange_communicator()) == 0) {
+            mpi_ensemble_.ensemble_communicator()) == 0) {
       std::ofstream output;
       output << std::scientific << std::setprecision(14);
 

--- a/source/quantities.template.h
+++ b/source/quantities.template.h
@@ -49,13 +49,13 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   Quantities<Description, dim, Number>::Quantities(
-      const MPI_Comm &mpi_communicator,
+      const MPIEnsemble &mpi_ensemble,
       const OfflineData<dim, Number> &offline_data,
       const HyperbolicSystem &hyperbolic_system,
       const ParabolicSystem &parabolic_system,
       const std::string &subsection /*= "Quantities"*/)
       : ParameterAcceptor(subsection)
-      , mpi_communicator_(mpi_communicator)
+      , mpi_ensemble_(mpi_ensemble)
       , offline_data_(&offline_data)
       , hyperbolic_system_(&hyperbolic_system)
       , parabolic_system_(&parabolic_system)
@@ -267,10 +267,11 @@ namespace ryujin
        * only MPI ranks participating who actually have boundary values.
        */
 
-      const auto received =
-          Utilities::MPI::gather(mpi_communicator_, interior_map);
+      const auto received = Utilities::MPI::gather(
+          mpi_ensemble_.subrange_communicator(), interior_map);
 
-      if (Utilities::MPI::this_mpi_process(mpi_communicator_) == 0) {
+      if (Utilities::MPI::this_mpi_process(
+              mpi_ensemble_.subrange_communicator()) == 0) {
 
         std::ofstream output(base_name_ + "-" + name + "-R" +
                              Utilities::to_string(cycle, 4) + "-points.dat");
@@ -309,10 +310,11 @@ namespace ryujin
        * only MPI ranks participating who actually have boundary values.
        */
 
-      const auto received =
-          Utilities::MPI::gather(mpi_communicator_, boundary_map);
+      const auto received = Utilities::MPI::gather(
+          mpi_ensemble_.subrange_communicator(), boundary_map);
 
-      if (Utilities::MPI::this_mpi_process(mpi_communicator_) == 0) {
+      if (Utilities::MPI::this_mpi_process(
+              mpi_ensemble_.subrange_communicator()) == 0) {
 
         std::ofstream output(base_name_ + "-" + name + "-R" +
                              Utilities::to_string(cycle, 4) + "-points.dat");
@@ -387,7 +389,7 @@ namespace ryujin
            * boundary mass.
            */
           constexpr auto index =
-              std::is_same<point_type, interior_point>::value ? 1 : 3;
+              std::is_same_v<point_type, interior_point> ? 1 : 3;
           const auto mass_i = std::get<index>(point);
 
           const auto U_i = U.get_tensor(i);
@@ -408,12 +410,13 @@ namespace ryujin
 
     /* synchronize MPI ranks (MPI Barrier): */
 
-    mass_sum = Utilities::MPI::sum(mass_sum, mpi_communicator_);
+    mass_sum =
+        Utilities::MPI::sum(mass_sum, mpi_ensemble_.subrange_communicator());
 
-    std::get<0>(spatial_average) =
-        Utilities::MPI::sum(std::get<0>(spatial_average), mpi_communicator_);
-    std::get<1>(spatial_average) =
-        Utilities::MPI::sum(std::get<1>(spatial_average), mpi_communicator_);
+    std::get<0>(spatial_average) = Utilities::MPI::sum(
+        std::get<0>(spatial_average), mpi_ensemble_.subrange_communicator());
+    std::get<1>(spatial_average) = Utilities::MPI::sum(
+        std::get<1>(spatial_average), mpi_ensemble_.subrange_communicator());
 
     /* take average: */
 
@@ -438,9 +441,11 @@ namespace ryujin
      * only MPI ranks participating who actually have interior values.
      */
 
-    const auto received = Utilities::MPI::gather(mpi_communicator_, values);
+    const auto received =
+        Utilities::MPI::gather(mpi_ensemble_.subrange_communicator(), values);
 
-    if (Utilities::MPI::this_mpi_process(mpi_communicator_) == 0) {
+    if (Utilities::MPI::this_mpi_process(
+            mpi_ensemble_.subrange_communicator()) == 0) {
 
       std::ofstream output(file_name);
       output << std::scientific << std::setprecision(14);
@@ -467,7 +472,8 @@ namespace ryujin
       const std::vector<std::tuple<Number, value_type>> &values,
       bool append)
   {
-    if (Utilities::MPI::this_mpi_process(mpi_communicator_) == 0) {
+    if (Utilities::MPI::this_mpi_process(
+            mpi_ensemble_.subrange_communicator()) == 0) {
       std::ofstream output;
       output << std::scientific << std::setprecision(14);
 

--- a/source/stub_solver.h
+++ b/source/stub_solver.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "hyperbolic_system.h"
+#include "mpi_ensemble.h"
 #include "parabolic_system.h"
 
 #include <initial_values.h>
@@ -36,7 +37,7 @@ namespace ryujin
      * Constructor.
      */
     StubSolver(
-        const MPI_Comm & /*mpi_communicator*/,
+        const MPIEnsemble & /*mpi_ensemle*/,
         std::map<std::string, dealii::Timer> & /*computing_timer*/,
         const HyperbolicSystem & /*hyperbolic_system*/,
         const ParabolicSystem & /*parabolic_system*/,

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -9,6 +9,7 @@
 
 #include "convenience_macros.h"
 #include "hyperbolic_module.h"
+#include "mpi_ensemble.h"
 #include "offline_data.h"
 #include "parabolic_module.h"
 #include "patterns_conversion.h"
@@ -265,7 +266,7 @@ namespace ryujin
      * Constructor.
      */
     TimeIntegrator(
-        const MPI_Comm &mpi_communicator,
+        const MPIEnsemble &mpi_ensemble,
         const OfflineData<dim, Number> &offline_data,
         const HyperbolicModule<Description, dim, Number> &hyperbolic_module,
         const ParabolicModule<Description, dim, Number> &parabolic_module,
@@ -454,7 +455,7 @@ namespace ryujin
      */
     //@{
 
-    const MPI_Comm &mpi_communicator_;
+    const MPIEnsemble &mpi_ensemble_;
 
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;
     dealii::SmartPointer<const HyperbolicModule<Description, dim, Number>>

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -27,13 +27,13 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   TimeIntegrator<Description, dim, Number>::TimeIntegrator(
-      const MPI_Comm &mpi_communicator,
+      const MPIEnsemble &mpi_ensemble,
       const OfflineData<dim, Number> &offline_data,
       const HyperbolicModule<Description, dim, Number> &hyperbolic_module,
       const ParabolicModule<Description, dim, Number> &parabolic_module,
       const std::string &subsection /*= "TimeIntegrator"*/)
       : ParameterAcceptor(subsection)
-      , mpi_communicator_(mpi_communicator)
+      , mpi_ensemble_(mpi_ensemble)
       , offline_data_(&offline_data)
       , hyperbolic_module_(&hyperbolic_module)
       , parabolic_module_(&parabolic_module)

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -153,6 +153,7 @@ namespace ryujin
     //@{
 
     std::string base_name_;
+    std::string base_name_ensemble_;
 
     std::string debug_filename_;
 
@@ -187,11 +188,10 @@ namespace ryujin
      */
     //@{
 
-    const MPI_Comm &mpi_communicator_;
+    MPIEnsemble mpi_ensemble_;
 
     std::map<std::string, dealii::Timer> computing_timer_;
 
-    MPIEnsemble mpi_ensemble_;
     HyperbolicSystem hyperbolic_system_;
     ParabolicSystem parabolic_system_;
     Discretization<dim> discretization_;
@@ -205,8 +205,9 @@ namespace ryujin
     VTUOutput<Description, dim, Number> vtu_output_;
     Quantities<Description, dim, Number> quantities_;
 
-    const unsigned int mpi_rank_;
-    const unsigned int n_mpi_processes_;
+    const unsigned int global_rank_;
+    const unsigned int n_global_ranks_;
+    dealii::types::global_dof_index n_global_dofs_;
 
     std::ofstream logfile_; /* log file */
 

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -11,6 +11,7 @@
 #include "hyperbolic_module.h"
 #include "initial_values.h"
 #include "mesh_adaptor.h"
+#include "mpi_ensemble.h"
 #include "offline_data.h"
 #include "parabolic_module.h"
 #include "postprocessor.h"
@@ -190,6 +191,7 @@ namespace ryujin
 
     std::map<std::string, dealii::Timer> computing_timer_;
 
+    MPIEnsemble mpi_ensemble_;
     HyperbolicSystem hyperbolic_system_;
     ParabolicSystem parabolic_system_;
     Discretization<dim> discretization_;

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -205,8 +205,6 @@ namespace ryujin
     VTUOutput<Description, dim, Number> vtu_output_;
     Quantities<Description, dim, Number> quantities_;
 
-    const unsigned int global_rank_;
-    const unsigned int n_global_ranks_;
     dealii::types::global_dof_index n_global_dofs_;
 
     std::ofstream logfile_; /* log file */

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -404,9 +404,12 @@ namespace ryujin
 
       /* Print and record cycle statistics: */
       if (terminal_update_interval_ != Number(0.)) {
+
+        /* Do we need to update the log file? */
         const bool write_to_log_file =
             (t >= relax * timer_cycle * timer_granularity_);
 
+        /* Do we need to update the terminal? */
         const auto wall_time = computing_timer_["time loop"].wall_time();
         int update_terminal =
             (wall_time >= last_terminal_output + terminal_update_interval_);
@@ -952,7 +955,7 @@ namespace ryujin
 
     /* Also print out parameters to a prm file: */
 
-    std::ofstream output(base_name_ensemble_ + "-parameters.prm");
+    std::ofstream output(base_name_ + "-parameters.prm");
     ParameterAcceptor::prm.print_parameters(output, ParameterHandler::ShortPRM);
   }
 

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -27,6 +27,7 @@ namespace ryujin
   TimeLoop<Description, dim, Number>::TimeLoop(const MPI_Comm &mpi_comm)
       : ParameterAcceptor("/A - TimeLoop")
       , mpi_communicator_(mpi_comm)
+      , mpi_ensemble_(mpi_comm)
       , hyperbolic_system_("/B - Equation")
       , parabolic_system_("/B - Equation")
       , discretization_(mpi_communicator_, "/C - Discretization")
@@ -255,6 +256,11 @@ namespace ryujin
       quantities_.prepare(base_name_);
       print_mpi_partition(logfile_);
     };
+
+    {
+      print_info("setting up ensemble");
+      mpi_ensemble_.prepare();
+    }
 
     {
       Scope scope(computing_timer_, "(re)initialize data structures");

--- a/source/vtu_output.h
+++ b/source/vtu_output.h
@@ -7,6 +7,7 @@
 
 #include <compile_time_options.h>
 
+#include "mpi_ensemble.h"
 #include "offline_data.h"
 #include "postprocessor.h"
 
@@ -61,7 +62,7 @@ namespace ryujin
     /**
      * Constructor.
      */
-    VTUOutput(const MPI_Comm &mpi_communicator,
+    VTUOutput(const MPIEnsemble &mpi_ensemble,
               const OfflineData<dim, Number> &offline_data,
               const HyperbolicSystem &hyperbolic_system,
               const ParabolicSystem &parabolic_system,
@@ -121,7 +122,7 @@ namespace ryujin
      */
     //@{
 
-    const MPI_Comm &mpi_communicator_;
+    const MPIEnsemble &mpi_ensemble_;
 
     dealii::SmartPointer<const OfflineData<dim, Number>> offline_data_;
     dealii::SmartPointer<const HyperbolicSystem> hyperbolic_system_;

--- a/source/vtu_output.template.h
+++ b/source/vtu_output.template.h
@@ -146,10 +146,10 @@ namespace ryujin
         /* MPI-based synchronous IO */
         data_out->write_vtu_in_parallel(
             name + "_" + Utilities::to_string(cycle, 6) + ".vtu",
-            mpi_ensemble_.subrange_communicator());
+            mpi_ensemble_.ensemble_communicator());
       } else {
         data_out->write_vtu_with_pvtu_record(
-            "", name, cycle, mpi_ensemble_.subrange_communicator(), 6);
+            "", name, cycle, mpi_ensemble_.ensemble_communicator(), 6);
       }
     }
 
@@ -193,13 +193,13 @@ namespace ryujin
         /* MPI-based synchronous IO */
         data_out->write_vtu_in_parallel(
             name + "-levelsets_" + Utilities::to_string(cycle, 6) + ".vtu",
-            mpi_ensemble_.subrange_communicator());
+            mpi_ensemble_.ensemble_communicator());
       } else {
         data_out->write_vtu_with_pvtu_record(
             "",
             name + "-levelsets",
             cycle,
-            mpi_ensemble_.subrange_communicator(),
+            mpi_ensemble_.ensemble_communicator(),
             6);
       }
     }

--- a/source/vtu_output.template.h
+++ b/source/vtu_output.template.h
@@ -20,7 +20,7 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   VTUOutput<Description, dim, Number>::VTUOutput(
-      const MPI_Comm &mpi_communicator,
+      const MPIEnsemble &mpi_ensemble,
       const OfflineData<dim, Number> &offline_data,
       const HyperbolicSystem &hyperbolic_system,
       const ParabolicSystem &parabolic_system,
@@ -29,7 +29,7 @@ namespace ryujin
       const ScalarVector &alpha,
       const std::string &subsection /*= "VTUOutput"*/)
       : ParameterAcceptor(subsection)
-      , mpi_communicator_(mpi_communicator)
+      , mpi_ensemble_(mpi_ensemble)
       , offline_data_(&offline_data)
       , hyperbolic_system_(&hyperbolic_system)
       , parabolic_system_(&parabolic_system)
@@ -146,10 +146,10 @@ namespace ryujin
         /* MPI-based synchronous IO */
         data_out->write_vtu_in_parallel(
             name + "_" + Utilities::to_string(cycle, 6) + ".vtu",
-            mpi_communicator_);
+            mpi_ensemble_.subrange_communicator());
       } else {
         data_out->write_vtu_with_pvtu_record(
-            "", name, cycle, mpi_communicator_, 6);
+            "", name, cycle, mpi_ensemble_.subrange_communicator(), 6);
       }
     }
 
@@ -193,10 +193,14 @@ namespace ryujin
         /* MPI-based synchronous IO */
         data_out->write_vtu_in_parallel(
             name + "-levelsets_" + Utilities::to_string(cycle, 6) + ".vtu",
-            mpi_communicator_);
+            mpi_ensemble_.subrange_communicator());
       } else {
         data_out->write_vtu_with_pvtu_record(
-            "", name + "-levelsets", cycle, mpi_communicator_, 6);
+            "",
+            name + "-levelsets",
+            cycle,
+            mpi_ensemble_.subrange_communicator(),
+            6);
       }
     }
 


### PR DESCRIPTION
This pull request adds the necessary infrastructure in form of an `MPIEnsemble` class and refactors the entire MPI communicator usage throughout ryujin to use said class. 

Note, I haven't hooked up the ensemble to anything yet. We will have to decide how to use and configure the class precisely for our intended use cases.

@ejtovar1 *ping*

