### PR TITLE
MatrixFree: disallow deal.II multithreading

### DIFF
--- a/source/main.cc
+++ b/source/main.cc
@@ -42,14 +42,18 @@ void flush_denormals_to_zero()
 void set_thread_limit(const MPI_Comm &mpi_communicator [[maybe_unused]])
 {
 #ifdef WITH_OPENMP
+  /* Obey OMP_THREAD_LIMIT and DEAL_II_NUM_THREADS: */
   const unsigned int n_threads_omp = omp_get_thread_limit();
   const unsigned int n_threads_dealii = dealii::MultithreadInfo::n_threads();
   const unsigned int n_threads = std::min(n_threads_omp, n_threads_dealii);
   omp_set_num_threads(n_threads);
-  dealii::MultithreadInfo::set_thread_limit(n_threads);
-#else
-  dealii::MultithreadInfo::set_thread_limit(1);
 #endif
+
+  /*
+   * We unconditionally set the thread limit for deal.II internal data
+   * structures to 1. This avoids a number of nasty surprises...
+   */
+  dealii::MultithreadInfo::set_thread_limit(1);
 }
 
 

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -1096,7 +1096,8 @@ namespace ryujin
            << n_global_dofs_ << " Qdofs on "               //
            << mpi_ensemble_.n_world_ranks() << " ranks / " //
 #ifdef WITH_OPENMP
-           << MultithreadInfo::n_threads() << " threads <" //
+
+           << omp_get_max_threads() << " threads <" //
 #else
            << "[openmp disabled] <" //
 #endif
@@ -1313,7 +1314,7 @@ namespace ryujin
                                 efficiency;
 #ifdef WITH_OPENMP
     if (terminal_show_rank_throughput_)
-      cpu_m_dofs_per_sec *= MultithreadInfo::n_threads();
+      cpu_m_dofs_per_sec *= omp_get_max_threads();
 #endif
 
     double cpu_time_skew = (current.cpu_time_max - current.cpu_time_min - //


### PR DESCRIPTION
Set the deal.II internal thread-pool size to 1 effectively disabling multithreading in deal.II internal code.

We are still parsing DEAL_II_NUM_THREADS (as well as OMP_THREAD_LIMIT) to set the size of the OpenMP thread pool that we are using for thread parallel loops.
