### PR TITLE
Geometry: add interface for hp discretizations

### DIFF
--- a/source/convenience_macros.h
+++ b/source/convenience_macros.h
@@ -216,6 +216,24 @@ namespace
 
 
 /**
+ * Variant of the macro above that takes two arguments, container and
+ * member, and creates an accessor function.
+ * ```
+ * const Foo& member() const { return container_.member; }
+ * ```
+ * The function will dereference container and member if they are of
+ * pointer type.
+ *
+ * @ingroup Miscellaneous
+ */
+#define ACCESSOR_CONTAINER_READ_ONLY(container, member)                        \
+  inline const auto &member() const                                            \
+  {                                                                            \
+    return dereference(dereference(container).member);                         \
+  }
+
+
+/**
  * Injects a label into the generated assembly.
  *
  * @ingroup Miscellaneous

--- a/source/discretization.h
+++ b/source/discretization.h
@@ -233,6 +233,25 @@ namespace ryujin
     void prepare(const std::string &base_name);
 
     /**
+     * A collection of mappings, finite elements, and quadratures that are
+     * set up by the Discretization class. We create a dedicated struct
+     * with all unique_ptr to keep the interface to
+     * Geometry::populate_hp_collections() sane.
+     */
+    struct Collection {
+      std::unique_ptr<const dealii::hp::MappingCollection<dim>> mapping;
+      std::unique_ptr<const dealii::hp::FECollection<dim>> finite_element;
+      std::unique_ptr<const dealii::hp::FECollection<dim>> finite_element_cg;
+      std::unique_ptr<const dealii::hp::QCollection<dim>> quadrature;
+      std::unique_ptr<const dealii::hp::QCollection<dim>> quadrature_high_order;
+      std::unique_ptr<const dealii::hp::QCollection<dim>> nodal_quadrature;
+      std::unique_ptr<const dealii::hp::QCollection<1>> quadrature_1d;
+      std::unique_ptr<const dealii::hp::QCollection<dim - 1>> face_quadrature;
+      std::unique_ptr<const dealii::hp::QCollection<dim - 1>>
+          face_nodal_quadrature;
+    };
+
+    /**
      * @name Accessors to data structures managed by this class.
      */
     //@{
@@ -313,20 +332,19 @@ namespace ryujin
      * Return a read-only const reference to the triangulation.
      */
     ACCESSOR_READ_ONLY(triangulation)
-
     /**
      * Return a read-only const reference to the mapping.
      *
      * @note The accessor returns an MappingCollection object.
      */
-    ACCESSOR_READ_ONLY(mapping)
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, mapping)
 
     /**
      * Return a read-only const reference to the finite element.
      *
      * @note The accessor returns an FECollection object.
      */
-    ACCESSOR_READ_ONLY(finite_element)
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, finite_element)
 
     /**
      * Return a read-only const reference to a continuous ("cG") variant of
@@ -334,14 +352,14 @@ namespace ryujin
      *
      * @note The accessor returns an FECollection object.
      */
-    ACCESSOR_READ_ONLY(finite_element_cg)
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, finite_element_cg)
 
     /**
      * Return a read-only const reference to the quadrature rule.
      *
      * @note The accessor returns an QCollection object.
      */
-    ACCESSOR_READ_ONLY(quadrature)
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, quadrature)
 
     /**
      * Return a read-only const reference to a highe order quadrature rule
@@ -349,7 +367,7 @@ namespace ryujin
      *
      * @note The accessor returns an QCollection object.
      */
-    ACCESSOR_READ_ONLY(quadrature_high_order)
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, quadrature_high_order)
 
     /**
      * Return a read-only const reference to the nodal quadrature rule
@@ -357,21 +375,21 @@ namespace ryujin
      *
      * @note The accessor returns an QCollection object.
      */
-    ACCESSOR_READ_ONLY(nodal_quadrature)
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, nodal_quadrature)
 
     /**
      * Return a read-only const reference to the 1D quadrature rule.
      *
      * @note The accessor returns an QCollection object.
      */
-    ACCESSOR_READ_ONLY(quadrature_1d)
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, quadrature_1d)
 
     /**
      * Return a read-only const reference to the face quadrature rule.
      *
      * @note The accessor returns an QCollection object.
      */
-    ACCESSOR_READ_ONLY(face_quadrature)
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, face_quadrature)
 
     /**
      * Return a read-only const reference to the nodal face quadrature rule
@@ -379,22 +397,7 @@ namespace ryujin
      *
      * @note The accessor returns an QCollection object.
      */
-    ACCESSOR_READ_ONLY(face_nodal_quadrature)
-
-  protected:
-    const MPIEnsemble &mpi_ensemble_;
-
-    std::unique_ptr<dealii::Triangulation<dim>> triangulation_;
-    std::unique_ptr<const dealii::hp::MappingCollection<dim>> mapping_;
-    std::unique_ptr<const dealii::hp::FECollection<dim>> finite_element_;
-    std::unique_ptr<const dealii::hp::FECollection<dim>> finite_element_cg_;
-    std::unique_ptr<const dealii::hp::QCollection<dim>> quadrature_;
-    std::unique_ptr<const dealii::hp::QCollection<dim>> quadrature_high_order_;
-    std::unique_ptr<const dealii::hp::QCollection<dim>> nodal_quadrature_;
-    std::unique_ptr<const dealii::hp::QCollection<1>> quadrature_1d_;
-    std::unique_ptr<const dealii::hp::QCollection<dim - 1>> face_quadrature_;
-    std::unique_ptr<const dealii::hp::QCollection<dim - 1>>
-        face_nodal_quadrature_;
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, face_nodal_quadrature)
 
   private:
     //@}
@@ -418,6 +421,12 @@ namespace ryujin
      * @name Internal data:
      */
     //@{
+    //
+    const MPIEnsemble &mpi_ensemble_;
+
+    std::unique_ptr<dealii::Triangulation<dim>> triangulation_;
+
+    Collection collection_;
 
     std::set<std::shared_ptr<Geometry<dim>>> geometry_list_;
     std::shared_ptr<Geometry<dim>> selected_geometry_;

--- a/source/discretization.h
+++ b/source/discretization.h
@@ -238,11 +238,15 @@ namespace ryujin
     //@{
 
     /**
+     * Return a read-only const reference to the selected geometry.
+     */
+    ACCESSOR_READ_ONLY(selected_geometry)
+
+    /**
      * Return a read-only const reference to the finite element ansatz.
      */
     ACCESSOR_READ_ONLY(ansatz)
 
-  public:
     /**
      * Return a boolean indicating whether the chosen Ansatz space is
      * discontinuous.
@@ -415,7 +419,8 @@ namespace ryujin
      */
     //@{
 
-    std::set<std::unique_ptr<Geometry<dim>>> geometry_list_;
+    std::set<std::shared_ptr<Geometry<dim>>> geometry_list_;
+    std::shared_ptr<Geometry<dim>> selected_geometry_;
 
     //@}
 

--- a/source/discretization.h
+++ b/source/discretization.h
@@ -419,6 +419,7 @@ namespace ryujin
     //@{
 
     Ansatz ansatz_;
+    MeshType mesh_type_;
 
     std::string geometry_;
 

--- a/source/discretization.h
+++ b/source/discretization.h
@@ -295,25 +295,6 @@ namespace ryujin
       __builtin_trap();
     }
 
-
-    /**
-     * Return a boolean indicating whether the chosen mesh geometry is
-     * stored in a parallel distributed, or parallel fullydistributed
-     * triangulation.
-     */
-    bool have_distributed_triangulation() const
-    {
-      using namespace dealii::parallel;
-      const auto *p_t = triangulation_.get();
-
-      if (dynamic_cast<const distributed::Triangulation<dim> *>(p_t))
-        return true;
-      else if (dynamic_cast<const fullydistributed::Triangulation<dim> *>(p_t))
-        return true;
-      else
-        return false;
-    }
-
     /**
      * Return a mutable reference to the refinement variable.
      */

--- a/source/discretization.h
+++ b/source/discretization.h
@@ -442,5 +442,15 @@ namespace ryujin
      */
     template <typename Discretization, int dim_, typename Number_>
     friend class SolutionTransfer;
+
+    /**
+     * For complex geometries with mixed finite elements (or when using
+     * FE_Nothing) we need to defer the setup of the hp::*Collection
+     * objects to the selected geometry. Thus, declare the Geometry class
+     * to be a friend so that it can set all the collection objects
+     * directly.
+     */
+    template <int dim_>
+    friend class Geometry;
   };
 } /* namespace ryujin */

--- a/source/discretization.template.h
+++ b/source/discretization.template.h
@@ -176,34 +176,35 @@ namespace ryujin
     const auto quadrature_degree = fe_degree + 1;
 
     if (have_discontinuous_ansatz()) {
-      finite_element_ =
+      collection_.finite_element =
           std::make_unique<hp::FECollection<dim>>(FE_DGQ<dim>(fe_degree));
-      finite_element_cg_ =
+      collection_.finite_element_cg =
           std::make_unique<hp::FECollection<dim>>(FE_Q<dim>(fe_degree));
     } else {
-      finite_element_ =
+      collection_.finite_element =
           std::make_unique<hp::FECollection<dim>>(FE_Q<dim>(fe_degree));
-      finite_element_cg_ =
+      collection_.finite_element_cg =
           std::make_unique<hp::FECollection<dim>>(FE_Q<dim>(fe_degree));
     }
 
-    mapping_ = std::make_unique<dealii::hp::MappingCollection<dim>>(
+    collection_.mapping = std::make_unique<dealii::hp::MappingCollection<dim>>(
         MappingQ<dim>(mapping_degree));
 
-    quadrature_ =
+    collection_.quadrature =
         std::make_unique<hp::QCollection<dim>>(QGauss<dim>(quadrature_degree));
-    quadrature_high_order_ = std::make_unique<hp::QCollection<dim>>(
+    collection_.quadrature_high_order = std::make_unique<hp::QCollection<dim>>(
         QGauss<dim>(quadrature_degree + 1));
-    nodal_quadrature_ = std::make_unique<hp::QCollection<dim>>(
+    collection_.nodal_quadrature = std::make_unique<hp::QCollection<dim>>(
         QGaussLobatto<dim>(quadrature_degree));
 
-    quadrature_1d_ =
+    collection_.quadrature_1d =
         std::make_unique<hp::QCollection<1>>(QGauss<1>(quadrature_degree));
 
-    face_quadrature_ = std::make_unique<hp::QCollection<dim - 1>>(
+    collection_.face_quadrature = std::make_unique<hp::QCollection<dim - 1>>(
         QGauss<dim - 1>(quadrature_degree));
-    face_nodal_quadrature_ = std::make_unique<hp::QCollection<dim - 1>>(
-        QGaussLobatto<dim - 1>(quadrature_degree));
+    collection_.face_nodal_quadrature =
+        std::make_unique<hp::QCollection<dim - 1>>(
+            QGaussLobatto<dim - 1>(quadrature_degree));
   }
 
 } /* namespace ryujin */

--- a/source/discretization.template.h
+++ b/source/discretization.template.h
@@ -34,8 +34,16 @@ namespace ryujin
     ansatz_ = Ansatz::cg_q1;
     add_parameter("finite element ansatz",
                   ansatz_,
-                  "The finite element ansatz used for discretization. valid "
+                  "The finite element ansatz used for discretization. Valid "
                   "choices are cG Q1, cG Q2, cG Q3.");
+
+    mesh_type_ =
+        (dim == 1 ? MeshType::parallel_shared : MeshType::parallel_distributed);
+    add_parameter("mesh type",
+                  mesh_type_,
+                  "The triangulation class used. Valid choices are \"serial\", "
+                  "\"parallel shared\", \"parallel distributed\", \"parallel "
+                  "fullydistributed\".");
 
     geometry_ = "cylinder";
     add_parameter("geometry",
@@ -71,11 +79,7 @@ namespace ryujin
     const auto smoothing =
         dealii::Triangulation<dim>::limit_level_difference_at_vertices;
 
-    // FIXME: This information will ultimately be provided by the Geometry.
-    const auto selection =
-        (dim == 1 ? MeshType::parallel_shared : MeshType::parallel_distributed);
-
-    switch (selection) {
+    switch (mesh_type_) {
     case MeshType::parallel_fullydistributed: {
       triangulation_ = std::make_unique<
           dealii::parallel::fullydistributed::Triangulation<dim>>(
@@ -104,6 +108,19 @@ namespace ryujin
               smoothing,
               /*artificial cells*/ true,
               settings);
+    } break;
+
+    case MeshType::serial: {
+      AssertThrow(
+          mpi_ensemble_.n_ensemble_ranks() == 1,
+          ExcMessage(
+              "The serial triangulation can only be used for serial "
+              "computations. If you want to run simulations with more than one "
+              "rank per ensemble, then please set \"mesh type\" to one of the "
+              "parallel triangulations supported by deal.II"));
+
+      triangulation_ = std::make_unique<dealii::Triangulation<dim>>(smoothing);
+
     } break;
 
     default:

--- a/source/discretization.template.h
+++ b/source/discretization.template.h
@@ -76,6 +76,25 @@ namespace ryujin
     std::cout << "Discretization<dim>::prepare()" << std::endl;
 #endif
 
+    /* Select geometry: */
+
+    {
+      bool initialized = false;
+      for (auto &it : geometry_list_)
+        if (it->name() == geometry_) {
+          selected_geometry_ = it;
+          initialized = true;
+          break;
+        }
+
+      AssertThrow(
+          initialized,
+          ExcMessage("Could not find a geometry description with name \"" +
+                     geometry_ + "\""));
+    }
+
+    /* Set up Triangulation object: */
+
     const auto smoothing =
         dealii::Triangulation<dim>::limit_level_difference_at_vertices;
 
@@ -127,22 +146,10 @@ namespace ryujin
       __builtin_trap();
     }
 
+    /* Create and distribute mesh: */
+
     auto &triangulation = *triangulation_;
-
-    {
-      bool initialized = false;
-      for (auto &it : geometry_list_)
-        if (it->name() == geometry_) {
-          it->create_triangulation(triangulation);
-          initialized = true;
-          break;
-        }
-
-      AssertThrow(
-          initialized,
-          ExcMessage("Could not find a geometry description with name \"" +
-                     geometry_ + "\""));
-    }
+    selected_geometry_->create_triangulation(triangulation);
 
     if (mesh_writeout_ && dealii::Utilities::MPI::this_mpi_process(
                               mpi_ensemble_.ensemble_communicator()) == 0) {

--- a/source/discretization.template.h
+++ b/source/discretization.template.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <boost/random/detail/polynomial.hpp>
 #include <compile_time_options.h>
 
 #include "discretization.h"
@@ -170,6 +171,21 @@ namespace ryujin
     if (std::abs(mesh_distortion_) > 1.0e-10)
       GridTools::distort_random(
           mesh_distortion_, triangulation, false, std::random_device()());
+
+    /*
+     * First, let the selected geometry populate our hp::*Collection
+     * objects. If the method returns false, however, we need to do the
+     * setup ourselves.
+     */
+
+    if (selected_geometry_->populate_hp_collections(
+            polynomial_degree(), have_discontinuous_ansatz(), collection_))
+      return;
+
+    /*
+     * Populate all collections with appropriate objects for the cG Qk, dG
+     * Qk finite element on purely quadrilateral, or hexahedral meshes:
+     */
 
     const auto fe_degree = polynomial_degree();
     const auto mapping_degree = fe_degree;

--- a/source/geometries/geometry.h
+++ b/source/geometries/geometry.h
@@ -10,6 +10,7 @@
 #include "convenience_macros.h"
 
 #include <deal.II/base/parameter_acceptor.h>
+#include <deal.II/dofs/dof_handler.h>
 #include <deal.II/grid/tria.h>
 
 #include <string>
@@ -48,7 +49,7 @@ namespace ryujin
      * description.
      */
     virtual void
-    create_triangulation(dealii::Triangulation<dim> &triangulation) = 0;
+    create_triangulation(dealii::Triangulation<dim> &triangulation) const = 0;
 
     /**
      * Return the name of the geometry as (const reference) std::string

--- a/source/geometries/geometry.h
+++ b/source/geometries/geometry.h
@@ -64,6 +64,26 @@ namespace ryujin
     }
 
     /**
+     * Populate all hp::*Collection objects for finite elements, mappings,
+     * and quadratures. As this is a formidable zoo of different collection
+     * objects, we get a writable reference to the discretization object to
+     * set them directly.
+     */
+    virtual bool populate_hp_collections(
+        const unsigned int /*fe_degree*/,
+        const bool /*have_discontinuous_ansatz*/,
+        typename ryujin::Discretization<dim>::Collection & /*collection*/) const
+    {
+      /*
+       * Signal, that we did nothing. In this case the Discretization
+       * object will populate all collections with appropriate objects for
+       * the cG Qk, dG Qk finite element on purely quadrilateral, or
+       * hexahedral meshes.
+       */
+      return false;
+    }
+
+    /**
      * Return the name of the geometry as (const reference) std::string
      */
     ACCESSOR_READ_ONLY(name)

--- a/source/geometries/geometry.h
+++ b/source/geometries/geometry.h
@@ -45,11 +45,23 @@ namespace ryujin
     }
 
     /**
-     * Create the triangulation according to the appropriate geometry
-     * description.
+     * Create a triangulation representing the current Geometry. This
+     * virtual method needs to be implemented in derived classes.
      */
     virtual void
     create_triangulation(dealii::Triangulation<dim> &triangulation) const = 0;
+
+    /**
+     * Set the correct active FE index for each active cell for the given
+     * DoFHandler. This method can be left empty for a standard geometry
+     * that only uses only one reference element. The method must be
+     * reimplemented for geometries that use hp capabilities, such as
+     * meshes with mixed finite elements, or meshes with FE_Nothing.
+     */
+    virtual void
+    set_active_fe_index(dealii::DoFHandler<dim> & /*dof_handler*/) const
+    {
+    }
 
     /**
      * Return the name of the geometry as (const reference) std::string

--- a/source/geometries/geometry_airfoil.h
+++ b/source/geometries/geometry_airfoil.h
@@ -905,7 +905,8 @@ namespace ryujin
                             "number of subdivisions in z direction");
       }
 
-      void create_triangulation(dealii::Triangulation<dim> &triangulation) final
+      void create_triangulation(
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         /*
          * Step 1: Create parametrization:

--- a/source/geometries/geometry_annulus.h
+++ b/source/geometries/geometry_annulus.h
@@ -265,7 +265,7 @@ namespace ryujin
       }
 
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) final
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         GridGenerator::annulus(
             triangulation, length_, inner_radius_, outer_radius_, angle_);

--- a/source/geometries/geometry_cylinder.h
+++ b/source/geometries/geometry_cylinder.h
@@ -251,7 +251,7 @@ namespace ryujin
       }
 
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) final
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         GridGenerator::cylinder(triangulation,
                                 length_,

--- a/source/geometries/geometry_disk.h
+++ b/source/geometries/geometry_disk.h
@@ -45,7 +45,7 @@ namespace ryujin
       }
 
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) final
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         if (balanced_) {
           GridGenerator::hyper_ball_balanced(

--- a/source/geometries/geometry_geotiff_profile.h
+++ b/source/geometries/geometry_geotiff_profile.h
@@ -163,7 +163,7 @@ namespace ryujin
 
 
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) final
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         /* create mesh: */
 

--- a/source/geometries/geometry_library.h
+++ b/source/geometries/geometry_library.h
@@ -41,16 +41,16 @@ namespace ryujin
         geometry_list.emplace(std::move(object));
       };
 
-      add(std::make_unique<Airfoil<dim>>(subsection));
-      add(std::make_unique<Annulus<dim>>(subsection));
-      add(std::make_unique<Cylinder<dim>>(subsection));
-      add(std::make_unique<Disk<dim>>(subsection));
-      add(std::make_unique<GeoTIFFProfile<dim>>(subsection));
-      add(std::make_unique<Reader<dim>>(subsection));
-      add(std::make_unique<RectangularDomain<dim>>(subsection));
-      add(std::make_unique<Step<dim>>(subsection));
-      add(std::make_unique<Wall<dim>>(subsection));
-      add(std::make_unique<WaveTank<dim>>(subsection));
+      add(std::make_shared<Airfoil<dim>>(subsection));
+      add(std::make_shared<Annulus<dim>>(subsection));
+      add(std::make_shared<Cylinder<dim>>(subsection));
+      add(std::make_shared<Disk<dim>>(subsection));
+      add(std::make_shared<GeoTIFFProfile<dim>>(subsection));
+      add(std::make_shared<Reader<dim>>(subsection));
+      add(std::make_shared<RectangularDomain<dim>>(subsection));
+      add(std::make_shared<Step<dim>>(subsection));
+      add(std::make_shared<Wall<dim>>(subsection));
+      add(std::make_shared<WaveTank<dim>>(subsection));
     }
   } /* namespace Geometries */
 } /* namespace ryujin */

--- a/source/geometries/geometry_reader.h
+++ b/source/geometries/geometry_reader.h
@@ -40,7 +40,7 @@ namespace ryujin
       }
 
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) final
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         dealii::GridIn<dim> gridin;
         gridin.attach_triangulation(triangulation);

--- a/source/geometries/geometry_rectangular_domain.h
+++ b/source/geometries/geometry_rectangular_domain.h
@@ -117,7 +117,8 @@ namespace ryujin
       }
 
 
-      void create_triangulation(dealii::Triangulation<dim> &triangulation) final
+      void create_triangulation(
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         /* create mesh: */
 

--- a/source/geometries/geometry_step.h
+++ b/source/geometries/geometry_step.h
@@ -163,7 +163,7 @@ namespace ryujin
       }
 
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) final
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         GridGenerator::step(
             triangulation, length_, height_, step_position_, step_height_);

--- a/source/geometries/geometry_tank.h
+++ b/source/geometries/geometry_tank.h
@@ -157,7 +157,7 @@ namespace ryujin
       }
 
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) final
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         GridGenerator::wavetank(triangulation,
                                 reservoir_length_,

--- a/source/geometries/geometry_wall.h
+++ b/source/geometries/geometry_wall.h
@@ -124,7 +124,7 @@ namespace ryujin
       }
 
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) final
+          typename dealii::Triangulation<dim> &triangulation) const final
       {
         GridGenerator::wall(triangulation, length_, height_, wall_position_);
       }

--- a/source/initial_values.template.h
+++ b/source/initial_values.template.h
@@ -246,7 +246,8 @@ namespace ryujin
     temp.reinit(scalar_partitioner);
 
     for (unsigned int d = 0; d < problem_dimension; ++d) {
-      VectorTools::interpolate(offline_data_->dof_handler(),
+      VectorTools::interpolate(offline_data_->discretization().mapping(),
+                               offline_data_->dof_handler(),
                                to_function<dim, Number>(callable, d),
                                temp);
       U.insert_component(temp, d);

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -212,6 +212,16 @@ namespace ryujin
       dof_handler_ = std::make_unique<dealii::DoFHandler<dim>>(triangulation);
     auto &dof_handler = *dof_handler_;
 
+    /*
+     * Set active FE indices:
+     *
+     * This information depends on the selected geometry. Therefore, let
+     * the selected geometry object handle the setup. For a standard
+     * geometry that has only one reference element the method simply does
+     * nothing.
+     */
+    discretization_->selected_geometry().set_active_fe_index(dof_handler);
+
     dof_handler.distribute_dofs(discretization_->finite_element());
 
     n_locally_owned_ = dof_handler.locally_owned_dofs().n_elements();


### PR DESCRIPTION
This pull requests add two new virtual functions to the `Geometry` class:
 - `Geometry::populate_hp_collection()`: populates the mapping, finite element, and quadrature collections for the given Geometry. The default implementation defers this task to the `Discretization` that will set up a simple, regular cG or dG discretization.
 - `Geometry::set_active_fe_index()`: is afterwards in charge of selecting the appropriate fe_index for a given active DoFHandler cell.
 - A new runtime parameter now allows to select the underlying low-level deal.II Triangulation.
