### PR TITLE
NavierStokes: add strict enforcement for admissibility

### DIFF
--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -57,12 +57,37 @@ namespace ryujin
 
 
   /**
-   * A class signalling a restart, thrown in HyperbolicModule::single_step and
-   * caught at various places.
+   * A class signalling a restart, thrown in HyperbolicModule::single_step
+   * and caught in the TimeIntegrator when performing a time step. We
+   * currently signal a restart whenever we encounter an invariant domain
+   * violation of the low-order update.
+   *
+   * This might happen, for example, in subsequent invocations of step() in
+   * high-order time stepping algorithms when the time step size has to be
+   * kept constant. A standard strategy implemented in TimeIntegrator is to
+   * simply fall back to a smaller relative CFL number and try again.
    *
    * @ingroup TimeLoop
    */
   class Restart final
+  {
+  };
+
+
+  /**
+   * A class signalling that a correction step is required for the update.
+   * This is meant to be a truly exceptional situation, for example where
+   * the high-order update violates an admissibility condition. With our
+   * limiting approach this must never happen, ... but we might have taken
+   * some short cuts in the parabolic update that under rare circumstances
+   * require limiting.
+   *
+   * This exception is currently only used internally in the NavierStokes
+   * solver.
+   *
+   * @ingroup TimeLoop
+   */
+  class Correction final
   {
   };
 
@@ -270,13 +295,23 @@ namespace ryujin
     ACCESSOR_READ_ONLY(alpha)
 
     /**
-     * The number of restarts issued by the step() function.
+     * The number of restarts signalled by the step() function. We signal a
+     * restart whenever we encounter an ID violation in the low order
+     * update.
      */
     ACCESSOR_READ_ONLY(n_restarts)
 
     /**
+     * The number of corrections performed by the step() function. This
+     * function exists to mirror the ParabolicModule interface and will
+     * always return 0.
+     */
+    ACCESSOR_READ_ONLY(n_corrections)
+
+    /**
      * The number of ID violation warnings encounterd in the step()
-     * function.
+     * function. We issue a warning whenever we encounter an ID violation
+     * in the low order update (and throwing a restart is disabled).
      */
     ACCESSOR_READ_ONLY(n_warnings)
 
@@ -317,7 +352,7 @@ namespace ryujin
     mutable Number cfl_;
 
     mutable unsigned int n_restarts_;
-
+    mutable unsigned int n_corrections_;
     mutable unsigned int n_warnings_;
 
     InitialPrecomputedVector initial_precomputed_;

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -45,6 +45,7 @@ namespace ryujin
       , initial_values_(&initial_values)
       , cfl_(0.2)
       , n_restarts_(0)
+      , n_corrections_(0)
       , n_warnings_(0)
   {
   }

--- a/source/navier_stokes/parabolic_solver.h
+++ b/source/navier_stokes/parabolic_solver.h
@@ -207,6 +207,7 @@ namespace ryujin
       //@{
 
       ACCESSOR_READ_ONLY(n_restarts)
+      ACCESSOR_READ_ONLY(n_corrections)
       ACCESSOR_READ_ONLY(n_warnings)
 
       //@}
@@ -281,6 +282,7 @@ namespace ryujin
           initial_values_;
 
       mutable unsigned int n_restarts_;
+      mutable unsigned int n_corrections_;
       mutable unsigned int n_warnings_;
       mutable double n_iterations_velocity_;
       mutable double n_iterations_internal_energy_;

--- a/source/navier_stokes/parabolic_solver.template.h
+++ b/source/navier_stokes/parabolic_solver.template.h
@@ -47,6 +47,7 @@ namespace ryujin
         , offline_data_(&offline_data)
         , initial_values_(&initial_values)
         , n_restarts_(0)
+        , n_corrections_(0)
         , n_warnings_(0)
         , n_iterations_velocity_(0.)
         , n_iterations_internal_energy_(0.)
@@ -238,13 +239,33 @@ namespace ryujin
         const IDViolationStrategy id_violation_strategy,
         const bool reinitialize_gmg) const
     {
-      step(old_state_vector,
-           t,
-           new_state_vector,
-           tau / Number(2.),
-           id_violation_strategy,
-           reinitialize_gmg,
-           /*crank_nicolson_extrapolation = */ true);
+      try {
+        step(old_state_vector,
+             t,
+             new_state_vector,
+             tau / Number(2.),
+             id_violation_strategy,
+             reinitialize_gmg,
+             /*crank_nicolson_extrapolation = */ true);
+
+      } catch (Correction) {
+
+        /*
+         * Under very rare circumstances we might fail to perform a Crank
+         * Nicolson step because the extrapolation step produced
+         * inadmissible states. We could correct the update now by
+         * performing a limiting step (either convex limiting, or flux
+         * corrected transport)... but *meh*, just perform a backward Euler
+         * step:
+         */
+        step(old_state_vector,
+             t,
+             new_state_vector,
+             tau,
+             id_violation_strategy,
+             reinitialize_gmg,
+             /*crank_nicolson_extrapolation = */ false);
+      }
     }
 
 
@@ -261,6 +282,8 @@ namespace ryujin
 #ifdef DEBUG_OUTPUT
       std::cout << "ParabolicSolver<dim, Number>::step()" << std::endl;
 #endif
+
+      constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const auto &old_U = std::get<0>(old_state_vector);
       auto &new_U = std::get<0>(new_state_vector);
@@ -282,10 +305,35 @@ namespace ryujin
 
 #ifdef DEBUG_OUTPUT
       std::cout << "        perform time-step with tau = " << tau << std::endl;
+      if (crank_nicolson_extrapolation)
+        std::cout << "        and extrapolate to t + 2 * tau" << std::endl;
 #endif
 
-      /* A boolean signalling that a restart is necessary: */
+      /*
+       * A boolean indicating that a restart is required.
+       *
+       * In our current implementation we set this boolean to true if the
+       * backward Euler step produces an internal energy update that
+       * violates the minimum principle, i.e., the minimum of the new
+       * internal energy is smaller than the minimum of the old internal
+       * energy.
+       *
+       * Depending on the chosen "id_violation_strategy" we either signal a
+       * restart by throwing a "Restart" object, or we simply increase the
+       * number of warnings.
+       */
       std::atomic<bool> restart_needed = false;
+
+      /*
+       * A boolean indicating that we have to correct the high-order Crank
+       * Nicolson update. Note that this is a truly exceptional case
+       * indicating that the high-order update produced an inadmissible
+       * state, *boo*.
+       *
+       * Our current limiting strategy is to simply fall back to perform a
+       * single backward Euler step...
+       */
+      std::atomic<bool> correction_needed = false;
 
       /*
        * Step 1:
@@ -833,11 +881,10 @@ namespace ryujin
 
             auto rho_e_i_new = rho_i * get_entry<T>(internal_energy_, i);
 
-            if (crank_nicolson_extrapolation) {
-              m_i_new = Number(2.0) * m_i_new - view.momentum(U_i);
-              rho_e_i_new =
-                  Number(2.0) * rho_e_i_new - view.internal_energy(U_i);
-            }
+            /*
+             * Check that the backward Euler step itself (which is our "low
+             * order" update) satisfies bounds. If not, signal a restart.
+             */
 
             if (!(T(0.) == std::max(T(0.), rho_i * e_min_old - rho_e_i_new))) {
 #ifdef DEBUG_OUTPUT
@@ -851,6 +898,30 @@ namespace ryujin
                         << std::endl;
 #endif
               restart_needed = true;
+            }
+
+            if (crank_nicolson_extrapolation) {
+              m_i_new = Number(2.0) * m_i_new - view.momentum(U_i);
+              rho_e_i_new =
+                  Number(2.0) * rho_e_i_new - view.internal_energy(U_i);
+
+              /*
+               * If we do perform an extrapolation step for Crank Nicolson
+               * we have to check whether we maintain admissibility
+               */
+
+              if (!(T(0.) ==
+                    std::max(T(0.), eps * rho_i * e_min_old - rho_e_i_new))) {
+#ifdef DEBUG_OUTPUT
+                std::cout << std::fixed << std::setprecision(16);
+                const auto e_i_new = rho_e_i_new / rho_i;
+
+                std::cout << "Bounds violation: high-order internal energy!"
+                          << "\t\te_min_new:         " << e_i_new << "\n"
+                          << "\t\t-- correction required --" << std::endl;
+#endif
+                correction_needed = true;
+              }
             }
 
             const auto E_i_new = rho_e_i_new + 0.5 * m_i_new * m_i_new / rho_i;
@@ -881,15 +952,32 @@ namespace ryujin
                     "time step [H] _ - synchronization barriers");
 
         /*
-         * Synchronize whether we have to restart the time step. Even though
-         * the restart condition itself only affects the local ensemble we
-         * nevertheless need to synchronize the boolean in case we perform
-         * synchronized global time steps. (Otherwise different ensembles
-         * might end up with a different time step.)
+         * Synchronize whether we have to restart or correct the time step.
+         * Even though the restart/correction condition itself only affects
+         * the local ensemble we nevertheless need to synchronize the
+         * boolean in case we perform synchronized global time steps.
+         * (Otherwise different ensembles might end up with a different
+         * time step.)
          */
+
         restart_needed.store(Utilities::MPI::logical_or(
             restart_needed.load(),
             mpi_ensemble_.synchronization_communicator()));
+
+        correction_needed.store(Utilities::MPI::logical_or(
+            correction_needed.load(),
+            mpi_ensemble_.synchronization_communicator()));
+      }
+
+      if (correction_needed) {
+        /* If we can do a restart try that first: */
+        if (id_violation_strategy == IDViolationStrategy::raise_exception) {
+          n_restarts_++;
+          throw Restart();
+        } else {
+          n_corrections_++;
+          throw Correction();
+        }
       }
 
       if (restart_needed) {

--- a/source/navier_stokes/parabolic_solver.template.h
+++ b/source/navier_stokes/parabolic_solver.template.h
@@ -301,6 +301,8 @@ namespace ryujin
       const unsigned int n_owned = offline_data_->n_locally_owned();
       const unsigned int n_regular = n_owned / simd_length * simd_length;
 
+      const auto &sparsity_simd = offline_data_->sparsity_pattern_simd();
+
       DiagonalMatrix<dim, Number> diagonal_matrix;
 
 #ifdef DEBUG_OUTPUT
@@ -439,10 +441,10 @@ namespace ryujin
         }
 
         /*
-         * Zero out constrained degrees of freedom due to periodic boundary
-         * conditions. These boundary conditions are enforced by modifying
-         * the stencil - consequently we have to remove constrained dofs from
-         * the linear system.
+         * Zero out constrained degrees of freedom due to hanging nodes and
+         * periodic boundary conditions. These boundary conditions are
+         * enforced by modifying the stencil - consequently we have to
+         * remove constrained dofs from the linear system.
          */
 
         affine_constraints.set_zero(density_);
@@ -728,11 +730,12 @@ namespace ryujin
         }
 
         /*
-         * Zero out constrained degrees of freedom due to periodic boundary
-         * conditions. These boundary conditions are enforced by modifying
-         * the stencil - consequently we have to remove constrained dofs from
-         * the linear system.
+         * Zero out constrained degrees of freedom due to hanging nodes and
+         * periodic boundary conditions. These boundary conditions are
+         * enforced by modifying the stencil - consequently we have to
+         * remove constrained dofs from the linear system.
          */
+        affine_constraints.set_zero(internal_energy_);
         affine_constraints.set_zero(internal_energy_rhs_);
 
         /*
@@ -871,6 +874,12 @@ namespace ryujin
 
           RYUJIN_OMP_FOR
           for (unsigned int i = left; i < right; i += stride_size) {
+
+            /* Skip constrained degrees of freedom: */
+            const unsigned int row_length = sparsity_simd.row_length(i);
+            if (row_length == 1)
+              continue;
+
             auto U_i = old_U.template get_tensor<T>(i);
             const auto rho_i = view.density(U_i);
 

--- a/source/parabolic_module.h
+++ b/source/parabolic_module.h
@@ -126,9 +126,17 @@ namespace ryujin
      */
     //@{
     /**
-     * The number of restarts issued by the step() function.
+     * The number of restarts signalled by the step() function.
      */
     ACCESSOR_READ_ONLY(n_restarts)
+
+
+    /**
+     * The number of corrections performed by the step() function. This
+     * function exists to mirror the ParabolicModule interface and will
+     * always return 0.
+     */
+    ACCESSOR_READ_ONLY(n_corrections)
 
     /**
      * The number of ID violation warnings encounterd in the step()
@@ -151,6 +159,7 @@ namespace ryujin
     mutable unsigned int cycle_;
 
     mutable unsigned int n_restarts_;
+    mutable unsigned int n_corrections_;
     mutable unsigned int n_warnings_;
 
     //@}

--- a/source/parabolic_module.template.h
+++ b/source/parabolic_module.template.h
@@ -30,6 +30,7 @@ namespace ryujin
                           initial_values,
                           subsection)
       , n_restarts_(0)
+      , n_corrections_(0)
       , n_warnings_(0)
   {
   }
@@ -80,6 +81,8 @@ namespace ryujin
                                             tau,
                                             id_violation_strategy_,
                                             reinit_gmg);
+
+      /* Update statistics: */
       n_restarts_ = parabolic_solver_.n_restarts();
       n_warnings_ = parabolic_solver_.n_warnings();
     }
@@ -109,6 +112,8 @@ namespace ryujin
                                             tau,
                                             id_violation_strategy_,
                                             reinit_gmg);
+
+      /* Update statistics: */
       n_restarts_ = parabolic_solver_.n_restarts();
       n_warnings_ = parabolic_solver_.n_warnings();
     }

--- a/source/parabolic_module.template.h
+++ b/source/parabolic_module.template.h
@@ -84,6 +84,7 @@ namespace ryujin
 
       /* Update statistics: */
       n_restarts_ = parabolic_solver_.n_restarts();
+      n_corrections_ = parabolic_solver_.n_corrections();
       n_warnings_ = parabolic_solver_.n_warnings();
     }
   }
@@ -115,6 +116,7 @@ namespace ryujin
 
       /* Update statistics: */
       n_restarts_ = parabolic_solver_.n_restarts();
+      n_corrections_ = parabolic_solver_.n_corrections();
       n_warnings_ = parabolic_solver_.n_warnings();
     }
   }

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -1217,7 +1217,11 @@ namespace ryujin
            << std::setprecision(0) << std::fixed << hyperbolic_module_.n_warnings()
            << "/"
            << std::setprecision(0) << std::fixed << parabolic_module_.n_warnings()
-           << " warn) ]" << std::endl;
+           << " warn) ("
+           << std::setprecision(0) << std::fixed << hyperbolic_module_.n_corrections()
+           << "/"
+           << std::setprecision(0) << std::fixed << parabolic_module_.n_corrections()
+           << " corr) ]" << std::endl;
 
     if constexpr (!ParabolicSystem::is_identity)
       parabolic_module_.print_solver_statistics(output);


### PR DESCRIPTION
We currently do not implement a limiter for the parabolic substep for Navier Stokes because it is a diffusion process that rarely needs any limiting.

However, for our Strang splitting we perform a Crank Nicolson step consisting of a backward Euler step and extrapolation. Under very rare circumstances this leads to inadmissible states.

We thus implement a very simple "limiting" technique: If the state Crank Nicolson update is inadmissible, use a low-order backward Euler update instead.
