### PR TITLE
Refactor bounds relaxation methods

### DIFF
--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -224,7 +224,7 @@ namespace ryujin
                                      const state_type &U,
                                      const state_type &P,
                                      const Number t_min = Number(0.),
-                                     const Number t_max = Number(1.));
+                                     const Number t_max = Number(1.)) const;
 
     private:
       //@}

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -396,17 +396,12 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline auto
     Limiter<dim, Number>::bounds(const Number hd_i) const -> Bounds
     {
-      auto relaxed_bounds = bounds_;
-      auto &[rho_min, rho_max, s_min] = relaxed_bounds;
+      const auto &[rho_min, rho_max, s_min] = bounds_;
 
-      /* Use r_i = factor * (m_i / |Omega|) ^ (1.5 / d): */
+      auto relaxed_bounds = fully_relax_bounds(bounds_, hd_i);
+      auto &[rho_min_relaxed, rho_max_relaxed, s_min_relaxed] = relaxed_bounds;
 
-      Number r_i = std::sqrt(hd_i);                              // in 3D: ^ 3/6
-      if constexpr (dim == 2)                                    //
-        r_i = dealii::Utilities::fixed_power<3>(std::sqrt(r_i)); // in 2D: ^ 3/4
-      else if constexpr (dim == 1)                               //
-        r_i = dealii::Utilities::fixed_power<3>(r_i);            // in 1D: ^ 3/2
-      r_i *= parameters.relaxation_factor();
+      /* Apply a stricter window: */
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       const Number rho_relaxation =
@@ -416,13 +411,12 @@ namespace ryujin
       const auto relaxation =
           ScalarNumber(2. * parameters.relaxation_factor()) * rho_relaxation;
 
-      rho_min = std::max((Number(1.) - r_i) * rho_min, rho_min - relaxation);
-      rho_max = std::min((Number(1.) + r_i) * rho_max, rho_max + relaxation);
-
       const auto entropy_relaxation =
           parameters.relaxation_factor() * (s_interp_max - s_min);
 
-      s_min = std::max((Number(1.) - r_i) * s_min, s_min - entropy_relaxation);
+      rho_min_relaxed = std::max(rho_min_relaxed, rho_min - relaxation);
+      rho_max_relaxed = std::min(rho_max_relaxed, rho_max + relaxation);
+      s_min_relaxed = std::max(s_min_relaxed, s_min - entropy_relaxation);
 
       return relaxed_bounds;
     }

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -404,18 +404,17 @@ namespace ryujin
       /* Apply a stricter window: */
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
-      const Number rho_relaxation =
+
+      const auto rho_relaxation =
+          ScalarNumber(2. * parameters.relaxation_factor()) *
           std::abs(rho_relaxation_numerator) /
           (std::abs(rho_relaxation_denominator) + Number(eps));
-
-      const auto relaxation =
-          ScalarNumber(2. * parameters.relaxation_factor()) * rho_relaxation;
 
       const auto entropy_relaxation =
           parameters.relaxation_factor() * (s_interp_max - s_min);
 
-      rho_min_relaxed = std::max(rho_min_relaxed, rho_min - relaxation);
-      rho_max_relaxed = std::min(rho_max_relaxed, rho_max + relaxation);
+      rho_min_relaxed = std::max(rho_min_relaxed, rho_min - rho_relaxation);
+      rho_max_relaxed = std::min(rho_max_relaxed, rho_max + rho_relaxation);
       s_min_relaxed = std::max(s_min_relaxed, s_min - entropy_relaxation);
 
       return relaxed_bounds;

--- a/source/euler/limiter.template.h
+++ b/source/euler/limiter.template.h
@@ -18,7 +18,7 @@ namespace ryujin
                                 const state_type &U,
                                 const state_type &P,
                                 const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */)
+                                const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -225,7 +225,7 @@ namespace ryujin
                                      const state_type &U,
                                      const state_type &P,
                                      const Number t_min = Number(0.),
-                                     const Number t_max = Number(1.));
+                                     const Number t_max = Number(1.)) const;
 
     private:
       //@}

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -462,19 +462,13 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline auto
     Limiter<dim, Number>::bounds(const Number hd_i) const -> Bounds
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
+      const auto &[rho_min, rho_max, s_min, gamma_min] = bounds_;
 
-      auto relaxed_bounds = bounds_;
-      auto &[rho_min, rho_max, s_min, gamma_min] = relaxed_bounds;
+      auto relaxed_bounds = fully_relax_bounds(bounds_, hd_i);
+      auto &[rho_min_relaxed, rho_max_relaxed, s_min_relaxed, g_m_relaxed] =
+          relaxed_bounds;
 
-      /* Use r_i = factor * (m_i / |Omega|) ^ (1.5 / d): */
-
-      Number r_i = std::sqrt(hd_i);                              // in 3D: ^ 3/6
-      if constexpr (dim == 2)                                    //
-        r_i = dealii::Utilities::fixed_power<3>(std::sqrt(r_i)); // in 2D: ^ 3/4
-      else if constexpr (dim == 1)                               //
-        r_i = dealii::Utilities::fixed_power<3>(r_i);            // in 1D: ^ 3/2
-      r_i *= parameters.relaxation_factor();
+      /* Apply a stricter window: */
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       const Number rho_relaxation =
@@ -484,27 +478,12 @@ namespace ryujin
       const auto relaxation =
           ScalarNumber(2. * parameters.relaxation_factor()) * rho_relaxation;
 
-      rho_min = std::max((Number(1.) - r_i) * rho_min, rho_min - relaxation);
-      rho_max = std::min((Number(1.) + r_i) * rho_max, rho_max + relaxation);
-
       const auto entropy_relaxation =
           parameters.relaxation_factor() * (s_interp_max - s_min);
 
-      s_min = std::max((Number(1.) - r_i) * s_min, s_min - entropy_relaxation);
-
-      /*
-       * If we have a maximum compressibility constant, b, the maximum
-       * bound for rho changes. See @cite ryujin-2023-4 for how to define
-       * rho_max.
-       */
-
-      const auto numerator = (gamma_min + Number(1.)) * rho_max;
-      const auto interpolation_b = view.eos_interpolation_b();
-      const auto denominator =
-          gamma_min - Number(1.) + ScalarNumber(2.) * interpolation_b * rho_max;
-      const auto upper_bound = numerator / denominator;
-
-      rho_max = std::min(upper_bound, rho_max);
+      rho_min_relaxed = std::max(rho_min_relaxed, rho_min - relaxation);
+      rho_max_relaxed = std::min(rho_max_relaxed, rho_max + relaxation);
+      s_min_relaxed = std::max(s_min_relaxed, s_min - entropy_relaxation);
 
       return relaxed_bounds;
     }

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -304,8 +304,11 @@ namespace ryujin
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 
+      const auto &[rho_min, rho_max, s_min, gamma_min] = bounds;
+
       auto relaxed_bounds = bounds;
-      auto &[rho_min, rho_max, s_min, gamma_min] = relaxed_bounds;
+      auto &[rho_min_relaxed, rho_max_relaxed, s_min_relaxed, g_m_relaxed] =
+          relaxed_bounds;
 
       /* Use r = factor * (m_i / |Omega|) ^ (1.5 / d): */
 
@@ -317,9 +320,9 @@ namespace ryujin
       r *= parameters.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
-      rho_min *= std::max(Number(1.) - r, Number(eps));
-      rho_max *= (Number(1.) + r);
-      s_min *= std::max(Number(1.) - r, Number(eps));
+      rho_min_relaxed *= std::max(Number(1.) - r, Number(eps));
+      rho_max_relaxed *= (Number(1.) + r);
+      s_min_relaxed *= std::max(Number(1.) - r, Number(eps));
 
       /*
        * If we have a maximum compressibility constant, b, the maximum
@@ -333,7 +336,7 @@ namespace ryujin
           gamma_min - Number(1.) + ScalarNumber(2.) * interpolation_b * rho_max;
       const auto rho_compressibility_bound = numerator / denominator;
 
-      rho_max = std::min(rho_compressibility_bound, rho_max);
+      rho_max_relaxed = std::min(rho_compressibility_bound, rho_max_relaxed);
 
       return relaxed_bounds;
     }

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -474,18 +474,17 @@ namespace ryujin
       /* Apply a stricter window: */
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
-      const Number rho_relaxation =
+
+      const auto rho_relaxation =
+          ScalarNumber(2. * parameters.relaxation_factor()) *
           std::abs(rho_relaxation_numerator) /
           (std::abs(rho_relaxation_denominator) + Number(eps));
-
-      const auto relaxation =
-          ScalarNumber(2. * parameters.relaxation_factor()) * rho_relaxation;
 
       const auto entropy_relaxation =
           parameters.relaxation_factor() * (s_interp_max - s_min);
 
-      rho_min_relaxed = std::max(rho_min_relaxed, rho_min - relaxation);
-      rho_max_relaxed = std::min(rho_max_relaxed, rho_max + relaxation);
+      rho_min_relaxed = std::max(rho_min_relaxed, rho_min - rho_relaxation);
+      rho_max_relaxed = std::min(rho_max_relaxed, rho_max + rho_relaxation);
       s_min_relaxed = std::max(s_min_relaxed, s_min - entropy_relaxation);
 
       return relaxed_bounds;

--- a/source/euler_aeos/limiter.template.h
+++ b/source/euler_aeos/limiter.template.h
@@ -18,7 +18,7 @@ namespace ryujin
                                 const state_type &U,
                                 const state_type &P,
                                 const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */)
+                                const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -172,7 +172,7 @@ namespace ryujin
                                      const state_type &U,
                                      const state_type &P,
                                      const Number t_min = Number(0.),
-                                     const Number t_max = Number(1.));
+                                     const Number t_max = Number(1.)) const;
 
     private:
       //@}

--- a/source/scalar_conservation/limiter.template.h
+++ b/source/scalar_conservation/limiter.template.h
@@ -17,7 +17,7 @@ namespace ryujin
                                 const state_type &U,
                                 const state_type &P,
                                 const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */)
+                                const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -190,7 +190,7 @@ namespace ryujin
                                      const state_type &U,
                                      const state_type &P,
                                      const Number t_min = Number(0.),
-                                     const Number t_max = Number(1.));
+                                     const Number t_max = Number(1.)) const;
 
     private:
       //@}

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -123,8 +123,8 @@ namespace ryujin
        * Given a state @p U_i and an index @p i return "strict" bounds,
        * i.e., a minimal convex set containing the state.
        */
-      Bounds bounds_from_state(const unsigned int i,
-                               const state_type &U_i) const;
+      Bounds projection_bounds_from_state(const unsigned int i,
+                                          const state_type &U_i) const;
 
       /**
        * Given two bounds bounds_left, bounds_right, this function computes
@@ -223,7 +223,8 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto Limiter<dim, Number>::bounds_from_state(
+    DEAL_II_ALWAYS_INLINE inline auto
+    Limiter<dim, Number>::projection_bounds_from_state(
         const unsigned int /*i*/, const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();

--- a/source/shallow_water/limiter.template.h
+++ b/source/shallow_water/limiter.template.h
@@ -19,7 +19,7 @@ namespace ryujin
                                 const state_type &U,
                                 const state_type &P,
                                 const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */)
+                                const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -109,6 +109,17 @@ namespace ryujin
         return Bounds{};
       }
 
+      /**
+       * This function applies a relaxation to a given a (strict) bound @p
+       * bounds using a non dimensionalized measure @p hd (that should
+       * scale as $h^d$, where $h$ is the local mesh size).
+       */
+      Bounds fully_relax_bounds(const Bounds & /*bounds*/,
+                                const Number & /*hd*/) const
+      {
+        return Bounds{};
+      }
+
       //@}
       /**
        * @name Stencil-based computation of bounds
@@ -155,9 +166,9 @@ namespace ryujin
       /**
        * Return the computed bounds (with relaxation applied).
        */
-      Bounds bounds(const Number /*hd_i*/) const
+      Bounds bounds(const Number hd_i) const
       {
-        auto relaxed_bounds = bounds_;
+        auto relaxed_bounds = fully_relax_bounds(bounds_, hd_i);
 
         return relaxed_bounds;
       }

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -176,7 +176,7 @@ namespace ryujin
                                      const state_type & /*U*/,
                                      const state_type & /*P*/,
                                      const Number /*t_min*/ = Number(0.),
-                                     const Number t_max = Number(1.))
+                                     const Number t_max = Number(1.)) const
       {
         return {t_max, true};
       }


### PR DESCRIPTION
This pull request reworks bounds computation into to separate steps: A generic fully_relax_bounds() method that applies our standard "relaxation window" and the portion in the bounds() method that applies a relaxation window based on fluctuations.
