### PR TITLE
Change `prepare_state_vector()` strategy for the `ParabolicModule`

### DIFF
--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -164,14 +164,9 @@ namespace ryujin
      * for an explicit euler step performed by the step() function. The
      * function performs the following tasks:
      *
-     *  - For a continuous finite element ansatz the method updates the @p U
-     *    component of the state vector by enforcing boundary conditions
-     *    for the supplied time time @p t. It then updates ghost ranges on
-     *    @p U so that the state vector is consistent across MPI ranks.
-     *  - For a discontinuous finite element ansatz it populates a local
-     *    boundary state vector that is used for computing the boundary
-     *    jump terms in the step() function when performing a dG update. It
-     *    then updates ghost ranges on @p U so that the state vector is
+     *  - We update the @p U component of the state vector by enforcing
+     *    boundary conditions for the supplied time time @p t. We then
+     *    updates ghost ranges on @p U so that the state vector is
      *    consistent across MPI ranks.
      *
      *  - The function then runs the precomputation loop that populates the

--- a/source/parabolic_module.h
+++ b/source/parabolic_module.h
@@ -83,7 +83,10 @@ namespace ryujin
 
     /**
      * This function preprocesses a given state vector @p U in preparation
-     * for an implicit backward Euler, or Crank Nicolson step.
+     * for a high order IMEX time step. This function exists because some
+     * time stepping variants have to precompute quantities before we can
+     * perform an IMEX step. In addition, this function is called whenever
+     * we perform a mesh transfer or output operation.
      */
     void prepare_state_vector(StateVector &state_vector, Number t) const;
 

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -523,9 +523,11 @@ namespace ryujin
               << std::endl;
 #endif
 
+    parabolic_module_->prepare_state_vector(state_vector, t);
+
     /* First explicit SSPRK 3 step with final result in temp_[0]: */
 
-    hyperbolic_module_->prepare_state_vector(/*!*/ state_vector, t);
+    hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
         /*!*/ state_vector, {}, {}, temp_[0], Number(0.0), tau_max / 2.);
 
@@ -539,7 +541,6 @@ namespace ryujin
 
     /* Implicit Crank-Nicolson step with final result in temp_[2]: */
 
-    parabolic_module_->prepare_state_vector(temp_[0], t);
     parabolic_module_->crank_nicolson_step(temp_[0], t, temp_[2], 2.0 * tau);
 
     /* Second SSPRK 3 step with final result in temp_[0]: */
@@ -571,6 +572,8 @@ namespace ryujin
               << std::endl;
 #endif
 
+    parabolic_module_->prepare_state_vector(state_vector, t);
+
     /* First explicit ERK(3,3,1) step with final result in temp_[2]: */
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
@@ -590,7 +593,6 @@ namespace ryujin
 
     /* Implicit Crank-Nicolson step with final result in temp_[3]: */
 
-    parabolic_module_->prepare_state_vector(temp_[2], t);
     parabolic_module_->crank_nicolson_step(temp_[2], t, temp_[3], 6.0 * tau);
 
     /* Second explicit ERK(3,3,1) 3 step with final result in temp_[2]: */
@@ -626,6 +628,8 @@ namespace ryujin
               << std::endl;
 #endif
 
+    parabolic_module_->prepare_state_vector(state_vector, t);
+
     /* First explicit ERK(4,3,1) step with final result in temp_[3]: */
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
@@ -649,7 +653,6 @@ namespace ryujin
 
     /* Implicit Crank-Nicolson step with final result in temp_[2]: */
 
-    parabolic_module_->prepare_state_vector(temp_[3], t);
     parabolic_module_->crank_nicolson_step(temp_[3], t, temp_[2], 8.0 * tau);
 
     /* Second explicit ERK(4,3,1) step with final result in temp_[3]: */
@@ -685,13 +688,14 @@ namespace ryujin
     std::cout << "TimeIntegrator<dim, Number>::step_imex_11()" << std::endl;
 #endif
 
+    parabolic_module_->prepare_state_vector(state_vector, t);
+
     /* Explicit step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
         state_vector, {}, {}, temp_[0], Number(0.), tau_max);
 
     /* Implicit step 1: T1 <- {T0, 1} at time t -> t + tau */
-    parabolic_module_->prepare_state_vector(temp_[0], t);
     parabolic_module_->template backward_euler_step<0>(
         temp_[0], t, {}, {}, temp_[1], 1.0 * tau);
 
@@ -707,13 +711,14 @@ namespace ryujin
     std::cout << "TimeIntegrator<dim, Number>::step_imex_22()" << std::endl;
 #endif
 
+    parabolic_module_->prepare_state_vector(state_vector, t);
+
     /* Explicit step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
         state_vector, {}, {}, temp_[0], Number(0.), tau_max / 2.);
 
     /* Implicit step 1: T1 <- {T0, 1} at time t -> t + tau */
-    parabolic_module_->prepare_state_vector(temp_[0], t);
     parabolic_module_->template backward_euler_step<0>(
         temp_[0], t, {}, {}, temp_[1], tau);
 
@@ -723,7 +728,6 @@ namespace ryujin
         temp_[1], {{state_vector}}, {{Number(-1.)}}, temp_[2], tau);
 
     /* Implicit step 2: T3 <- {T2, 0} and {U_old, 1} at t + tau -> t + 2 tau */
-    parabolic_module_->prepare_state_vector(temp_[2], t);
     parabolic_module_->template backward_euler_step<1>(temp_[2],
                                                        t + 1.0 * tau,
                                                        {{state_vector}},
@@ -743,6 +747,8 @@ namespace ryujin
     std::cout << "TimeIntegrator<dim, Number>::step_imex_33()" << std::endl;
 #endif
 
+    parabolic_module_->prepare_state_vector(state_vector, t);
+
     /* IMEX(3, 3; 1), see @cite ErnGuermond2023, Sec. 4.3. */
 
     const Number gamma = Number(0.5) + std::sqrt(Number(3.0)) / Number(6.0);
@@ -753,7 +759,6 @@ namespace ryujin
         state_vector, {}, {}, temp_[0], Number(0.), tau_max / 3.);
 
     /* Implicit step 1: T1 <- {U_old, 1 - 3*gamma} at time t -> t + tau */
-    parabolic_module_->prepare_state_vector(temp_[0], t);
     parabolic_module_->template backward_euler_step<1>(
         temp_[0],
         t,
@@ -771,7 +776,6 @@ namespace ryujin
      * Implicit step 2:
      * T3 <- {U_old, 6*gamma-1} and {T1, 2-9*gamma} at t -> t + * 2 tau
      */
-    parabolic_module_->prepare_state_vector(temp_[2], t);
     parabolic_module_->template backward_euler_step<2>(
         temp_[2],
         t + tau,
@@ -789,7 +793,6 @@ namespace ryujin
                                          tau);
 
     /* Implicit step 3: */
-    parabolic_module_->prepare_state_vector(temp_[4], t);
     parabolic_module_->template backward_euler_step<3>(
         temp_[4],
         t + 2. * tau,

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -408,9 +408,10 @@ namespace ryujin
           Scope scope(computing_timer_, "(re)initialize data structures");
           print_info("performing mesh adaptation");
 
-          hyperbolic_module_.prepare_state_vector(state_vector, t);
           if (!ParabolicSystem::is_identity)
             parabolic_module_.prepare_state_vector(state_vector, t);
+          hyperbolic_module_.prepare_state_vector(state_vector, t);
+
           adapt_mesh_and_transfer_state_vector(state_vector,
                                                prepare_compute_kernels);
         }
@@ -664,9 +665,9 @@ namespace ryujin
     std::cout << "TimeLoop<dim, Number>::compute_error()" << std::endl;
 #endif
 
-    hyperbolic_module_.prepare_state_vector(state_vector, t);
     if (!ParabolicSystem::is_identity)
       parabolic_module_.prepare_state_vector(state_vector, t);
+    hyperbolic_module_.prepare_state_vector(state_vector, t);
 
     Vector<Number> difference_per_cell(
         discretization_.triangulation().n_active_cells());
@@ -844,9 +845,9 @@ namespace ryujin
     if (!(do_full_output || do_levelsets || do_checkpointing))
       return;
 
-    hyperbolic_module_.prepare_state_vector(state_vector, t);
     if (!ParabolicSystem::is_identity)
       parabolic_module_.prepare_state_vector(state_vector, t);
+    hyperbolic_module_.prepare_state_vector(state_vector, t);
 
     /* Data output: */
     if (do_full_output || do_levelsets) {


### PR DESCRIPTION
For a parabolic update step we potentially need to precompute values before we do a combined IMEX step. Everything else can be refactored into the parabolic step() function itself.

Thus, simply update the logic for `ParabolicModule::prepare_state_vector()` and only call the method before a combined IMEX time step.
