### PR TITLE
`TimeLoop`: use a wall-time based checkpointing logic

### DIFF
--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -568,7 +568,7 @@ namespace ryujin
 
     {
       Scope scope(computing_timer_,
-                  "time step [H] _ - synchronization barriers");
+                  "time step [X] _ - synchronization barriers");
 
       /*
        * MPI Barrier: Synchronize the maximal time-step size. This has to
@@ -1209,7 +1209,7 @@ namespace ryujin
 
     {
       Scope scope(computing_timer_,
-                  "time step [H] _ - synchronization barriers");
+                  "time step [X] _ - synchronization barriers");
 
       /*
        * Synchronize whether we have to restart the time step. Even though

--- a/source/navier_stokes/parabolic_solver.template.h
+++ b/source/navier_stokes/parabolic_solver.template.h
@@ -523,7 +523,7 @@ namespace ryujin
 
       {
         Scope scope(computing_timer_,
-                    "time step [P] _ - synchronization barriers");
+                    "time step [X] _ - synchronization barriers");
 
         /* Compute the global minimum of the internal energy: */
 
@@ -968,7 +968,7 @@ namespace ryujin
 
       {
         Scope scope(computing_timer_,
-                    "time step [H] _ - synchronization barriers");
+                    "time step [X] _ - synchronization barriers");
 
         /*
          * Synchronize whether we have to restart or correct the time step.

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -163,14 +163,12 @@ namespace ryujin
     bool enforce_t_final_;
     Number timer_granularity_;
 
-    bool enable_checkpointing_;
     bool enable_output_full_;
     bool enable_output_levelsets_;
     bool enable_compute_error_;
     bool enable_compute_quantities_;
     bool enable_mesh_adaptivity_;
 
-    unsigned int timer_checkpoint_multiplier_;
     unsigned int timer_output_full_multiplier_;
     unsigned int timer_output_levelsets_multiplier_;
     unsigned int timer_compute_quantities_multiplier_;
@@ -183,6 +181,8 @@ namespace ryujin
 
     Number terminal_update_interval_;
     bool terminal_show_rank_throughput_;
+
+    Number checkpoint_update_interval_;
 
     //@}
     /**

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -138,7 +138,8 @@ namespace ryujin
 
     void print_information(unsigned int output_cycle,
                            Number last_checkpoint,
-                           std::ostream &stream);
+                           std::ostream &stream,
+                           bool final_time = false);
     void print_memory_statistics(std::ostream &stream);
     void print_timers(std::ostream &stream);
     void print_throughput(unsigned int cycle,

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -129,6 +129,16 @@ namespace ryujin
 
     void print_parameters(std::ostream &stream);
     void print_mpi_partition(std::ostream &stream);
+
+    void print_info(const std::string &header);
+
+    void print_head(const std::string &header,
+                    const std::string &secondary,
+                    std::ostream &stream);
+
+    void print_information(unsigned int output_cycle,
+                           Number last_checkpoint,
+                           std::ostream &stream);
     void print_memory_statistics(std::ostream &stream);
     void print_timers(std::ostream &stream);
     void print_throughput(unsigned int cycle,
@@ -136,14 +146,10 @@ namespace ryujin
                           std::ostream &stream,
                           bool final_time = false);
 
-    void print_info(const std::string &header);
-    void print_head(const std::string &header,
-                    const std::string &secondary,
-                    std::ostream &stream);
-
     void print_cycle_statistics(unsigned int cycle,
                                 Number t,
                                 unsigned int output_cycle,
+                                Number last_checkpoint,
                                 bool write_to_logfile = false,
                                 bool final_time = false);
     //@}

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -464,7 +464,7 @@ namespace ryujin
       if (update_checkpoint) {
         Scope scop(computing_timer_, "time step [X]   - perform checkpointing");
         print_info("scheduling checkpointing");
-        write_checkpoint(state_vector, base_name_ensemble_, t, cycle);
+        write_checkpoint(state_vector, base_name_ensemble_, t, timer_cycle);
         last_checkpoint = wall_time;
       }
     } /* end of loop */
@@ -475,7 +475,7 @@ namespace ryujin
     if (checkpoint_update_interval_ != Number(0.)) {
       Scope scope(computing_timer_, "time step [X]   - perform checkpointing");
       print_info("scheduling checkpointing");
-      write_checkpoint(state_vector, base_name_ensemble_, t, cycle);
+      write_checkpoint(state_vector, base_name_ensemble_, t, timer_cycle);
     }
 
     computing_timer_["time loop"].stop();
@@ -520,7 +520,7 @@ namespace ryujin
       StateVector &state_vector,
       const std::string &base_name,
       Number &t,
-      unsigned int &output_cycle,
+      unsigned int &timer_cycle,
       const Callable &prepare_compute_kernels)
   {
 #ifdef DEBUG_OUTPUT
@@ -560,7 +560,7 @@ namespace ryujin
 
       std::ifstream file(meta, std::ios::binary);
       boost::archive::binary_iarchive ia(file);
-      ia >> t >> output_cycle >> transfer_handle;
+      ia >> t >> timer_cycle >> transfer_handle;
     }
 
     int ierr;
@@ -572,7 +572,7 @@ namespace ryujin
           MPI_Bcast(&t, 1, MPI_FLOAT, 0, mpi_ensemble_.ensemble_communicator());
     AssertThrowMPI(ierr);
 
-    ierr = MPI_Bcast(&output_cycle,
+    ierr = MPI_Bcast(&timer_cycle,
                      1,
                      MPI_UNSIGNED,
                      0,
@@ -601,7 +601,7 @@ namespace ryujin
       const StateVector &state_vector,
       const std::string &base_name,
       const Number &t,
-      const unsigned int &output_cycle)
+      const unsigned int &timer_cycle)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeLoop<dim, Number>::write_checkpoint()" << std::endl;
@@ -643,7 +643,7 @@ namespace ryujin
       std::string meta = name + ".metadata";
       std::ofstream file(meta, std::ios::binary | std::ios::trunc);
       boost::archive::binary_oarchive oa(file);
-      oa << t << output_cycle << transfer_handle;
+      oa << t << timer_cycle << transfer_handle;
     }
 
     const int ierr = MPI_Barrier(mpi_ensemble_.ensemble_communicator());

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -215,6 +215,13 @@ namespace ryujin
   }
 
 
+  /*
+   * ---------------------------------------------------------------------------
+   * Setup and main loop:
+   * ---------------------------------------------------------------------------
+   */
+
+
   template <typename Description, int dim, typename Number>
   void TimeLoop<Description, dim, Number>::run()
   {
@@ -443,8 +450,11 @@ namespace ryujin
       if (write_to_log_file || update_terminal) {
         Scope scope(computing_timer_,
                     "time step [X] _ - synchronization barriers");
-        print_cycle_statistics(
-            cycle, t, timer_cycle, /*logfile*/ write_to_log_file);
+        print_cycle_statistics(cycle,
+                               t,
+                               timer_cycle,
+                               last_checkpoint,
+                               /*logfile*/ write_to_log_file);
         last_terminal_output = wall_time;
       }
 
@@ -472,8 +482,12 @@ namespace ryujin
 
     if (terminal_update_interval_ != Number(0.)) {
       /* Write final timing statistics to screen and logfile: */
-      print_cycle_statistics(
-          cycle, t, timer_cycle, /*logfile*/ true, /*final*/ true);
+      print_cycle_statistics(cycle,
+                             t,
+                             timer_cycle,
+                             last_checkpoint,
+                             /*logfile*/ true,
+                             /*final*/ true);
     }
 
     if (enable_compute_error_) {
@@ -491,6 +505,13 @@ namespace ryujin
     CALLGRIND_DUMP_STATS;
 #endif
   }
+
+
+  /*
+   * ---------------------------------------------------------------------------
+   * Checkpointing, VTK output, and compute error:
+   * ---------------------------------------------------------------------------
+   */
 
 
   template <typename Description, int dim, typename Number>
@@ -878,7 +899,9 @@ namespace ryujin
 
 
   /*
+   * ---------------------------------------------------------------------------
    * Output and logging related functions:
+   * ---------------------------------------------------------------------------
    */
 
 
@@ -983,6 +1006,108 @@ namespace ryujin
     print_snippet("rel", data[3]);
 
     stream << output.str() << std::endl;
+  }
+
+
+  template <typename Description, int dim, typename Number>
+  void TimeLoop<Description, dim, Number>::print_info(const std::string &header)
+  {
+    if (mpi_ensemble_.world_rank() != 0)
+      return;
+
+    std::cout << "[INFO] " << header << std::endl;
+  }
+
+
+  template <typename Description, int dim, typename Number>
+  void
+  TimeLoop<Description, dim, Number>::print_head(const std::string &header,
+                                                 const std::string &secondary,
+                                                 std::ostream &stream)
+  {
+    if (mpi_ensemble_.world_rank() != 0)
+      return;
+
+    const int header_size = header.size();
+    const auto padded_header =
+        std::string(std::max(0, 34 - header_size) / 2, ' ') + header +
+        std::string(std::max(0, 35 - header_size) / 2, ' ');
+
+    const int secondary_size = secondary.size();
+    const auto padded_secondary =
+        std::string(std::max(0, 34 - secondary_size) / 2, ' ') + secondary +
+        std::string(std::max(0, 35 - secondary_size) / 2, ' ');
+
+    /* clang-format off */
+    stream << "\n";
+    stream << "    ####################################################\n";
+    stream << "    #########"     <<  padded_header   <<     "#########\n";
+    stream << "    #########"     << padded_secondary <<     "#########\n";
+    stream << "    ####################################################\n";
+    stream << std::endl;
+    /* clang-format on */
+  }
+
+
+  template <typename Description, int dim, typename Number>
+  void TimeLoop<Description, dim, Number>::print_information(
+      unsigned int timer_cycle, Number last_checkpoint, std::ostream &stream)
+  {
+    static const std::string vectorization_name = [] {
+      constexpr auto width = VectorizedArray<Number>::size();
+
+      std::string result;
+      if (width == 1)
+        result = "scalar ";
+      else
+        result = std::to_string(width * 8 * sizeof(Number)) + " bit packed ";
+
+      if constexpr (std::is_same_v<Number, double>)
+        return result + "double";
+      else if constexpr (std::is_same_v<Number, float>)
+        return result + "float";
+      else
+        __builtin_trap();
+    }();
+
+    stream << "Information: (HYP) " << hyperbolic_system_.get().problem_name;
+    if constexpr (!ParabolicSystem::is_identity) {
+      stream << "\n             (PAR) " << parabolic_system_.get().problem_name;
+    }
+    stream << "\n             [" << base_name_ << "] ";
+    if (mpi_ensemble_.n_ensembles() > 1) {
+      stream << mpi_ensemble_.n_ensembles() << " ensembles ";
+    }
+    stream << "with "                                      //
+           << n_global_dofs_ << " Qdofs on "               //
+           << mpi_ensemble_.n_world_ranks() << " ranks / " //
+#ifdef WITH_OPENMP
+           << MultithreadInfo::n_threads() << " threads <" //
+#else
+           << "[openmp disabled] <" //
+#endif
+           << vectorization_name << ">\n";
+
+    if (enable_compute_quantities_ || enable_output_full_ ||
+        enable_output_levelsets_) {
+      stream << "             Last output cycle "                          //
+             << timer_cycle - 1                                            //
+             << " at t = " << timer_granularity_ * (timer_cycle - 1)       //
+             << " (terminal update interval " << terminal_update_interval_ //
+             << "s)\n";
+    }
+
+    if (checkpoint_update_interval_ != Number(0.)) {
+      const auto wall_time =
+          Utilities::MPI::min_max_avg(computing_timer_["time loop"].wall_time(),
+                                      mpi_ensemble_.world_communicator());
+
+      stream << "             Last checkpoint at wall time "          //
+             << std::setprecision(2) << std::fixed << last_checkpoint //
+             << "s (" << std::setprecision(0)
+             << std::max(Number(0.), wall_time.max - last_checkpoint)
+             << "s ago)\n";
+    }
   }
 
 
@@ -1271,71 +1396,17 @@ namespace ryujin
 
 
   template <typename Description, int dim, typename Number>
-  void TimeLoop<Description, dim, Number>::print_info(const std::string &header)
-  {
-    if (mpi_ensemble_.world_rank() != 0)
-      return;
-
-    std::cout << "[INFO] " << header << std::endl;
-  }
-
-
-  template <typename Description, int dim, typename Number>
-  void
-  TimeLoop<Description, dim, Number>::print_head(const std::string &header,
-                                                 const std::string &secondary,
-                                                 std::ostream &stream)
-  {
-    if (mpi_ensemble_.world_rank() != 0)
-      return;
-
-    const int header_size = header.size();
-    const auto padded_header =
-        std::string(std::max(0, 34 - header_size) / 2, ' ') + header +
-        std::string(std::max(0, 35 - header_size) / 2, ' ');
-
-    const int secondary_size = secondary.size();
-    const auto padded_secondary =
-        std::string(std::max(0, 34 - secondary_size) / 2, ' ') + secondary +
-        std::string(std::max(0, 35 - secondary_size) / 2, ' ');
-
-    /* clang-format off */
-    stream << "\n";
-    stream << "    ####################################################\n";
-    stream << "    #########"     <<  padded_header   <<     "#########\n";
-    stream << "    #########"     << padded_secondary <<     "#########\n";
-    stream << "    ####################################################\n";
-    stream << std::endl;
-    /* clang-format on */
-  }
-
-
-  template <typename Description, int dim, typename Number>
   void TimeLoop<Description, dim, Number>::print_cycle_statistics(
       unsigned int cycle,
       Number t,
       unsigned int timer_cycle,
+      Number last_checkpoint,
       bool write_to_logfile,
       bool final_time)
   {
-    static const std::string vectorization_name = [] {
-      constexpr auto width = VectorizedArray<Number>::size();
-
-      std::string result;
-      if (width == 1)
-        result = "scalar ";
-      else
-        result = std::to_string(width * 8 * sizeof(Number)) + " bit packed ";
-
-      if constexpr (std::is_same_v<Number, double>)
-        return result + "double";
-      else if constexpr (std::is_same_v<Number, float>)
-        return result + "float";
-      else
-        __builtin_trap();
-    }();
-
     std::ostringstream output;
+
+    /* Print header: */
 
     std::ostringstream primary;
     if (final_time) {
@@ -1351,43 +1422,24 @@ namespace ryujin
 
     print_head(primary.str(), secondary.str(), output);
 
-    output << "Information: (HYP) " << hyperbolic_system_.get().problem_name;
-    if constexpr (!ParabolicSystem::is_identity) {
-      output << "\n             (PAR) " << parabolic_system_.get().problem_name;
-    }
-    output << "\n             [" << base_name_ << "] ";
-    if (mpi_ensemble_.n_ensembles() > 1) {
-      output << mpi_ensemble_.n_ensembles() << " ensembles ";
-    }
-    output << "with "                                      //
-           << n_global_dofs_ << " Qdofs on "               //
-           << mpi_ensemble_.n_world_ranks() << " ranks / " //
-#ifdef WITH_OPENMP
-           << MultithreadInfo::n_threads() << " threads <" //
-#else
-           << "[openmp disabled] <" //
-#endif
-           << vectorization_name                                         //
-           << ">\n             Last output cycle "                       //
-           << timer_cycle - 1                                            //
-           << " at t = " << timer_granularity_ * (timer_cycle - 1)       //
-           << " (terminal update interval " << terminal_update_interval_ //
-           << "s)\n";
+    /* Print information and statistics: */
 
+    print_information(timer_cycle, last_checkpoint, output);
     print_memory_statistics(output);
     print_timers(output);
     print_throughput(cycle, t, output, final_time);
 
-    if (mpi_ensemble_.world_rank() == 0) {
-#ifndef DEBUG_OUTPUT
-      std::cout << "\033[2J\033[H";
-#endif
-      std::cout << output.str() << std::flush;
+    /* Only output on rank 0: */
+    if (mpi_ensemble_.world_rank() != 0)
+      return;
 
-      if (write_to_logfile) {
-        logfile_ << "\n" << output.str() << std::flush;
-      }
+#ifndef DEBUG_OUTPUT
+    std::cout << "\033[2J\033[H";
+#endif
+    std::cout << output.str() << std::flush;
+
+    if (write_to_logfile) {
+      logfile_ << "\n" << output.str() << std::flush;
     }
   }
-
 } // namespace ryujin

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -441,6 +441,8 @@ namespace ryujin
           (wall_time >= last_terminal_output + terminal_update_interval_);
 
       if (write_to_log_file || update_terminal) {
+        Scope scope(computing_timer_,
+                    "time step [X] _ - synchronization barriers");
         print_cycle_statistics(
             cycle, t, timer_cycle, /*logfile*/ write_to_log_file);
         last_terminal_output = wall_time;

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -104,14 +104,6 @@ namespace ryujin
                   "routines are run. This \"baseline tick\" is further "
                   "modified by the corresponding \"*_multiplier\" options");
 
-    enable_checkpointing_ = false;
-    add_parameter(
-        "enable checkpointing",
-        enable_checkpointing_,
-        "Write out checkpoints to resume an interrupted computation at timer "
-        "granularity intervals. The frequency is determined by \"timer "
-        "granularity\" and \"timer checkpoint multiplier\"");
-
     enable_output_full_ = false;
     add_parameter("enable output full",
                   enable_output_full_,
@@ -148,12 +140,6 @@ namespace ryujin
         "The frequency how often we query MeshAdaptor::analyze() for deciding "
         "on adapting the mesh is determined by \"timer granularity\" and "
         "\"timer mesh refinement multiplier\"");
-
-    timer_checkpoint_multiplier_ = 1;
-    add_parameter("timer checkpoint multiplier",
-                  timer_checkpoint_multiplier_,
-                  "Multiplicative modifier applied to \"timer granularity\" "
-                  "that determines the checkpointing granularity");
 
     timer_output_full_multiplier_ = 1;
     add_parameter("timer output full multiplier",
@@ -201,7 +187,8 @@ namespace ryujin
     add_parameter("terminal update interval",
                   terminal_update_interval_,
                   "Number of seconds after which output statistics are "
-                  "recomputed and printed on the terminal");
+                  "recomputed and printed on the terminal. Setting the "
+                  "interval to zero disables terminal output.");
 
     terminal_show_rank_throughput_ = true;
     add_parameter("terminal show rank throughput",
@@ -211,6 +198,13 @@ namespace ryujin
                   "number of threads (per rank). If set to false then a plain "
                   "average per thread \"CPU\" throughput value is computed by "
                   "using the umodified total accumulated CPU time.");
+
+    checkpoint_update_interval_ = 0;
+    add_parameter(
+        "checkpoint update interval",
+        checkpoint_update_interval_,
+        "Number of seconds after which a new checkpoint is written out to "
+        "disk. Setting the interval to zero disables checkpointing.");
 
     debug_filename_ = "";
     add_parameter("debug filename",
@@ -319,10 +313,12 @@ namespace ryujin
     Vectors::debug_poison_precomputed_values<Description>(state_vector,
                                                           offline_data_);
 
-    unsigned int cycle = 1;
-    Number last_terminal_output = (terminal_update_interval_ == Number(0.)
-                                       ? std::numeric_limits<Number>::max()
-                                       : std::numeric_limits<Number>::lowest());
+    Number last_terminal_output = terminal_update_interval_ == Number(0.)
+                                      ? std::numeric_limits<Number>::max()
+                                      : Number(0.);
+    Number last_checkpoint = checkpoint_update_interval_ == Number(0.)
+                                 ? std::numeric_limits<Number>::max()
+                                 : Number(0.);
 
     /*
      * The honorable main loop:
@@ -334,6 +330,7 @@ namespace ryujin
     constexpr Number relax =
         Number(1.) - Number(10.) * std::numeric_limits<Number>::epsilon();
 
+    unsigned int cycle = 0;
     for (;; ++cycle) {
 
 #ifdef DEBUG_OUTPUT
@@ -348,17 +345,18 @@ namespace ryujin
         quantities_.accumulate(state_vector, t);
       }
 
-      /* Perform various tasks whenever we reach a timer tick: */
+      /* Perform output tasks whenever we reach a timer tick: */
 
       if (t >= relax * timer_cycle * timer_granularity_) {
         if (enable_compute_error_) {
+          /*
+           * FIXME: We interpolate the analytic solution at every timer
+           * tick. If we happen to actually not output anything then this
+           * is terribly inefficient...
+           */
+
           StateVector analytic;
           {
-            /*
-             * FIXME: We interpolate the analytic solution at every timer
-             * tick. If we happen to actually not output anything then this
-             * is terribly inefficient...
-             */
             Scope scope(computing_timer_,
                         "time step [X]   - interpolate analytic solution");
             Vectors::reinit_state_vector<Description>(analytic, offline_data_);
@@ -366,11 +364,6 @@ namespace ryujin
                 initial_values_.get().interpolate_hyperbolic_vector(t);
           }
 
-          /*
-           * FIXME: a call to output() will also write a checkpoint (if
-           * enabled). So as a workaround we simply call the output()
-           * function for the analytic solution first...
-           */
           output(analytic,
                  base_name_ensemble_ + "-analytic_solution",
                  t,
@@ -428,36 +421,50 @@ namespace ryujin
 
       t += tau;
 
+      /* Synchronize wall time: */
+
+      auto wall_time = computing_timer_["time loop"].wall_time();
+      {
+        Scope scope(computing_timer_,
+                    "time step [X] _ - synchronization barriers");
+        wall_time =
+            Utilities::MPI::max(wall_time, mpi_ensemble_.world_communicator());
+      }
+
       /* Print and record cycle statistics: */
-      if (terminal_update_interval_ != Number(0.)) {
 
-        /* Do we need to update the log file? */
-        const bool write_to_log_file =
-            (t >= relax * timer_cycle * timer_granularity_);
+      const bool write_to_log_file =
+          (terminal_update_interval_ != Number(0.)) && /* suppress output */
+          (t >= relax * timer_cycle * timer_granularity_);
 
-        /* Do we need to update the terminal? */
-        const auto wall_time = computing_timer_["time loop"].wall_time();
-        int update_terminal =
-            (wall_time >= last_terminal_output + terminal_update_interval_);
+      const bool update_terminal =
+          (wall_time >= last_terminal_output + terminal_update_interval_);
 
-        /* Broadcast boolean from rank 0 to all other ranks: */
-        const auto ierr = MPI_Bcast(&update_terminal,
-                                    1,
-                                    MPI_INT,
-                                    0,
-                                    mpi_ensemble_.world_communicator());
-        AssertThrowMPI(ierr);
+      if (write_to_log_file || update_terminal) {
+        print_cycle_statistics(
+            cycle, t, timer_cycle, /*logfile*/ write_to_log_file);
+        last_terminal_output = wall_time;
+      }
 
-        if (write_to_log_file || update_terminal) {
-          print_cycle_statistics(
-              cycle, t, timer_cycle, /*logfile*/ write_to_log_file);
-          last_terminal_output = wall_time;
-        }
+      const bool update_checkpoint =
+          (wall_time >= last_checkpoint + checkpoint_update_interval_);
+
+      if (update_checkpoint) {
+        Scope scop(computing_timer_, "time step [X]   - perform checkpointing");
+        print_info("scheduling checkpointing");
+        write_checkpoint(state_vector, base_name_ensemble_, t, cycle);
+        last_checkpoint = wall_time;
       }
     } /* end of loop */
 
     /* We have actually performed one cycle less. */
     --cycle;
+
+    if (checkpoint_update_interval_ != Number(0.)) {
+      Scope scope(computing_timer_, "time step [X]   - perform checkpointing");
+      print_info("scheduling checkpointing");
+      write_checkpoint(state_vector, base_name_ensemble_, t, cycle);
+    }
 
     computing_timer_["time loop"].stop();
 
@@ -838,41 +845,33 @@ namespace ryujin
     const bool do_levelsets =
         (cycle % timer_output_levelsets_multiplier_ == 0) &&
         enable_output_levelsets_;
-    const bool do_checkpointing =
-        (cycle % timer_checkpoint_multiplier_ == 0) && enable_checkpointing_;
 
     /* There is nothing to do: */
-    if (!(do_full_output || do_levelsets || do_checkpointing))
+    if (!(do_full_output || do_levelsets))
       return;
+
+    /* Prepare vectors for output: */
 
     if (!ParabolicSystem::is_identity)
       parabolic_module_.prepare_state_vector(state_vector, t);
     hyperbolic_module_.prepare_state_vector(state_vector, t);
 
     /* Data output: */
-    if (do_full_output || do_levelsets) {
-      Scope scope(computing_timer_, "time step [X]   - perform vtu output");
-      print_info("scheduling output");
 
-      postprocessor_.compute(state_vector);
-      /*
-       * Workaround: Manually reset bounds during the first output cycle
-       * (which is often just a uniform flow field) to obtain a better
-       * normailization:
-       */
-      if (cycle == 0)
-        postprocessor_.reset_bounds();
+    Scope scope(computing_timer_, "time step [X]   - perform vtu output");
+    print_info("scheduling output");
 
-      vtu_output_.schedule_output(
-          state_vector, name, t, cycle, do_full_output, do_levelsets);
-    }
+    postprocessor_.compute(state_vector);
+    /*
+     * Workaround: Manually reset bounds during the first output cycle
+     * (which is often just a uniform flow field) to obtain a better
+     * normailization:
+     */
+    if (cycle == 0)
+      postprocessor_.reset_bounds();
 
-    /* Checkpointing: */
-    if (do_checkpointing) {
-      Scope scope(computing_timer_, "time step [X]   - perform checkpointing");
-      print_info("scheduling checkpointing");
-      write_checkpoint(state_vector, base_name_ensemble_, t, cycle);
-    }
+    vtu_output_.schedule_output(
+        state_vector, name, t, cycle, do_full_output, do_levelsets);
   }
 
 

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -337,7 +337,7 @@ namespace ryujin
     constexpr Number relax =
         Number(1.) - Number(10.) * std::numeric_limits<Number>::epsilon();
 
-    unsigned int cycle = 0;
+    unsigned int cycle = 1;
     for (;; ++cycle) {
 
 #ifdef DEBUG_OUTPUT
@@ -1090,11 +1090,19 @@ namespace ryujin
 
     if (enable_compute_quantities_ || enable_output_full_ ||
         enable_output_levelsets_) {
-      stream << "             Last output cycle "                          //
-             << timer_cycle - 1                                            //
-             << " at t = " << timer_granularity_ * (timer_cycle - 1)       //
-             << " (terminal update interval " << terminal_update_interval_ //
-             << "s)\n";
+      stream << "             Last output cycle "                    //
+             << timer_cycle - 1                                      //
+             << " at t = " << timer_granularity_ * (timer_cycle - 1) //
+             << " [ ";
+
+      if (enable_output_full_)
+        stream << "full ";
+      if (enable_output_levelsets_)
+        stream << "levelsets ";
+      if (enable_compute_quantities_)
+        stream << "quantities ";
+
+      stream << "]\n";
     }
 
     if (checkpoint_update_interval_ != Number(0.)) {
@@ -1105,8 +1113,8 @@ namespace ryujin
       stream << "             Last checkpoint at wall time "          //
              << std::setprecision(2) << std::fixed << last_checkpoint //
              << "s (" << std::setprecision(0)
-             << std::max(Number(0.), wall_time.max - last_checkpoint)
-             << "s ago)\n";
+             << std::max(0., wall_time.max - last_checkpoint)
+             << "s ago, interval " << checkpoint_update_interval_ << "s)\n";
     }
   }
 
@@ -1366,7 +1374,8 @@ namespace ryujin
            << " dt/s) ]" << std::endl;
     /* clang-format on */
 
-    /* and print an ETA */
+    /* And print an ETA: */
+
     time_per_second_exp = 0.8 * time_per_second_exp + 0.2 * time_per_second;
     auto eta = static_cast<unsigned int>(std::max(t_final_ - t, Number(0.)) /
                                          time_per_second_exp);
@@ -1387,6 +1396,10 @@ namespace ryujin
 
     const unsigned int minutes = eta / 60;
     output << minutes << " min";
+
+    output << " (terminal update every " //
+           << std::setprecision(2) << std::fixed << terminal_update_interval_
+           << "s)";
 
     if (mpi_ensemble_.world_rank() != 0)
       return;

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -1061,7 +1061,10 @@ namespace ryujin
 
   template <typename Description, int dim, typename Number>
   void TimeLoop<Description, dim, Number>::print_information(
-      unsigned int timer_cycle, Number last_checkpoint, std::ostream &stream)
+      unsigned int timer_cycle,
+      Number last_checkpoint,
+      std::ostream &stream,
+      bool final_time)
   {
     static const std::string vectorization_name = [] {
       constexpr auto width = VectorizedArray<Number>::size();
@@ -1120,11 +1123,15 @@ namespace ryujin
           Utilities::MPI::min_max_avg(computing_timer_["time loop"].wall_time(),
                                       mpi_ensemble_.world_communicator());
 
-      stream << "             Last checkpoint at wall time "          //
-             << std::setprecision(2) << std::fixed << last_checkpoint //
-             << "s (" << std::setprecision(0)
-             << std::max(0., wall_time.max - last_checkpoint)
-             << "s ago, interval " << checkpoint_update_interval_ << "s)\n";
+      if (final_time) {
+        stream << "             Last checkpoint at FINAL TIME\n";
+      } else {
+        stream << "             Last checkpoint at wall time "          //
+               << std::setprecision(2) << std::fixed << last_checkpoint //
+               << "s (" << std::setprecision(0)
+               << std::max(0., wall_time.max - last_checkpoint)
+               << "s ago, interval " << checkpoint_update_interval_ << "s)\n";
+      }
     }
   }
 
@@ -1447,7 +1454,7 @@ namespace ryujin
 
     /* Print information and statistics: */
 
-    print_information(timer_cycle, last_checkpoint, output);
+    print_information(timer_cycle, last_checkpoint, output, final_time);
     print_memory_statistics(output);
     print_timers(output);
     print_throughput(cycle, t, output, final_time);

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -408,9 +408,9 @@ namespace ryujin
           Scope scope(computing_timer_, "(re)initialize data structures");
           print_info("performing mesh adaptation");
 
+          hyperbolic_module_.prepare_state_vector(state_vector, t);
           if (!ParabolicSystem::is_identity)
             parabolic_module_.prepare_state_vector(state_vector, t);
-          hyperbolic_module_.prepare_state_vector(state_vector, t);
 
           adapt_mesh_and_transfer_state_vector(state_vector,
                                                prepare_compute_kernels);
@@ -463,6 +463,11 @@ namespace ryujin
 
       if (update_checkpoint) {
         Scope scop(computing_timer_, "time step [X]   - perform checkpointing");
+
+        hyperbolic_module_.prepare_state_vector(state_vector, t);
+        if (!ParabolicSystem::is_identity)
+          parabolic_module_.prepare_state_vector(state_vector, t);
+
         print_info("scheduling checkpointing");
         write_checkpoint(state_vector, base_name_ensemble_, t, timer_cycle);
         last_checkpoint = wall_time;
@@ -474,6 +479,11 @@ namespace ryujin
 
     if (checkpoint_update_interval_ != Number(0.)) {
       Scope scope(computing_timer_, "time step [X]   - perform checkpointing");
+
+      hyperbolic_module_.prepare_state_vector(state_vector, t);
+      if (!ParabolicSystem::is_identity)
+        parabolic_module_.prepare_state_vector(state_vector, t);
+
       print_info("scheduling checkpointing");
       write_checkpoint(state_vector, base_name_ensemble_, t, timer_cycle);
     }
@@ -695,9 +705,9 @@ namespace ryujin
     std::cout << "TimeLoop<dim, Number>::compute_error()" << std::endl;
 #endif
 
+    hyperbolic_module_.prepare_state_vector(state_vector, t);
     if (!ParabolicSystem::is_identity)
       parabolic_module_.prepare_state_vector(state_vector, t);
-    hyperbolic_module_.prepare_state_vector(state_vector, t);
 
     Vector<Number> difference_per_cell(
         discretization_.triangulation().n_active_cells());
@@ -875,9 +885,9 @@ namespace ryujin
 
     /* Prepare vectors for output: */
 
+    hyperbolic_module_.prepare_state_vector(state_vector, t);
     if (!ParabolicSystem::is_identity)
       parabolic_module_.prepare_state_vector(state_vector, t);
-    hyperbolic_module_.prepare_state_vector(state_vector, t);
 
     /* Data output: */
 


### PR DESCRIPTION
The current checkpointing logic where the checkpointing operation is tied to the `output()` mechanism isn't really great.

Worse, it actually misses the point: checkpointing is a mechanism to ensure that we do not lose too much computating time in case a computation gets aborted. Thus, let's tie it to elapsed wall time instead.
