### PR TITLE
Geometries: small cleanup

### DIFF
--- a/source/geometries/geometry_airfoil.h
+++ b/source/geometries/geometry_airfoil.h
@@ -825,7 +825,7 @@ namespace ryujin
     class Airfoil : public Geometry<dim>
     {
     public:
-      Airfoil(const std::string subsection)
+      Airfoil(const std::string &subsection)
           : Geometry<dim>("airfoil", subsection)
       {
         /* Parameters affecting parameterization: */

--- a/source/geometries/geometry_annulus.h
+++ b/source/geometries/geometry_annulus.h
@@ -243,7 +243,7 @@ namespace ryujin
     class Annulus : public Geometry<dim>
     {
     public:
-      Annulus(const std::string subsection)
+      Annulus(const std::string &subsection)
           : Geometry<dim>("annulus", subsection)
       {
         length_ = 2.;

--- a/source/geometries/geometry_cylinder.h
+++ b/source/geometries/geometry_cylinder.h
@@ -228,7 +228,7 @@ namespace ryujin
     class Cylinder : public Geometry<dim>
     {
     public:
-      Cylinder(const std::string subsection)
+      Cylinder(const std::string &subsection)
           : Geometry<dim>("cylinder", subsection)
       {
         length_ = 4.;

--- a/source/geometries/geometry_disk.h
+++ b/source/geometries/geometry_disk.h
@@ -25,7 +25,7 @@ namespace ryujin
     class Disk : public Geometry<dim>
     {
     public:
-      Disk(const std::string subsection)
+      Disk(const std::string &subsection)
           : Geometry<dim>("disk", subsection)
       {
         balanced_ = true;

--- a/source/geometries/geometry_geotiff_profile.h
+++ b/source/geometries/geometry_geotiff_profile.h
@@ -81,7 +81,7 @@ namespace ryujin
     class GeoTIFFProfile : public Geometry<dim>
     {
     public:
-      GeoTIFFProfile(const std::string subsection)
+      GeoTIFFProfile(const std::string &subsection)
           : Geometry<dim>("geotiff profile", subsection)
           , geotiff_reader_(subsection + "/geotiff profile")
       {

--- a/source/geometries/geometry_geotiff_profile.h
+++ b/source/geometries/geometry_geotiff_profile.h
@@ -281,7 +281,7 @@ namespace ryujin
       }
 
     private:
-      GeoTIFFReader<dim> geotiff_reader_;
+      GeoTIFFReader geotiff_reader_;
 
       dealii::Point<dim> point_left_;
       dealii::Point<dim> point_right_;

--- a/source/geometries/geometry_reader.h
+++ b/source/geometries/geometry_reader.h
@@ -28,7 +28,7 @@ namespace ryujin
     class Reader : public Geometry<dim>
     {
     public:
-      Reader(const std::string subsection)
+      Reader(const std::string &subsection)
           : Geometry<dim>("reader", subsection)
       {
         filename_ = "ryujin.msh";

--- a/source/geometries/geometry_rectangular_domain.h
+++ b/source/geometries/geometry_rectangular_domain.h
@@ -37,8 +37,8 @@ namespace ryujin
     class RectangularDomain : public Geometry<dim>
     {
     public:
-      RectangularDomain(const std::string subsection)
-          : Geometry<dim>("rectangular domain", subsection)
+      RectangularDomain(const std::string &name, const std::string &subsection)
+          : Geometry<dim>(name, subsection)
       {
         this->add_parameter("position bottom left",
                             point_left_,
@@ -117,8 +117,14 @@ namespace ryujin
       }
 
 
+      RectangularDomain(const std::string subsection)
+          : RectangularDomain("rectangular domain", subsection)
+      {
+      }
+
+
       void create_triangulation(
-          typename dealii::Triangulation<dim> &triangulation) const final
+          typename dealii::Triangulation<dim> &triangulation) const override
       {
         /* create mesh: */
 

--- a/source/geometries/geometry_step.h
+++ b/source/geometries/geometry_step.h
@@ -143,7 +143,7 @@ namespace ryujin
     class Step : public Geometry<dim>
     {
     public:
-      Step(const std::string subsection)
+      Step(const std::string &subsection)
           : Geometry<dim>("step", subsection)
       {
         length_ = 3.;

--- a/source/geometries/geometry_tank.h
+++ b/source/geometries/geometry_tank.h
@@ -134,7 +134,7 @@ namespace ryujin
     class WaveTank : public Geometry<dim>
     {
     public:
-      WaveTank(const std::string subsection)
+      WaveTank(const std::string &subsection)
           : Geometry<dim>("wave tank", subsection)
       {
         reservoir_length_ = 157. / 100.;

--- a/source/geometries/geometry_wall.h
+++ b/source/geometries/geometry_wall.h
@@ -107,7 +107,7 @@ namespace ryujin
     class Wall : public Geometry<dim>
     {
     public:
-      Wall(const std::string subsection)
+      Wall(const std::string &subsection)
           : Geometry<dim>("wall", subsection)
       {
         length_ = 3.2;

--- a/source/geotiff_reader.h
+++ b/source/geotiff_reader.h
@@ -12,7 +12,8 @@
 #include "patterns_conversion.h"
 
 #include <deal.II/base/parameter_acceptor.h>
-#include <iomanip>
+
+#include <numeric>
 
 #ifdef WITH_GDAL
 #include <cpl_conv.h>
@@ -51,7 +52,6 @@ namespace ryujin
    *
    * @ingroup ShallowWaterEquations
    */
-  template <int dim>
   class GeoTIFFReader : dealii::ParameterAcceptor
   {
   public:
@@ -127,7 +127,17 @@ namespace ryujin
       this->parse_parameters_call_back.connect(set_up);
     }
 
-
+    /*
+     * Query height information for a given position. The method is
+     * templated in dim, so that it can be called with a @p point having an
+     * arbitrary dimension. The method, however, only only uses the first
+     * two coordinates, x and y, from @p point, translates (x, y) into
+     * image coordinates (i, j) and returns an interpolated height value.
+     *
+     * @note If dim < 2, then the y coordinate is set to zero. Similarly,
+     * if dim == 0, then the tiff raster is queried at coordinate (0, 0).
+     */
+    template <int dim>
     DEAL_II_ALWAYS_INLINE inline double
     compute_height(const dealii::Point<dim> &point) const
     {
@@ -136,10 +146,14 @@ namespace ryujin
         return true;
       });
 
-      const double x = point[0];
+      double x = 0;
+      if constexpr (dim >= 1)
+        x = point[0];
+
       double y = 0;
       if constexpr (dim >= 2)
         y = point[1];
+
       const auto &[di, dj] = apply_inverse_transformation(x, y);
 
       /* Check that we are in bounds: */

--- a/source/shallow_water/initial_state_geotiff.h
+++ b/source/shallow_water/initial_state_geotiff.h
@@ -93,7 +93,7 @@ namespace ryujin
 
     private:
       const HyperbolicSystem &hyperbolic_system_;
-      mutable GeoTIFFReader<dim> geotiff_reader_;
+      mutable GeoTIFFReader geotiff_reader_;
 
       /* Runtime parameters: */
 


### PR DESCRIPTION
- **Geometries: use const reference instead of copy by value**
- **RectangularDomain: add constructor variant that allows to change the geometry name**
- **GeoTIFFReader: move template from class to method, add comment**
