### PR TITLE
Workaround: force-disable DEAL_II_WITH_MAGIC_ENUM

### DIFF
--- a/source/compile_time_options.h.in
+++ b/source/compile_time_options.h.in
@@ -38,3 +38,11 @@
  * reference when trying to link the final executable.
  */
 #cmakedefine BUG_COLLECT_PERIODIC_FACES_INSTANTIATION
+
+/*
+ * This is an evil hack: We define our own
+ */
+#include <deal.II/base/config.h>
+#ifdef DEAL_II_WITH_MAGIC_ENUM
+#undef DEAL_II_WITH_MAGIC_ENUM
+#endif

--- a/source/convenience_macros.h
+++ b/source/convenience_macros.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <deal.II/base/function.h>
 
 /**

--- a/source/cubic_spline.h
+++ b/source/cubic_spline.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #ifdef DEAL_II_WITH_GSL
 #include <gsl/gsl_spline.h>
 

--- a/source/diagonal_preconditioner.h
+++ b/source/diagonal_preconditioner.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "state_vector.h"
 
 #include <deal.II/lac/la_parallel_block_vector.h>

--- a/source/euler/description.h
+++ b/source/euler/description.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "../stub_parabolic_system.h"
 #include "../stub_solver.h"
 #include "hyperbolic_system.h"

--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <compile_time_options.h>
+
 #include <convenience_macros.h>
 #include <discretization.h>
 #include <multicomponent_vector.h>

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
-#include <compile_time_options.h>
 #include <multicomponent_vector.h>
 #include <simd.h>
 

--- a/source/euler/initial_state_astro_jet.h
+++ b/source/euler/initial_state_astro_jet.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_becker_solution.h
+++ b/source/euler/initial_state_becker_solution.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_contrast.h
+++ b/source/euler/initial_state_contrast.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_exact_riemann_solution.h
+++ b/source/euler/initial_state_exact_riemann_solution.h
@@ -6,10 +6,13 @@
 
 #pragma once
 
-#include <cmath>
-#include <deal.II/base/tensor.h>
+#include <compile_time_options.h>
 
 #include <initial_state_library.h>
+
+#include <deal.II/base/tensor.h>
+
+#include <cmath>
 
 // #define DEBUG_SOLUTION
 

--- a/source/euler/initial_state_four_state_contrast.h
+++ b/source/euler/initial_state_four_state_contrast.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_function.h
+++ b/source/euler/initial_state_function.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 #include <deal.II/base/function_parser.h>

--- a/source/euler/initial_state_icf_like.h
+++ b/source/euler/initial_state_icf_like.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_isentropic_vortex.h
+++ b/source/euler/initial_state_isentropic_vortex.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 #include <simd.h>
 

--- a/source/euler/initial_state_leblanc.h
+++ b/source/euler/initial_state_leblanc.h
@@ -5,8 +5,11 @@
 
 #pragma once
 
-#include <cmath>
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
+
+#include <cmath>
 
 namespace ryujin
 {

--- a/source/euler/initial_state_library_euler.h
+++ b/source/euler/initial_state_library_euler.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 #include "initial_state_astro_jet.h"

--- a/source/euler/initial_state_noh.h
+++ b/source/euler/initial_state_noh.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_radial_contrast.h
+++ b/source/euler/initial_state_radial_contrast.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_ramp_up.h
+++ b/source/euler/initial_state_ramp_up.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_rarefaction.h
+++ b/source/euler/initial_state_rarefaction.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_shock_front.h
+++ b/source/euler/initial_state_shock_front.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_smooth_wave.h
+++ b/source/euler/initial_state_smooth_wave.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 #include <simd.h>
 

--- a/source/euler/initial_state_three_state_contrast.h
+++ b/source/euler/initial_state_three_state_contrast.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/initial_state_uniform.h
+++ b/source/euler/initial_state_uniform.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <compile_time_options.h>

--- a/source/euler/riemann_solver.h
+++ b/source/euler/riemann_solver.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <simd.h>

--- a/source/euler/riemann_solver.template.h
+++ b/source/euler/riemann_solver.template.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <compile_time_options.h>
-
 #include "riemann_solver.h"
 
 #include <newton.h>

--- a/source/euler_aeos/description.h
+++ b/source/euler_aeos/description.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "../stub_parabolic_system.h"
 #include "../stub_solver.h"
 #include "hyperbolic_system.h"

--- a/source/euler_aeos/equation_of_state_function.h
+++ b/source/euler_aeos/equation_of_state_function.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "equation_of_state.h"
 
 #include <deal.II/base/function_parser.h>

--- a/source/euler_aeos/equation_of_state_jones_wilkins_lee.h
+++ b/source/euler_aeos/equation_of_state_jones_wilkins_lee.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "equation_of_state.h"
 
 namespace ryujin

--- a/source/euler_aeos/equation_of_state_library.h
+++ b/source/euler_aeos/equation_of_state_library.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "equation_of_state.h"
 
 namespace ryujin

--- a/source/euler_aeos/equation_of_state_noble_abel_stiffened_gas.h
+++ b/source/euler_aeos/equation_of_state_noble_abel_stiffened_gas.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "equation_of_state.h"
 
 namespace ryujin

--- a/source/euler_aeos/equation_of_state_polytropic_gas.h
+++ b/source/euler_aeos/equation_of_state_polytropic_gas.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "equation_of_state.h"
 
 namespace ryujin

--- a/source/euler_aeos/equation_of_state_pressureless.h
+++ b/source/euler_aeos/equation_of_state_pressureless.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "equation_of_state.h"
 
 namespace ryujin

--- a/source/euler_aeos/equation_of_state_sesame.h
+++ b/source/euler_aeos/equation_of_state_sesame.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <filesystem>
-
 #include <compile_time_options.h>
 
 #include "equation_of_state.h"
@@ -20,6 +18,8 @@
 #ifdef WITH_EOSPAC
 #include "eos_Interface.h"
 #endif
+
+#include <filesystem>
 
 
 namespace ryujin

--- a/source/euler_aeos/equation_of_state_van_der_waals.h
+++ b/source/euler_aeos/equation_of_state_van_der_waals.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "equation_of_state.h"
 
 namespace ryujin

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "equation_of_state_library.h"
 
-#include <compile_time_options.h>
 #include <convenience_macros.h>
 #include <discretization.h>
 #include <multicomponent_vector.h>

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
-#include <compile_time_options.h>
 #include <multicomponent_vector.h>
 #include <simd.h>
 

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
-#include <compile_time_options.h>
 #include <multicomponent_vector.h>
 #include <newton.h>
 #include <simd.h>

--- a/source/euler_aeos/riemann_solver.h
+++ b/source/euler_aeos/riemann_solver.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <simd.h>

--- a/source/euler_aeos/riemann_solver.template.h
+++ b/source/euler_aeos/riemann_solver.template.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <compile_time_options.h>
-
 #include "riemann_solver.h"
 
 #include <newton.h>

--- a/source/geometries/geometry_airfoil.h
+++ b/source/geometries/geometry_airfoil.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 #include "cubic_spline.h"

--- a/source/geometries/geometry_annulus.h
+++ b/source/geometries/geometry_annulus.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 namespace ryujin

--- a/source/geometries/geometry_common_includes.h
+++ b/source/geometries/geometry_common_includes.h
@@ -7,6 +7,8 @@
 
 #include <compile_time_options.h>
 
+#include <compile_time_options.h>
+
 #include "discretization.h"
 #include "geometry.h"
 

--- a/source/geometries/geometry_cylinder.h
+++ b/source/geometries/geometry_cylinder.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 namespace ryujin

--- a/source/geometries/geometry_disk.h
+++ b/source/geometries/geometry_disk.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 namespace ryujin

--- a/source/geometries/geometry_geotiff_profile.h
+++ b/source/geometries/geometry_geotiff_profile.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 #include "geotiff_reader.h"
 

--- a/source/geometries/geometry_library.h
+++ b/source/geometries/geometry_library.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_airfoil.h"
 #include "geometry_annulus.h"
 #include "geometry_cylinder.h"

--- a/source/geometries/geometry_reader.h
+++ b/source/geometries/geometry_reader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 #include <deal.II/grid/grid_in.h>

--- a/source/geometries/geometry_rectangular_domain.h
+++ b/source/geometries/geometry_rectangular_domain.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 namespace ryujin

--- a/source/geometries/geometry_step.h
+++ b/source/geometries/geometry_step.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 namespace ryujin

--- a/source/geometries/geometry_tank.h
+++ b/source/geometries/geometry_tank.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 namespace ryujin

--- a/source/geometries/geometry_wall.h
+++ b/source/geometries/geometry_wall.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "geometry_common_includes.h"
 
 namespace ryujin

--- a/source/geotiff_reader.h
+++ b/source/geotiff_reader.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "convenience_macros.h"
 #include "lazy.h"
 #include "patterns_conversion.h"

--- a/source/instrumentation.h
+++ b/source/instrumentation.h
@@ -5,8 +5,7 @@
 
 #pragma once
 
-#include "openmp.h"
-
+#include <compile_time_options.h>
 
 #ifdef WITH_VALGRIND
 

--- a/source/lazy.h
+++ b/source/lazy.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <deal.II/base/config.h>
+#include <compile_time_options.h>
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_consumption.h>

--- a/source/local_index_handling.h
+++ b/source/local_index_handling.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <deal.II/base/partitioner.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>

--- a/source/mesh_adaptor.h
+++ b/source/mesh_adaptor.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "mpi_ensemble.h"
 #include "offline_data.h"
 

--- a/source/multicomponent_vector.h
+++ b/source/multicomponent_vector.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "simd.h"
 
 #include <deal.II/base/mpi.h>

--- a/source/navier_stokes/description.h
+++ b/source/navier_stokes/description.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "../euler/hyperbolic_system.h"
 #include "../euler/indicator.h"
 #include "../euler/limiter.h"

--- a/source/navier_stokes/parabolic_solver.h
+++ b/source/navier_stokes/parabolic_solver.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
-#include "hyperbolic_module.h"
-
 #include <compile_time_options.h>
+
+#include "hyperbolic_module.h"
 
 #include <convenience_macros.h>
 #include <initial_values.h>

--- a/source/navier_stokes/parabolic_solver_gmg_operators.h
+++ b/source/navier_stokes/parabolic_solver_gmg_operators.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <offline_data.h>
 #include <openmp.h>
 #include <simd.h>

--- a/source/navier_stokes/parabolic_system.h
+++ b/source/navier_stokes/parabolic_system.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <compile_time_options.h>
+
 #include <convenience_macros.h>
 
 #include <deal.II/base/parameter_acceptor.h>

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -20,7 +20,6 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/la_parallel_vector.h>
 #include <deal.II/lac/sparse_matrix.h>
-
 #include <deal.II/numerics/data_out.h>
 
 namespace ryujin

--- a/source/parabolic_module.h
+++ b/source/parabolic_module.h
@@ -5,11 +5,10 @@
 
 #pragma once
 
-#include "hyperbolic_module.h"
-
 #include <compile_time_options.h>
 
 #include "convenience_macros.h"
+#include "hyperbolic_module.h"
 #include "initial_values.h"
 #include "mpi_ensemble.h"
 #include "offline_data.h"

--- a/source/patterns_conversion.h
+++ b/source/patterns_conversion.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
-#include <deal.II/base/parameter_acceptor.h>
+#include <compile_time_options.h>
 
-#include <numeric>
+#include <deal.II/base/parameter_acceptor.h>
 
 #ifndef DOXYGEN
 

--- a/source/postprocessor.h
+++ b/source/postprocessor.h
@@ -5,7 +5,8 @@
 
 #pragma once
 
-#include "compile_time_options.h"
+#include <compile_time_options.h>
+
 #include "mpi_ensemble.h"
 #include "offline_data.h"
 

--- a/source/postprocessor.template.h
+++ b/source/postprocessor.template.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
+#include "openmp.h"
 #include "postprocessor.h"
-
-#include <simd.h>
+#include "simd.h"
 
 #include <deal.II/base/function_parser.h>
 #include <deal.II/numerics/data_out.h>

--- a/source/scalar_conservation/description.h
+++ b/source/scalar_conservation/description.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "../stub_parabolic_system.h"
 #include "../stub_solver.h"
 #include "hyperbolic_system.h"

--- a/source/scalar_conservation/flux_burgers.h
+++ b/source/scalar_conservation/flux_burgers.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "flux.h"
 
 namespace ryujin

--- a/source/scalar_conservation/flux_function.h
+++ b/source/scalar_conservation/flux_function.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "flux.h"
 
 #include <deal.II/base/function_parser.h>

--- a/source/scalar_conservation/flux_kpp.h
+++ b/source/scalar_conservation/flux_kpp.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "flux.h"
 
 namespace ryujin

--- a/source/scalar_conservation/flux_library.h
+++ b/source/scalar_conservation/flux_library.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "flux.h"
 
 namespace ryujin

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "flux_library.h"
 
 #include <convenience_macros.h>

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>

--- a/source/scalar_conservation/initial_state_function.h
+++ b/source/scalar_conservation/initial_state_function.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 #include <initial_state_library.h>
 

--- a/source/scalar_conservation/initial_state_uniform.h
+++ b/source/scalar_conservation/initial_state_uniform.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 #include <initial_state_library.h>
 

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -5,9 +5,10 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
-#include <compile_time_options.h>
 #include <multicomponent_vector.h>
 #include <simd.h>
 

--- a/source/scalar_conservation/riemann_solver.h
+++ b/source/scalar_conservation/riemann_solver.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <simd.h>

--- a/source/scope.h
+++ b/source/scope.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <deal.II/base/timer.h>
 
 #include <map>

--- a/source/scratch_data.h
+++ b/source/scratch_data.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "discretization.h"
 
 #include <deal.II/base/quadrature_lib.h>

--- a/source/selected_components_extractor.h
+++ b/source/selected_components_extractor.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "state_vector.h"
 
 namespace ryujin

--- a/source/shallow_water/description.h
+++ b/source/shallow_water/description.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "../stub_parabolic_system.h"
 #include "../stub_solver.h"
 #include "hyperbolic_system.h"

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <convenience_macros.h>
 #include <deal.II/base/config.h>
 #include <discretization.h>

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>

--- a/source/shallow_water/initial_state_circular_dam_break.h
+++ b/source/shallow_water/initial_state_circular_dam_break.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 #include <initial_state_library.h>
 

--- a/source/shallow_water/initial_state_contrast.h
+++ b/source/shallow_water/initial_state_contrast.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/shallow_water/initial_state_flow_over_bump.h
+++ b/source/shallow_water/initial_state_flow_over_bump.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 #include <simd.h>

--- a/source/shallow_water/initial_state_function.h
+++ b/source/shallow_water/initial_state_function.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 #include <deal.II/base/function_parser.h>

--- a/source/shallow_water/initial_state_geotiff.h
+++ b/source/shallow_water/initial_state_geotiff.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <geotiff_reader.h>
 #include <initial_state_library.h>
 #include <lazy.h>

--- a/source/shallow_water/initial_state_hou_test.h
+++ b/source/shallow_water/initial_state_hou_test.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 #include <deal.II/base/function_parser.h>

--- a/source/shallow_water/initial_state_library_shallow_water.h
+++ b/source/shallow_water/initial_state_library_shallow_water.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 #include "initial_state_contrast.h"

--- a/source/shallow_water/initial_state_paraboloid.h
+++ b/source/shallow_water/initial_state_paraboloid.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/shallow_water/initial_state_ritter_dam_break.h
+++ b/source/shallow_water/initial_state_ritter_dam_break.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/shallow_water/initial_state_sloping_friction.h
+++ b/source/shallow_water/initial_state_sloping_friction.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 #include <simd.h>

--- a/source/shallow_water/initial_state_smooth_vortex.h
+++ b/source/shallow_water/initial_state_smooth_vortex.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/shallow_water/initial_state_soliton.h
+++ b/source/shallow_water/initial_state_soliton.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/shallow_water/initial_state_three_bumps_dam_break.h
+++ b/source/shallow_water/initial_state_three_bumps_dam_break.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include "hyperbolic_system.h"
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/shallow_water/initial_state_transient.h
+++ b/source/shallow_water/initial_state_transient.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/shallow_water/initial_state_uniform.h
+++ b/source/shallow_water/initial_state_uniform.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_state_library.h>
 
 namespace ryujin

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -7,9 +7,10 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
-#include <compile_time_options.h>
 #include <multicomponent_vector.h>
 #include <newton.h>
 

--- a/source/shallow_water/riemann_solver.h
+++ b/source/shallow_water/riemann_solver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <simd.h>

--- a/source/skeleton/description.h
+++ b/source/skeleton/description.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "../stub_parabolic_system.h"
 #include "../stub_solver.h"
 #include "hyperbolic_system.h"

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <convenience_macros.h>
 #include <discretization.h>
 #include <multicomponent_vector.h>
@@ -16,7 +18,6 @@
 #include <deal.II/base/tensor.h>
 
 #include <array>
-#include <functional>
 
 namespace ryujin
 {

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>

--- a/source/skeleton/initial_state_uniform.h
+++ b/source/skeleton/initial_state_uniform.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 #include <initial_state_library.h>
 

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <compile_time_options.h>

--- a/source/skeleton/riemann_solver.h
+++ b/source/skeleton/riemann_solver.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "hyperbolic_system.h"
 
 #include <simd.h>

--- a/source/solution_transfer.template.h
+++ b/source/solution_transfer.template.h
@@ -5,15 +5,14 @@
 
 #pragma once
 
-#include <compile_time_options.h>
-#include <deal.II/base/exceptions.h>
 
+#include "openmp.h"
 #include "solution_transfer.h"
 #if DEAL_II_VERSION_GTE(9, 6, 0)
 #include "tensor_product_point_kernels.h"
 #endif
 
-#include <deal.II/base/config.h>
+#include <deal.II/base/exceptions.h>
 #include <deal.II/distributed/tria.h>
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_tools.h>

--- a/source/sparse_matrix_simd.h
+++ b/source/sparse_matrix_simd.h
@@ -5,12 +5,11 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/partitioner.h>
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
-
-#include "openmp.h"
-#include "simd.h"
 
 namespace ryujin
 {

--- a/source/sparse_matrix_simd.template.h
+++ b/source/sparse_matrix_simd.template.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "openmp.h"
+#include "simd.h"
 #include "sparse_matrix_simd.h"
 
 #include <deal.II/base/vectorization.h>

--- a/source/state_vector.h
+++ b/source/state_vector.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include "multicomponent_vector.h"
 
 #include <deal.II/lac/la_parallel_block_vector.h>

--- a/source/stub_parabolic_system.h
+++ b/source/stub_parabolic_system.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <compile_time_options.h>
+
 #include <convenience_macros.h>
 
 #include <deal.II/base/parameter_acceptor.h>

--- a/source/stub_solver.h
+++ b/source/stub_solver.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <initial_values.h>
 #include <mpi_ensemble.h>
 #include <offline_data.h>

--- a/source/tensor_product_point_kernels.h
+++ b/source/tensor_product_point_kernels.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/ndarray.h>

--- a/source/transfinite_interpolation.h
+++ b/source/transfinite_interpolation.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <deal.II/base/config.h>
 #include <deal.II/grid/manifold.h>
 #include <deal.II/grid/tria.h>

--- a/source/version_info.h
+++ b/source/version_info.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <compile_time_options.h>
+
 #include <ostream>
 
 namespace ryujin


### PR DESCRIPTION
Unfortuantely, the enum reflection mechanism that is enabled with DEAL_II_WITH_MAGIC_ENUM uses a different name mangling that we do (underscore "_" versus space " "). So we cannot switch to the deal.II built-in. For now, let us simply disable the overloads in question until we found a solution how to avoid the "ambigous partial specialization" error that we trigger.
