### PR TITLE
Allow user-specified maximal timestep size

### DIFF
--- a/source/euler/initial_state_exact_riemann_solution.h
+++ b/source/euler/initial_state_exact_riemann_solution.h
@@ -429,11 +429,13 @@ namespace ryujin
         }
 
 #ifdef DEBUG
-        const double phi_1 = phi(p_1, data_1, data_2);
-        const double phi_2 = phi(p_2, data_1, data_2);
-        Assert(phi_1 * phi_2 <= 0.,
-               dealii::ExcMessage(
-                   "Euler::ExactRiemannSolver: failed to compute p_star."));
+        {
+          const double phi_1 = phi(p_1, data_1, data_2);
+          const double phi_2 = phi(p_2, data_1, data_2);
+          Assert(phi_1 * phi_2 <= 0.,
+                 dealii::ExcMessage(
+                     "Euler::ExactRiemannSolver: failed to compute p_star."));
+        }
 #endif
 
         //

--- a/source/solution_transfer.h
+++ b/source/solution_transfer.h
@@ -59,7 +59,7 @@ namespace ryujin
     /**
      * Array type used to store accumulated bounds.
      */
-    using Bounds = Description::template Limiter<dim, Number>::Bounds;
+    using Bounds = typename Description::template Limiter<dim, Number>::Bounds;
 
     //@}
     /**

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -470,6 +470,7 @@ namespace ryujin
     CFLRecoveryStrategy cfl_recovery_strategy_;
 
     Number acceptable_tau_max_ratio_;
+    Number tau_max_;
 
     TimeSteppingScheme time_stepping_scheme_;
     Number efficiency_;

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -65,6 +65,9 @@ namespace ryujin
                   "a (sub)step and enforced time-step size tau. If the ratio "
                   "is violated then a restart will be singnalled.");
 
+    tau_max_ = Number(1.0);
+    add_parameter("tau_max", tau_max_, "Largest time step size allowed.");
+
     if (ParabolicSystem::is_identity)
       time_stepping_scheme_ = TimeSteppingScheme::erk_33;
     else
@@ -246,7 +249,8 @@ namespace ryujin
       Number t,
       Number t_final /*=std::numeric_limits<Number>::max()*/)
   {
-    Number tau_max = t_final - t; /* enforces t <= t_final */
+    Number tau_max =
+        std::min(tau_max_, t_final - t); /* enforces t <= t_final */
 
 #ifdef DEBUG_OUTPUT
     std::cout << "TimeIntegrator<dim, Number>::step()" << std::endl;

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -65,7 +65,7 @@ namespace ryujin
                   "a (sub)step and enforced time-step size tau. If the ratio "
                   "is violated then a restart will be singnalled.");
 
-    tau_max_ = Number(1.0);
+    tau_max_ = std::numeric_limits<Number>::max();
     add_parameter("tau_max", tau_max_, "Largest time step size allowed.");
 
     if (ParabolicSystem::is_identity)


### PR DESCRIPTION
@tamiko 

This allows for a user to add the entry `tau_max = ...` under the TimeIntegrator section of their prm file to give another way to control the time step size in their simulations. By default, the entry is `tau_max = 1`.

I also included 2 small changes that I needed in order to compile and pass the debug mode test-suite on my machine (Debian 12 and Clang 14.0.6).