### PR TITLE
`EulerAEOS`: small fixes

### DIFF
--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -1160,9 +1160,6 @@ namespace ryujin
 
         /* Supersonic outflow: do nothing, i.e., keep U as is */
 
-      } else if (id == Boundary::do_nothing) {
-        /* Do nothing */
-
       } else {
         AssertThrow(false, dealii::ExcNotImplemented());
       }

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -1209,9 +1209,9 @@ namespace ryujin
       const auto rho_e = internal_energy(U);
       const auto covolume = Number(1.) - b * rho;
 
-
       return positive_part(gamma - Number(1.)) *
-             safe_division(rho_e - rho * q, covolume - gamma * pinf);
+                 safe_division(rho_e - rho * q, covolume) -
+             gamma * pinf;
     }
 
 

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -1390,9 +1390,6 @@ namespace ryujin
         /* Supersonic outflow: do nothing, i.e., keep U as is */
 #endif
 
-      } else if (id == Boundary::do_nothing) {
-        /* Do nothing */
-
       } else {
         AssertThrow(false, dealii::ExcNotImplemented());
       }

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -394,7 +394,7 @@ namespace ryujin
       static inline const auto precomputed_names =
           std::array<std::string, n_precomputed_values>{
               {"p",
-               "surrogate_gamma",
+               "surrogate_gamma_min",
                "surrogate_specific_entropy",
                "surrogate_harten_entropy"}};
 

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -732,9 +732,6 @@ namespace ryujin
                                "for scalar conservation equations."));
         __builtin_trap();
 
-      } else if (id == Boundary::do_nothing) {
-        /* Do nothing */
-
       } else {
         AssertThrow(false, dealii::ExcNotImplemented());
       }

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -1010,9 +1010,6 @@ namespace ryujin
 
         /* Supersonic outflow: do nothing, i.e., keep U as is */
 
-      } else if (id == Boundary::do_nothing) {
-        /* Do nothing */
-
       } else {
         AssertThrow(false, dealii::ExcNotImplemented());
       }


### PR DESCRIPTION
- **HyperbolicSystem: remove "do nothing" case from boundary enforcement**
- **EulerAEOS: HyperbolicSystem: fix name for precomputed component**
- **EulerAEOS: HyperbolicSystem: fix typo**
