### PR TITLE
CMake: add a configure option for each equation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ option(DEBUG_EXPENSIVE_BOUNDS_CHECK "Debug: enable debug code paths for addition
 option(DEBUG_OUTPUT "Debug: enable detailed time-step output" OFF)
 option(DEBUG_SANITIZER "Debug: enable address and UBSAN sanitizers for DEBUG build" OFF)
 option(DEBUG_SYMMETRY_CHECK "Debug: enable debug code paths that verify d_ij, c_ij, m_ij for (anti)symmetry" OFF)
+option(DEFAULT_ENABLE_EQUATIONS "Default enable all available equations. This parameter only sets the default value of all EQUATION_* configuration options" ON)
 option(DENORMALS_ARE_ZERO "Set the \"denormals are zero\" and \"flush to zero\" bits in the MXCSR register" ON)
 option(FORCE_DEAL_II_SPARSE_MATRIX "Always use dealii::SparseMatrix instead of TrilinosWrappers::SparseMatrix for assembly" OFF)
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -83,7 +83,13 @@ endmacro()
 file(GLOB _files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS */CMakeLists.txt)
 foreach(_file ${_files})
   get_filename_component(_directory "${_file}" DIRECTORY)
-  setup_equation("${_directory}")
+
+  string(TOUPPER "${_directory}" _directory_upper)
+  set(EQUATION_${_directory_upper} ${DEFAULT_ENABLE_EQUATIONS} CACHE BOOL "Enable the equation »${_directory}« compute module")
+
+  if(EQUATION_${_directory_upper})
+    setup_equation("${_directory}")
+  endif()
 endforeach()
 
 #


### PR DESCRIPTION
This pull requests add a couple of configuration options to selectively disable or enable equations.
