### PR TITLE
EulerAEOS: remove interpolatory pinfty from van der Waals EOS

### DIFF
--- a/source/euler_aeos/equation_of_state_van_der_waals.h
+++ b/source/euler_aeos/equation_of_state_van_der_waals.h
@@ -51,9 +51,11 @@ namespace ryujin
         /* Update the EOS interpolation parameters on parameter read in: */
         ParameterAcceptor::parse_parameters_call_back.connect([this] {
           this->interpolation_b_ = b_;
-          /* Note that this EOS allows for negative pressures. */
-          if (b_ > 0.)
-            this->interpolation_pinfty_ = a_ / (b_ * b_);
+          /*
+           * FIXME: The van der Waals EOS allows for negative pressures. We
+           * should thus come up with a sensible way of setting
+           * "interpolation_pinfty_"...
+           */
         });
       }
 


### PR DESCRIPTION
Let us remove the interpolatory pfinty for the time being. While this would allow for negative pressures it unfortunately restricts the admissible set severly...
