### PR TITLE
`TimeIntegrator`: add "cruise control" strategy

### DIFF
--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -71,10 +71,15 @@ namespace ryujin
    * kept constant. A standard strategy implemented in TimeIntegrator is to
    * simply fall back to a smaller relative CFL number and try again.
    *
+   * The field @p suggested_tau_max is set to a tau_max value with which
+   * the entire update step should be restarted.
+   *
    * @ingroup TimeLoop
    */
   class Restart final
   {
+  public:
+    const double suggested_tau_max;
   };
 
 

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -30,8 +30,12 @@ namespace ryujin
    * numbers > 1, and/or later stages in the Runge Kutta scheme when the
    * time step tau is prescribed.
    *
-   * The invariant domain violation is detected in the limiter and
-   * typically implies that the low-order update is already out of bounds.
+   * The invariant domain violation is detected in the limiter and implies
+   * that the low-order update itself lies outside the invariant domain.
+   *
+   * A "CFL violation" occurs if the computed tau_max of a substep is
+   * significantly larger than the previously computed time step size tau
+   * with which we perform the update.
    *
    * @note Data structures in HyperbolicModule are initialized with the
    * ensemble subrange communicator stored in MPIEnsemble. However, the
@@ -268,6 +272,27 @@ namespace ryujin
     ACCESSOR_READ_ONLY(cfl)
 
     /**
+     * Sets the relative maximal acceptable tau_max ratio. If the ratio of
+     * the enforced time-step size tau and our computed tau_max for the
+     * hyperbolic (sub) step is above this limit we throw a Restart
+     * exception.
+     */
+    void acceptable_tau_max_ratio(Number new_acceptable_tau_max_ratio) const
+    {
+      Assert(new_acceptable_tau_max_ratio >= Number(1.),
+             dealii::ExcInternalError());
+      acceptable_tau_max_ratio_ = new_acceptable_tau_max_ratio;
+    }
+
+    /**
+     * Returns the relative maximal acceptable tau_max ratio. If the ratio
+     * of the enforced time-step size tau and our computed tau_max for the
+     * hyperbolic (sub) step is above this limit we throw a Restart
+     * exception.
+     */
+    ACCESSOR_READ_ONLY(acceptable_tau_max_ratio)
+
+    /**
      * Return a reference to the OfflineData object
      */
     ACCESSOR_READ_ONLY(offline_data)
@@ -345,6 +370,7 @@ namespace ryujin
         initial_values_;
 
     mutable Number cfl_;
+    mutable Number acceptable_tau_max_ratio_;
 
     mutable unsigned int n_restarts_;
     mutable unsigned int n_corrections_;

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -79,7 +79,7 @@ namespace ryujin
   class Restart final
   {
   public:
-    const double suggested_tau_max;
+    double suggested_tau_max;
   };
 
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -552,8 +552,8 @@ namespace ryujin
         dij_matrix_.write_entry(d_sum, i, 0);
 
         const Number mass = lumped_mass_matrix.local_element(i);
-        const Number tau = cfl_ * mass / (Number(-2.) * d_sum);
-        local_tau_max = std::min(local_tau_max, tau);
+        const Number local_tau = cfl_ * mass / (Number(-2.) * d_sum);
+        local_tau_max = std::min(local_tau_max, local_tau);
       }
 
       /* Synchronize tau max over all threads: */
@@ -582,15 +582,16 @@ namespace ryujin
           ExcMessage(
               "I'm sorry, Dave. I'm afraid I can't do that.\nWe crashed."));
 
-      /* We need to signal a restart if the enforced tau is too wacky: */
-      restart_needed = (tau > acceptable_tau_max_ratio_ * tau_max.load());
-
       tau = (tau == Number(0.) ? tau_max.load() : tau);
 
 #ifdef DEBUG_OUTPUT
-      std::cout << "        computed tau_max = " << tau_max << std::endl;
-      std::cout << "        perform time-step with tau = " << tau << std::endl;
+      std::cout << "        computed tau_max = " << tau_max
+                << " (CFL = " << cfl_ << ")" << std::endl;
+      std::cout << "        step with tau    = " << tau << std::endl;
 #endif
+
+      /* We need to signal a restart if the enforced tau is too wacky: */
+      restart_needed = (tau > acceptable_tau_max_ratio_ * tau_max.load());
     }
 
 #ifdef DEBUG
@@ -1225,10 +1226,18 @@ namespace ryujin
       switch (id_violation_strategy_) {
       case IDViolationStrategy::warn:
         n_warnings_++;
+#ifdef DEBUG_OUTPUT
+        std::cout << "        raised warning, CFL/IDP violation encountered "
+                  << std::endl;
+#endif
         break;
       case IDViolationStrategy::raise_exception:
         n_restarts_++;
         /* Suggest a restart with tau_max: */
+#ifdef DEBUG_OUTPUT
+        std::cout << "        signalling restart (suggested_tau_max = "
+                  << tau_max << ")" << std::endl;
+#endif
         throw Restart{tau_max};
       }
     }

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -1228,7 +1228,8 @@ namespace ryujin
         break;
       case IDViolationStrategy::raise_exception:
         n_restarts_++;
-        throw Restart();
+        /* Suggest a restart with tau_max: */
+        throw Restart{tau_max};
       }
     }
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -44,6 +44,7 @@ namespace ryujin
       , hyperbolic_system_(&hyperbolic_system)
       , initial_values_(&initial_values)
       , cfl_(0.2)
+      , acceptable_tau_max_ratio_(1.e6)
       , n_restarts_(0)
       , n_corrections_(0)
       , n_warnings_(0)
@@ -580,6 +581,9 @@ namespace ryujin
           !std::isnan(tau_max) && !std::isinf(tau_max) && tau_max > 0.,
           ExcMessage(
               "I'm sorry, Dave. I'm afraid I can't do that.\nWe crashed."));
+
+      /* We need to signal a restart if the enforced tau is too wacky: */
+      restart_needed = (tau > acceptable_tau_max_ratio_ * tau_max.load());
 
       tau = (tau == Number(0.) ? tau_max.load() : tau);
 

--- a/source/navier_stokes/parabolic_solver.template.h
+++ b/source/navier_stokes/parabolic_solver.template.h
@@ -992,7 +992,8 @@ namespace ryujin
         /* If we can do a restart try that first: */
         if (id_violation_strategy == IDViolationStrategy::raise_exception) {
           n_restarts_++;
-          throw Restart();
+          /* Half step size is a good heuristic: */
+          throw Restart{Number(0.5) * tau};
         } else {
           n_corrections_++;
           throw Correction();
@@ -1006,7 +1007,8 @@ namespace ryujin
           break;
         case IDViolationStrategy::raise_exception:
           n_restarts_++;
-          throw Restart();
+          /* Half step size is a good heuristic: */
+          throw Restart{Number(0.5) * tau};
         }
       }
     }

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -444,6 +444,8 @@ namespace ryujin
 
     CFLRecoveryStrategy cfl_recovery_strategy_;
 
+    Number acceptable_tau_max_ratio_;
+
     TimeSteppingScheme time_stepping_scheme_;
     double efficiency_;
 

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -32,11 +32,20 @@ namespace ryujin
 
     /**
      * Step with the chosen "cfl max" value and, in case an invariant
-     * domain and or CFL condition violation is detected, the time step
-     * is repeated with "cfl min". If this is unsuccessful as well, a
-     * warning is emitted.
+     * domain or "CFL condition" violation is detected, the time step is
+     * repeated with "cfl min". If this is unsuccessful as well, a warning
+     * is emitted.
      */
     bang_bang_control,
+
+    /**
+     * Adaptive strategy that similarly to "bang bang control" first steps
+     * with the chosen "cfl max" value, and, in case of an invariant domain
+     * violation or a "CFL condition" violation restarts the time step
+     * using a tau_max hint coming from the sub step where we encountered a
+     * problem. This is the default strategy.
+     */
+    cruise_control,
   };
 
 
@@ -208,10 +217,11 @@ namespace ryujin
 } // namespace ryujin
 
 #ifndef DOXYGEN
-DECLARE_ENUM(ryujin::CFLRecoveryStrategy,
-             LIST({ryujin::CFLRecoveryStrategy::none, "none"},
-                  {ryujin::CFLRecoveryStrategy::bang_bang_control,
-                   "bang bang control"}));
+DECLARE_ENUM(
+    ryujin::CFLRecoveryStrategy,
+    LIST({ryujin::CFLRecoveryStrategy::none, "none"},
+         {ryujin::CFLRecoveryStrategy::bang_bang_control, "bang bang control"},
+         {ryujin::CFLRecoveryStrategy::cruise_control, "cruise control"}, ));
 
 DECLARE_ENUM(
     ryujin::TimeSteppingScheme,

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -58,6 +58,13 @@ namespace ryujin
                   "CFL/invariant domain violation recovery strategy: none, "
                   "bang bang control");
 
+    acceptable_tau_max_ratio_ = Number(2.0);
+    add_parameter("acceptable tau_max ratio",
+                  acceptable_tau_max_ratio_,
+                  "Maximal acceptable discrepancy between computed tau_max of "
+                  "a (sub)step and enforced time-step size tau. If the ratio "
+                  "is violated then a restart will be singnalled.");
+
     if (ParabolicSystem::is_identity)
       time_stepping_scheme_ = TimeSteppingScheme::erk_33;
     else
@@ -141,13 +148,19 @@ namespace ryujin
       Vectors::reinit_state_vector<Description>(it, *offline_data_);
     }
 
-    /* Reset CFL to canonical starting value: */
+    /* Reset CFL to starting value, set maximal acceptable tau_max ratio: */
 
     AssertThrow(cfl_min_ > 0., ExcMessage("cfl min must be a positive value"));
     AssertThrow(cfl_max_ >= cfl_min_,
                 ExcMessage("cfl max must be greater than or equal to cfl min"));
 
+    AssertThrow(
+        acceptable_tau_max_ratio_ >= 1.0,
+        ExcMessage(
+            "acceptable tau_max ratio must be greater than or equal to 1."));
+
     hyperbolic_module_->cfl(cfl_max_);
+    hyperbolic_module_->acceptable_tau_max_ratio(acceptable_tau_max_ratio_);
 
     const auto check_whether_timestepping_makes_sense = [&]() {
       /*

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -216,6 +216,13 @@ namespace ryujin
   }
 
 
+  /*
+   * -------------------------------------------------------------------------
+   * High level step function implementing various CFLRecoveryStrategy
+   * -------------------------------------------------------------------------
+   */
+
+
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step(
       StateVector &state_vector,
@@ -316,11 +323,24 @@ namespace ryujin
   }
 
 
+  /*
+   * -------------------------------------------------------------------------
+   * Concrete implementation of ERK / IMEX time stepping strategies.
+   * -------------------------------------------------------------------------
+   */
+
+
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_ssprk_22(
       StateVector &state_vector, Number t, Number tau_max)
   {
     /* SSP-RK2, see @cite Shu1988, Eq. 2.15. */
+
+#ifdef DEBUG_OUTPUT
+    std::cout << "TimeIntegrator<dim, Number>::step_ssprk_22()" << std::endl;
+#endif
+
+    Assert(efficiency_ == 1., dealii::ExcInternalError());
 
     /* Step 1: T0 = U_old + tau * L(U_old) at t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
@@ -344,6 +364,12 @@ namespace ryujin
       StateVector &state_vector, Number t, Number tau_max)
   {
     /* SSP-RK3, see @cite Shu1988, Eq. 2.18. */
+
+#ifdef DEBUG_OUTPUT
+    std::cout << "TimeIntegrator<dim, Number>::step_ssprk_33()" << std::endl;
+#endif
+
+    Assert(efficiency_ == 1., dealii::ExcInternalError());
 
     /* Step 1: T0 = U_old + tau * L(U_old) at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
@@ -377,6 +403,8 @@ namespace ryujin
     std::cout << "TimeIntegrator<dim, Number>::step_erk_11()" << std::endl;
 #endif
 
+    Assert(efficiency_ == 1., dealii::ExcInternalError());
+
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
@@ -395,10 +423,12 @@ namespace ryujin
     std::cout << "TimeIntegrator<dim, Number>::step_erk_22()" << std::endl;
 #endif
 
+    Assert(efficiency_ == 2., dealii::ExcInternalError());
+
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(.0), tau_max / 2.);
+        state_vector, {}, {}, temp_[0], Number(.0), tau_max / efficiency_);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -406,7 +436,7 @@ namespace ryujin
         temp_[0], {{state_vector}}, {{Number(-1.)}}, temp_[1], tau);
 
     state_vector.swap(temp_[1]);
-    return 2. * tau;
+    return efficiency_ * tau;
   }
 
 
@@ -418,10 +448,12 @@ namespace ryujin
     std::cout << "TimeIntegrator<dim, Number>::step_erk_33()" << std::endl;
 #endif
 
+    Assert(efficiency_ == 3., dealii::ExcInternalError());
+
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / 3.);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + 1*tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -440,7 +472,7 @@ namespace ryujin
                                          tau);
 
     state_vector.swap(temp_[2]);
-    return 3. * tau;
+    return efficiency_ * tau;
   }
 
 
@@ -452,10 +484,12 @@ namespace ryujin
     std::cout << "TimeIntegrator<dim, Number>::step_erk_43()" << std::endl;
 #endif
 
+    Assert(efficiency_ == 4., dealii::ExcInternalError());
+
     /* Step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / 4.);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Step 2: T1 <- {T0, 2} and {U_old, -1} at time t + 1*tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -479,7 +513,7 @@ namespace ryujin
                                          tau);
 
     state_vector.swap(temp_[3]);
-    return 4. * tau;
+    return efficiency_ * tau;
   }
 
 
@@ -490,6 +524,8 @@ namespace ryujin
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_erk_54()" << std::endl;
 #endif
+
+    Assert(efficiency_ == 5., dealii::ExcInternalError());
 
     constexpr Number c = 0.2; /* equidistant c_i */
     constexpr Number a_21 = +0.2;
@@ -502,16 +538,16 @@ namespace ryujin
     constexpr Number a_52 = +0.51534223099602405;
     constexpr Number a_53 = -0.81662794199265554;
     constexpr Number a_54 = +0.88505294668159373;
-    constexpr Number a_61 = -0.10511678454691901; /* aka b_1 */
-    constexpr Number a_62 = +0.87880047152100838; /* aka b_2 */
-    constexpr Number a_63 = -0.58903404061484477; /* aka b_3 */
-    constexpr Number a_64 = +0.46213380485434047; /* aka b_4 */
-    // constexpr Number a_65 = +0.35321654878641495; /* aka b_5 */
+    constexpr Number a_61 = -0.10511678454691901;                  /* aka b_1 */
+    constexpr Number a_62 = +0.87880047152100838;                  /* aka b_2 */
+    constexpr Number a_63 = -0.58903404061484477;                  /* aka b_3 */
+    constexpr Number a_64 = +0.46213380485434047;                  /* aka b_4 */
+    constexpr Number a_65 [[maybe_unused]] = +0.35321654878641495; /* aka b_5 */
 
     /* Step 1: at time t -> t + 1*tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / 5.);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Step 2: at time t + 1*tau -> t + 2*tau */
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
@@ -549,7 +585,7 @@ namespace ryujin
         tau);
 
     state_vector.swap(temp_[4]);
-    return 5. * tau;
+    return efficiency_ * tau;
   }
 
 
@@ -564,13 +600,15 @@ namespace ryujin
               << std::endl;
 #endif
 
+    Assert(efficiency_ == 2., dealii::ExcInternalError());
+
     parabolic_module_->prepare_state_vector(state_vector, t);
 
     /* First explicit SSPRK 3 step with final result in temp_[0]: */
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector, {}, {}, temp_[0], Number(0.0), tau_max / 2.);
+        state_vector, {}, {}, temp_[0], Number(0.0), tau_max / efficiency_);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<0>(temp_[0], {}, {}, temp_[1], tau);
@@ -598,7 +636,7 @@ namespace ryujin
     sadd(temp_[0], Number(2.0 / 3.0), Number(1.0 / 3.0), /*!*/ temp_[2]);
 
     state_vector.swap(temp_[0]);
-    return 2. * tau;
+    return efficiency_ * tau;
   }
 
 
@@ -613,21 +651,23 @@ namespace ryujin
               << std::endl;
 #endif
 
+    Assert(efficiency_ == 6., dealii::ExcInternalError());
+
     parabolic_module_->prepare_state_vector(state_vector, t);
 
     /* First explicit ERK(3,3,1) step with final result in temp_[2]: */
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector, {}, {}, temp_[0], Number(0.), tau_max / 6.);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<1>(
-        temp_[0], {{/*!*/ state_vector}}, {{Number(-1.)}}, temp_[1], tau);
+        temp_[0], {{state_vector}}, {{Number(-1.)}}, temp_[1], tau);
 
     hyperbolic_module_->prepare_state_vector(temp_[1], t + 2.0 * tau);
     hyperbolic_module_->template step<2>(temp_[1],
-                                         {{/*!*/ state_vector, temp_[0]}},
+                                         {{state_vector, temp_[0]}},
                                          {{Number(0.75), Number(-2.)}},
                                          temp_[2],
                                          tau);
@@ -654,7 +694,7 @@ namespace ryujin
                                          tau);
 
     state_vector.swap(temp_[2]);
-    return 6. * tau;
+    return efficiency_ * tau;
   }
 
 
@@ -669,17 +709,19 @@ namespace ryujin
               << std::endl;
 #endif
 
+    Assert(efficiency_ == 8., dealii::ExcInternalError());
+
     parabolic_module_->prepare_state_vector(state_vector, t);
 
     /* First explicit ERK(4,3,1) step with final result in temp_[3]: */
 
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        /*!*/ state_vector, {}, {}, temp_[0], Number(0.), tau_max / 8.);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     hyperbolic_module_->prepare_state_vector(temp_[0], t + 1.0 * tau);
     hyperbolic_module_->template step<1>(
-        temp_[0], {{/*!*/ state_vector}}, {{Number(-1.)}}, temp_[1], tau);
+        temp_[0], {{state_vector}}, {{Number(-1.)}}, temp_[1], tau);
 
     hyperbolic_module_->prepare_state_vector(temp_[1], t + 2.0 * tau);
     hyperbolic_module_->template step<1>(
@@ -718,8 +760,9 @@ namespace ryujin
                                          tau);
 
     state_vector.swap(temp_[3]);
-    return 8. * tau;
+    return efficiency_ * tau;
   }
+
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_imex_11(
@@ -728,6 +771,8 @@ namespace ryujin
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_imex_11()" << std::endl;
 #endif
+
+    Assert(efficiency_ == 1., dealii::ExcInternalError());
 
     parabolic_module_->prepare_state_vector(state_vector, t);
 
@@ -744,6 +789,7 @@ namespace ryujin
     return tau;
   }
 
+
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_imex_22(
       StateVector &state_vector, Number t, Number tau_max)
@@ -752,12 +798,14 @@ namespace ryujin
     std::cout << "TimeIntegrator<dim, Number>::step_imex_22()" << std::endl;
 #endif
 
+    Assert(efficiency_ == 2., dealii::ExcInternalError());
+
     parabolic_module_->prepare_state_vector(state_vector, t);
 
     /* Explicit step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / 2.);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Implicit step 1: T1 <- {T0, 1} at time t -> t + tau */
     parabolic_module_->template backward_euler_step<0>(
@@ -777,8 +825,9 @@ namespace ryujin
                                                        tau);
 
     state_vector.swap(temp_[3]);
-    return 2. * tau;
+    return efficiency_ * tau;
   }
+
 
   template <typename Description, int dim, typename Number>
   Number TimeIntegrator<Description, dim, Number>::step_imex_33(
@@ -787,6 +836,8 @@ namespace ryujin
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step_imex_33()" << std::endl;
 #endif
+
+    Assert(efficiency_ == 3., dealii::ExcInternalError());
 
     parabolic_module_->prepare_state_vector(state_vector, t);
 
@@ -797,7 +848,7 @@ namespace ryujin
     /* Explicit step 1: T0 <- {U_old, 1} at time t -> t + tau */
     hyperbolic_module_->prepare_state_vector(state_vector, t);
     Number tau = hyperbolic_module_->template step<0>(
-        state_vector, {}, {}, temp_[0], Number(0.), tau_max / 3.);
+        state_vector, {}, {}, temp_[0], Number(0.), tau_max / efficiency_);
 
     /* Implicit step 1: T1 <- {U_old, 1 - 3*gamma} at time t -> t + tau */
     parabolic_module_->template backward_euler_step<1>(
@@ -845,7 +896,7 @@ namespace ryujin
         tau);
 
     state_vector.swap(temp_[5]);
-    return 3. * tau;
+    return efficiency_ * tau;
   }
 
 } /* namespace ryujin */

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -620,7 +620,13 @@ namespace ryujin
 
     /* Implicit Crank-Nicolson step with final result in temp_[2]: */
 
-    parabolic_module_->crank_nicolson_step(temp_[0], t, temp_[2], 2.0 * tau);
+    try {
+      parabolic_module_->crank_nicolson_step(temp_[0], t, temp_[2], 2.0 * tau);
+    } catch (Restart &restart) {
+      /* Adjust suggested_tau_max. We multiply with efficiency_ again later */
+      restart.suggested_tau_max /= efficiency_;
+      throw;
+    }
 
     /* Second SSPRK 3 step with final result in temp_[0]: */
 
@@ -674,7 +680,13 @@ namespace ryujin
 
     /* Implicit Crank-Nicolson step with final result in temp_[3]: */
 
-    parabolic_module_->crank_nicolson_step(temp_[2], t, temp_[3], 6.0 * tau);
+    try {
+      parabolic_module_->crank_nicolson_step(temp_[2], t, temp_[3], 6.0 * tau);
+    } catch (Restart &restart) {
+      /* Adjust suggested_tau_max. We multiply with efficiency_ again later */
+      restart.suggested_tau_max /= efficiency_;
+      throw;
+    }
 
     /* Second explicit ERK(3,3,1) 3 step with final result in temp_[2]: */
 
@@ -736,7 +748,13 @@ namespace ryujin
 
     /* Implicit Crank-Nicolson step with final result in temp_[2]: */
 
-    parabolic_module_->crank_nicolson_step(temp_[3], t, temp_[2], 8.0 * tau);
+    try {
+      parabolic_module_->crank_nicolson_step(temp_[3], t, temp_[2], 8.0 * tau);
+    } catch (Restart &restart) {
+      /* Adjust suggested_tau_max. We multiply with efficiency_ again later */
+      restart.suggested_tau_max /= efficiency_;
+      throw;
+    }
 
     /* Second explicit ERK(4,3,1) step with final result in temp_[3]: */
 

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -52,11 +52,11 @@ namespace ryujin
         "Maximal admissible relative CFL constant. How this parameter is used "
         "depends on the chosen CFL recovery strategy");
 
-    cfl_recovery_strategy_ = CFLRecoveryStrategy::bang_bang_control;
+    cfl_recovery_strategy_ = CFLRecoveryStrategy::cruise_control;
     add_parameter("cfl recovery strategy",
                   cfl_recovery_strategy_,
                   "CFL/invariant domain violation recovery strategy: none, "
-                  "bang bang control");
+                  "bang bang control, cruise control");
 
     acceptable_tau_max_ratio_ = Number(2.0);
     add_parameter("acceptable tau_max ratio",
@@ -222,10 +222,12 @@ namespace ryujin
       Number t,
       Number t_final /*=std::numeric_limits<Number>::max()*/)
   {
+    Number tau_max = t_final - t; /* enforces t <= t_final */
+
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step()" << std::endl;
+    std::cout << "        enforcing tau_max <= " << tau_max << std::endl;
 #endif
-    Number tau_max = t_final - t;
 
     const auto single_step = [&]() {
       switch (time_stepping_scheme_) {
@@ -260,7 +262,7 @@ namespace ryujin
       }
     };
 
-    if (cfl_recovery_strategy_ == CFLRecoveryStrategy::bang_bang_control) {
+    if (cfl_recovery_strategy_ != CFLRecoveryStrategy::none) {
       hyperbolic_module_->id_violation_strategy_ =
           IDViolationStrategy::raise_exception;
       parabolic_module_->id_violation_strategy_ =
@@ -271,19 +273,45 @@ namespace ryujin
     try {
       return single_step();
 
-    } catch (Restart) {
+    } catch (const Restart &restart) {
 
       AssertThrow(cfl_recovery_strategy_ != CFLRecoveryStrategy::none,
                   dealii::ExcInternalError());
 
+      hyperbolic_module_->id_violation_strategy_ = IDViolationStrategy::warn;
+      parabolic_module_->id_violation_strategy_ = IDViolationStrategy::warn;
+
       if (cfl_recovery_strategy_ == CFLRecoveryStrategy::bang_bang_control) {
-        hyperbolic_module_->id_violation_strategy_ = IDViolationStrategy::warn;
-        parabolic_module_->id_violation_strategy_ = IDViolationStrategy::warn;
+        /* Retry with cfl_min instead of cfl_max: */
+#ifdef DEBUG_OUTPUT
+        std::cout
+            << "        restart with bang bang control: setting cfl to cfl_min"
+            << std::endl;
+#endif
         hyperbolic_module_->cfl(cfl_min_);
-        return single_step();
       }
 
-      __builtin_unreachable();
+      if (cfl_recovery_strategy_ == CFLRecoveryStrategy::cruise_control) {
+        /* Retry with the suggested tau_max: */
+#ifdef DEBUG_OUTPUT
+        std::cout
+            << "        restart with cruise control: using suggested_tau_max"
+            << std::endl;
+#endif
+        //
+        // Multiply the suggested tau_max value with the efficiency.
+        //
+        // We have to account for the fact that the e Restart exception is
+        // thrown within a substep of the hyperbolic or parabolic module.
+        // This implies that the suggested_tau_max is computed for that
+        // particular substep and not for the full combined method (where
+        // tau_max can be larger). We thus multiply tau_max with the
+        // efficiency factor.
+        //
+        tau_max = std::min(tau_max, efficiency_ * restart.suggested_tau_max);
+      }
+
+      return single_step();
     }
   }
 


### PR DESCRIPTION
Add a "cruise control" strategy that restarts a given time step with the suggested tau_max instead of recomputing a tau_max from cfl_min.
