### PR TITLE
`OfflineData`: add cG/dG DoFHandlers

### DIFF
--- a/source/discretization.h
+++ b/source/discretization.h
@@ -362,7 +362,7 @@ namespace ryujin
     ACCESSOR_CONTAINER_READ_ONLY(collection_, finite_element_dg)
 
     /**
-     * Return a read-only const reference to the finite element.
+     * Return a read-only const reference to the selected finite element.
      *
      * @note The accessor returns an FECollection object.
      */

--- a/source/discretization.h
+++ b/source/discretization.h
@@ -240,8 +240,8 @@ namespace ryujin
      */
     struct Collection {
       std::unique_ptr<const dealii::hp::MappingCollection<dim>> mapping;
-      std::unique_ptr<const dealii::hp::FECollection<dim>> finite_element;
       std::unique_ptr<const dealii::hp::FECollection<dim>> finite_element_cg;
+      std::unique_ptr<const dealii::hp::FECollection<dim>> finite_element_dg;
       std::unique_ptr<const dealii::hp::QCollection<dim>> quadrature;
       std::unique_ptr<const dealii::hp::QCollection<dim>> quadrature_high_order;
       std::unique_ptr<const dealii::hp::QCollection<dim>> nodal_quadrature;
@@ -340,19 +340,39 @@ namespace ryujin
     ACCESSOR_CONTAINER_READ_ONLY(collection_, mapping)
 
     /**
-     * Return a read-only const reference to the finite element.
-     *
-     * @note The accessor returns an FECollection object.
-     */
-    ACCESSOR_CONTAINER_READ_ONLY(collection_, finite_element)
-
-    /**
      * Return a read-only const reference to a continuous ("cG") variant of
-     * the selected discontinuous finite element space.
+     * the selected finite element space.
+     *
+     * @note If the selected finite element space is continuous then this
+     * method simply returns the same object as finite_element().
      *
      * @note The accessor returns an FECollection object.
      */
     ACCESSOR_CONTAINER_READ_ONLY(collection_, finite_element_cg)
+
+    /**
+     * Return a read-only const reference to a discontinuous ("dG") variant
+     * of the selected finite element space.
+     *
+     * @note If the selected finite element space is discontinuous then
+     * this method simply returns the same object as finite_element().
+     *
+     * @note The accessor returns an FECollection object.
+     */
+    ACCESSOR_CONTAINER_READ_ONLY(collection_, finite_element_dg)
+
+    /**
+     * Return a read-only const reference to the finite element.
+     *
+     * @note The accessor returns an FECollection object.
+     */
+    const dealii::hp::FECollection<dim> &finite_element() const
+    {
+      if (have_discontinuous_ansatz())
+        return *collection_.finite_element_dg;
+      else
+        return *collection_.finite_element_cg;
+    }
 
     /**
      * Return a read-only const reference to the quadrature rule.

--- a/source/discretization.template.h
+++ b/source/discretization.template.h
@@ -189,8 +189,8 @@ namespace ryujin
      * standard_simplices, however, we need to do the setup ourselves:
      */
 
-    const auto collection_type = selected_geometry_->populate_hp_collections(
-        fe_degree, have_discontinuous_ansatz(), collection_);
+    const auto collection_type =
+        selected_geometry_->populate_hp_collections(fe_degree, collection_);
 
     switch (collection_type) {
     case Geometry<dim>::HP_Collection::populated_by_geometry: {
@@ -199,8 +199,8 @@ namespace ryujin
        */
 
       Assert(collection_.mapping, dealii::ExcInternalError());
-      Assert(collection_.finite_element, dealii::ExcInternalError());
       Assert(collection_.finite_element_cg, dealii::ExcInternalError());
+      Assert(collection_.finite_element_dg, dealii::ExcInternalError());
       Assert(collection_.quadrature, dealii::ExcInternalError());
       Assert(collection_.quadrature_high_order, dealii::ExcInternalError());
       Assert(collection_.nodal_quadrature, dealii::ExcInternalError());
@@ -215,17 +215,10 @@ namespace ryujin
        * Qk finite element on purely quadrilateral, or hexahedral meshes:
        */
 
-      if (have_discontinuous_ansatz()) {
-        collection_.finite_element =
-            std::make_unique<hp::FECollection<dim>>(FE_DGQ<dim>(fe_degree));
-        collection_.finite_element_cg =
-            std::make_unique<hp::FECollection<dim>>(FE_Q<dim>(fe_degree));
-      } else {
-        collection_.finite_element =
-            std::make_unique<hp::FECollection<dim>>(FE_Q<dim>(fe_degree));
-        collection_.finite_element_cg =
-            std::make_unique<hp::FECollection<dim>>(FE_Q<dim>(fe_degree));
-      }
+      collection_.finite_element_cg =
+          std::make_unique<hp::FECollection<dim>>(FE_Q<dim>(fe_degree));
+      collection_.finite_element_dg =
+          std::make_unique<hp::FECollection<dim>>(FE_DGQ<dim>(fe_degree));
 
       collection_.mapping =
           std::make_unique<dealii::hp::MappingCollection<dim>>(
@@ -253,17 +246,10 @@ namespace ryujin
        * Pk finite element on purely quadrilateral, or hexahedral meshes:
        */
 
-      if (have_discontinuous_ansatz()) {
-        collection_.finite_element = std::make_unique<hp::FECollection<dim>>(
-            FE_SimplexDGP<dim>(fe_degree));
-        collection_.finite_element_cg = std::make_unique<hp::FECollection<dim>>(
-            FE_SimplexP<dim>(fe_degree));
-      } else {
-        collection_.finite_element = std::make_unique<hp::FECollection<dim>>(
-            FE_SimplexP<dim>(fe_degree));
-        collection_.finite_element_cg = std::make_unique<hp::FECollection<dim>>(
-            FE_SimplexP<dim>(fe_degree));
-      }
+      collection_.finite_element_cg =
+          std::make_unique<hp::FECollection<dim>>(FE_SimplexP<dim>(fe_degree));
+      collection_.finite_element_dg = std::make_unique<hp::FECollection<dim>>(
+          FE_SimplexDGP<dim>(fe_degree));
 
       collection_.mapping =
           std::make_unique<dealii::hp::MappingCollection<dim>>(

--- a/source/geometries/geometry.h
+++ b/source/geometries/geometry.h
@@ -95,7 +95,6 @@ namespace ryujin
      */
     virtual HP_Collection populate_hp_collections(
         const unsigned int /*fe_degree*/,
-        const bool /*have_discontinuous_ansatz*/,
         typename ryujin::Discretization<dim>::Collection & /*collection*/) const
     {
       /*

--- a/source/geometries/geometry_rectangular_domain.h
+++ b/source/geometries/geometry_rectangular_domain.h
@@ -275,7 +275,6 @@ namespace ryujin
 
       typename Geometry<dim>::HP_Collection
       populate_hp_collections(const unsigned int /*fe_degree*/,
-                              const bool /*have_discontinuous_ansatz*/,
                               typename ryujin::Discretization<dim>::Collection
                                   & /*collection*/) const override
       {

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -90,8 +90,8 @@ namespace ryujin
                 const std::string &subsection = "/OfflineData");
 
     /**
-     * Prepare offline data. A call to prepare() internally calls setup()
-     * and assemble().
+     * Prepare offline data. A call to prepare() sets up storage, dof
+     * handlers, sparsity patterns, and assembles all matrices.
      *
      * The problem_dimension and n_precomputed_values parameters is used to
      * set up appropriately sized vector partitioners for the state and
@@ -99,17 +99,7 @@ namespace ryujin
      */
     void prepare(const unsigned int problem_dimension,
                  const unsigned int n_precomputed_values,
-                 const unsigned int n_parabolic_state_vectors)
-    {
-      setup(problem_dimension, n_precomputed_values);
-
-      create_matrices();
-
-      if (!dof_handler_->has_hp_capabilities())
-        create_multigrid_data();
-
-      n_parabolic_state_vectors_ = n_parabolic_state_vectors;
-    }
+                 const unsigned int n_parabolic_state_vectors);
 
     /**
      * The DofHandler for our (scalar) CG ansatz space in (deal.II typical)
@@ -291,28 +281,54 @@ namespace ryujin
     //@{
 
     /**
+     * Set up DoFHandlers. Internally used in prepare().
+     *
+     * @note This method populates various OfflineData internal data structures.
+     */
+    void create_dof_handlers();
+
+    /**
+     * Renumber the hyperbolic DoFHandler for use with our SIMD sparsity
+     * pattern. Internally used in prepare().
+     *
+     * @note This method populates various OfflineData internal data structures.
+     */
+    void renumber_for_simd();
+
+    /**
      * Set up affine constraints and sparsity pattern. Internally used in
      * setup().
+     *
+     * @note This method populates various OfflineData internal data structures.
      */
     void create_constraints_and_sparsity_pattern();
 
     /**
-     * Set up DoFHandler, all IndexSet objects and the SparsityPattern.
-     * Initialize matrix storage.
      *
-     * The problem_dimension parameter is used to setup up an appropriately
-     * sized vector partitioner for the MultiComponentVector.
+     * @note This method populates various OfflineData internal data structures.
      */
-    void setup(const unsigned int problem_dimension,
-               const unsigned int n_precomputed_values);
+    void ensure_simd_stride_consistency();
 
     /**
-     * Assemble all matrices.
+     * Create partitioner. Internally used in setup().
+     *
+     * @note This method populates various OfflineData internal data structures.
+     */
+    void create_partitioner_and_simd_sparsity(
+        const unsigned int problem_dimension,
+        const unsigned int n_precomputed_values);
+
+    /**
+     * Assemble all matrices. Internally used in prepare().
+     *
+     * @note This method populates various OfflineData internal data structures.
      */
     void create_matrices();
 
     /**
-     * Create multigrid data.
+     * Create multigrid data. Internally used in prepare().
+     *
+     * @note This method populates various OfflineData internal data structures.
      */
     void create_multigrid_data();
 

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -102,13 +102,53 @@ namespace ryujin
                  const unsigned int n_parabolic_state_vectors);
 
     /**
-     * The DofHandler for our (scalar) CG ansatz space in (deal.II typical)
-     * global numbering.
+     * Return a read-only const reference to the DoFHandler for the
+     * continuous ("cG") variant of the selected finite element space.
+     *
+     * @note If the selected finite element space is continuous then this
+     * method simply returns the same object as dof_handler().
      */
-    ACCESSOR_READ_ONLY(dof_handler)
+    ACCESSOR_READ_ONLY(dof_handler_cg)
 
     /**
-     * An AffineConstraints object storing constraints in (Deal.II typical)
+     * Return a read-only const reference to the DoFHandler for the
+     * discontinuous ("dG") variant of the selected finite element space.
+     *
+     * @note If the selected finite element space is discontinuous then
+     * this method simply returns the same object as dof_handler().
+     */
+    ACCESSOR_READ_ONLY(dof_handler_dg)
+
+    /**
+     * Return a read-only const reference to the dof handler.
+     */
+    const dealii::DoFHandler<dim> &dof_handler() const
+    {
+      if (discretization_->have_discontinuous_ansatz()) {
+        Assert(dof_handler_dg_, dealii::ExcInternalError());
+        return *dof_handler_dg_;
+      } else {
+        Assert(dof_handler_cg_, dealii::ExcInternalError());
+        return *dof_handler_cg_;
+      }
+    }
+
+    /**
+     * Return a writable reference to the dof handler.
+     */
+    dealii::DoFHandler<dim> &dof_handler()
+    {
+      if (discretization_->have_discontinuous_ansatz()) {
+        Assert(dof_handler_dg_, dealii::ExcInternalError());
+        return *dof_handler_dg_;
+      } else {
+        Assert(dof_handler_cg_, dealii::ExcInternalError());
+        return *dof_handler_cg_;
+      }
+    }
+
+    /**
+     * An AffineConstraints object storing constraints in (deal.II typical)
      * global numbering.
      */
     ACCESSOR_READ_ONLY(affine_constraints)
@@ -340,7 +380,8 @@ namespace ryujin
 
     const MPIEnsemble &mpi_ensemble_;
 
-    std::unique_ptr<dealii::DoFHandler<dim>> dof_handler_;
+    std::unique_ptr<dealii::DoFHandler<dim>> dof_handler_cg_;
+    std::unique_ptr<dealii::DoFHandler<dim>> dof_handler_dg_;
 
     dealii::AffineConstraints<Number> affine_constraints_;
 

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -93,7 +93,7 @@ namespace ryujin
 
     create_matrices();
 
-    if (!dof_handler_->has_hp_capabilities())
+    if (!dof_handler().has_hp_capabilities())
       create_multigrid_data();
 
     n_parabolic_state_vectors_ = n_parabolic_state_vectors;
@@ -104,9 +104,14 @@ namespace ryujin
   void OfflineData<dim, Number>::create_dof_handlers()
   {
     const auto &triangulation = discretization_->triangulation();
-    if (!dof_handler_)
-      dof_handler_ = std::make_unique<dealii::DoFHandler<dim>>(triangulation);
-    auto &dof_handler = *dof_handler_;
+
+    if (!dof_handler_cg_)
+      dof_handler_cg_ =
+          std::make_unique<dealii::DoFHandler<dim>>(triangulation);
+
+    if (!dof_handler_dg_)
+      dof_handler_dg_ =
+          std::make_unique<dealii::DoFHandler<dim>>(triangulation);
 
     /*
      * Set active FE indices: This information depends on the selected
@@ -114,17 +119,19 @@ namespace ryujin
      * setup. For a standard geometry that has only one reference element
      * the method simply does nothing.
      */
-    discretization_->selected_geometry().update_dof_handler(dof_handler);
 
-    dof_handler.distribute_dofs(discretization_->finite_element());
+    discretization_->selected_geometry().update_dof_handler(*dof_handler_cg_);
+    discretization_->selected_geometry().update_dof_handler(*dof_handler_dg_);
+
+    dof_handler_cg_->distribute_dofs(discretization_->finite_element_cg());
+    dof_handler_dg_->distribute_dofs(discretization_->finite_element_dg());
   }
 
 
   template <int dim, typename Number>
   void OfflineData<dim, Number>::renumber_for_simd()
   {
-    Assert(dof_handler_, dealii::ExcInternalError());
-    auto &dof_handler = *dof_handler_;
+    auto &dof_handler = this->dof_handler();
     const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
     n_locally_owned_ = locally_owned.n_elements();
 
@@ -184,8 +191,7 @@ namespace ryujin
   template <int dim, typename Number>
   void OfflineData<dim, Number>::ensure_simd_stride_consistency()
   {
-    Assert(dof_handler_, dealii::ExcInternalError());
-    auto &dof_handler = *dof_handler_;
+    auto &dof_handler = this->dof_handler();
 
     /*
      * A small lambda to check for stride-level consistency of the internal
@@ -275,7 +281,7 @@ namespace ryujin
      * pattern:
      */
 
-    auto &dof_handler = *dof_handler_;
+    auto &dof_handler = this->dof_handler();
     const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
     Assert(n_locally_owned_ == locally_owned.n_elements(),
            dealii::ExcInternalError());
@@ -417,9 +423,7 @@ namespace ryujin
       const unsigned int problem_dimension,
       const unsigned int n_precomputed_values)
   {
-    Assert(dof_handler_, dealii::ExcInternalError());
-    auto &dof_handler = *dof_handler_;
-
+    auto &dof_handler = this->dof_handler();
     const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
     Assert(n_locally_owned_ == locally_owned.n_elements(),
            dealii::ExcInternalError());
@@ -536,7 +540,7 @@ namespace ryujin
      * Then, assemble:
      */
 
-    auto &dof_handler = *dof_handler_;
+    auto &dof_handler = this->dof_handler();
 
     measure_of_omega_ = 0.;
 
@@ -1301,7 +1305,7 @@ namespace ryujin
               << std::endl;
 #endif
 
-    auto &dof_handler = *dof_handler_;
+    auto &dof_handler = this->dof_handler();
 
     Assert(!dof_handler.has_hp_capabilities(), dealii::ExcInternalError());
 

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -216,6 +216,7 @@ namespace ryujin
       return i / group_size * group_size;
     };
 
+#if DEAL_II_VERSION_GTE(9, 5, 0)
     /*
      * A small lambda that performs a "logical or" over all MPI ranks:
      */
@@ -236,7 +237,6 @@ namespace ryujin
      * node constraints). Therefore, the following little dance:
      */
 
-#if DEAL_II_VERSION_GTE(9, 5, 0)
     if (mpi_allreduce_logical_or(affine_constraints_.n_constraints() > 0)) {
       if (mpi_allreduce_logical_or( //
               consistent_stride_range() != n_locally_internal_)) {

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -71,6 +71,202 @@ namespace ryujin
 
 
   template <int dim, typename Number>
+  void OfflineData<dim, Number>::prepare(
+      const unsigned int problem_dimension,
+      const unsigned int n_precomputed_values,
+      const unsigned int n_parabolic_state_vectors)
+  {
+#ifdef DEBUG_OUTPUT
+    std::cout << "OfflineData<dim, Number>::prepare()" << std::endl;
+#endif
+
+    create_dof_handlers();
+
+    renumber_for_simd();
+
+    create_constraints_and_sparsity_pattern();
+
+    ensure_simd_stride_consistency();
+
+    create_partitioner_and_simd_sparsity(problem_dimension,
+                                         n_precomputed_values);
+
+    create_matrices();
+
+    if (!dof_handler_->has_hp_capabilities())
+      create_multigrid_data();
+
+    n_parabolic_state_vectors_ = n_parabolic_state_vectors;
+  }
+
+
+  template <int dim, typename Number>
+  void OfflineData<dim, Number>::create_dof_handlers()
+  {
+    const auto &triangulation = discretization_->triangulation();
+    if (!dof_handler_)
+      dof_handler_ = std::make_unique<dealii::DoFHandler<dim>>(triangulation);
+    auto &dof_handler = *dof_handler_;
+
+    /*
+     * Set active FE indices: This information depends on the selected
+     * geometry. Therefore, let the selected geometry object handle the
+     * setup. For a standard geometry that has only one reference element
+     * the method simply does nothing.
+     */
+    discretization_->selected_geometry().update_dof_handler(dof_handler);
+
+    dof_handler.distribute_dofs(discretization_->finite_element());
+  }
+
+
+  template <int dim, typename Number>
+  void OfflineData<dim, Number>::renumber_for_simd()
+  {
+    Assert(dof_handler_, dealii::ExcInternalError());
+    auto &dof_handler = *dof_handler_;
+    const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
+    n_locally_owned_ = locally_owned.n_elements();
+
+    /*
+     * Initial renumbering with Cuthill McKee (because we can):
+     */
+
+    DoFRenumbering::Cuthill_McKee(dof_handler);
+
+    /*
+     * Reorder all (individual) export indices at the beginning of the
+     * locally_internal index range to achieve a better packing:
+     *
+     * Note: This function might miss export indices that come from
+     * eliminating hanging node and periodicity constraints (which we do
+     * not know at this point because they depend on the renumbering...).
+     */
+    DoFRenumbering::export_indices_first(dof_handler,
+                                         mpi_ensemble_.ensemble_communicator(),
+                                         n_locally_owned_,
+                                         1);
+
+    /*
+     * Group degrees of freedom that have the same stencil size in groups
+     * of multiples of the VectorizedArray<Number>::size().
+     *
+     * In order to determine the stencil size we have to create a first,
+     * temporary sparsity pattern:
+     */
+    create_constraints_and_sparsity_pattern();
+    n_locally_internal_ = DoFRenumbering::internal_range(
+        dof_handler, sparsity_pattern_, VectorizedArray<Number>::size());
+
+    /*
+     * Reorder all (strides of) locally internal indices that contain
+     * export indices to the start of the index range. This reordering
+     * preserves the binning introduced by
+     * DoFRenumbering::internal_range().
+     *
+     * Note: This function might miss export indices that come from
+     * eliminating hanging node and periodicity constraints (which we do
+     * not know at this point because they depend on the renumbering...).
+     * We therefore have to update n_export_indices_ later again.
+     */
+    n_export_indices_ = DoFRenumbering::export_indices_first(
+        dof_handler,
+        mpi_ensemble_.ensemble_communicator(),
+        n_locally_internal_,
+        VectorizedArray<Number>::size());
+  }
+
+
+  /*
+   * Modifies:
+   *     n_locally_internal_
+   */
+  template <int dim, typename Number>
+  void OfflineData<dim, Number>::ensure_simd_stride_consistency()
+  {
+    Assert(dof_handler_, dealii::ExcInternalError());
+    auto &dof_handler = *dof_handler_;
+
+    /*
+     * A small lambda to check for stride-level consistency of the internal
+     * index range:
+     */
+    const auto consistent_stride_range [[maybe_unused]] = [&]() {
+      constexpr auto group_size = VectorizedArray<Number>::size();
+      const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
+      const auto offset = n_locally_owned_ != 0 ? *locally_owned.begin() : 0;
+
+      unsigned int group_row_length = 0;
+      unsigned int i = 0;
+      for (; i < n_locally_internal_; ++i) {
+        if (i % group_size == 0) {
+          group_row_length = sparsity_pattern_.row_length(offset + i);
+        } else {
+          if (group_row_length != sparsity_pattern_.row_length(offset + i)) {
+            break;
+          }
+        }
+      }
+      return i / group_size * group_size;
+    };
+
+    /*
+     * A small lambda that performs a "logical or" over all MPI ranks:
+     */
+    const auto mpi_allreduce_logical_or = [&](const bool local_value) {
+      std::function<bool(const bool &, const bool &)> comparator =
+          [](const bool &left, const bool &right) -> bool {
+        return left || right;
+      };
+      return Utilities::MPI::all_reduce(
+          local_value, mpi_ensemble_.ensemble_communicator(), comparator);
+    };
+
+    /*
+     * We have to ensure that the locally internal numbering range is still
+     * consistent, meaning that all strides have the same stencil size.
+     * This property might not hold any more after the elimination
+     * procedure of constrained degrees of freedom (periodicity, or hanging
+     * node constraints). Therefore, the following little dance:
+     */
+
+#if DEAL_II_VERSION_GTE(9, 5, 0)
+    if (mpi_allreduce_logical_or(affine_constraints_.n_constraints() > 0)) {
+      if (mpi_allreduce_logical_or( //
+              consistent_stride_range() != n_locally_internal_)) {
+        /*
+         * In this case we try to fix up the numbering by pushing affected
+         * strides to the end and slightly lowering the n_locally_internal_
+         * marker.
+         */
+        n_locally_internal_ = DoFRenumbering::inconsistent_strides_last(
+            dof_handler,
+            sparsity_pattern_,
+            n_locally_internal_,
+            VectorizedArray<Number>::size());
+        create_constraints_and_sparsity_pattern();
+        n_locally_internal_ = consistent_stride_range();
+      }
+    }
+#endif
+
+    /*
+     * Check that after all the dof manipulation and setup we still end up
+     * with indices in [0, locally_internal) that have uniform stencil size
+     * within a stride.
+     */
+    Assert(consistent_stride_range() == n_locally_internal_,
+           dealii::ExcInternalError());
+  }
+
+
+  /*
+   * Populates:
+   *     n_locally_owned_
+   *     affine_constraints_
+   *     sparsity_pattern_
+   */
+  template <int dim, typename Number>
   void OfflineData<dim, Number>::create_constraints_and_sparsity_pattern()
   {
     /*
@@ -81,6 +277,8 @@ namespace ryujin
 
     auto &dof_handler = *dof_handler_;
     const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
+    Assert(n_locally_owned_ == locally_owned.n_elements(),
+           dealii::ExcInternalError());
 
 #if DEAL_II_VERSION_GTE(9, 6, 0)
     const auto locally_relevant =
@@ -206,162 +404,21 @@ namespace ryujin
   }
 
 
+  /*
+   * Populates:
+   *     n_locally_relevant_
+   *     scalar_partitioner_
+   *     hyperbolic_vector_partitioner_
+   *     precomputed_vector_partitioner_
+   *     sparsity_pattern_simd_
+   */
   template <int dim, typename Number>
-  void OfflineData<dim, Number>::setup(const unsigned int problem_dimension,
-                                       const unsigned int n_precomputed_values)
+  void OfflineData<dim, Number>::create_partitioner_and_simd_sparsity(
+      const unsigned int problem_dimension,
+      const unsigned int n_precomputed_values)
   {
-#ifdef DEBUG_OUTPUT
-    std::cout << "OfflineData<dim, Number>::setup()" << std::endl;
-#endif
-
-    /*
-     * Initialize dof handler:
-     */
-
-    const auto &triangulation = discretization_->triangulation();
-    if (!dof_handler_)
-      dof_handler_ = std::make_unique<dealii::DoFHandler<dim>>(triangulation);
+    Assert(dof_handler_, dealii::ExcInternalError());
     auto &dof_handler = *dof_handler_;
-
-    /*
-     * Set active FE indices: This information depends on the selected
-     * geometry. Therefore, let the selected geometry object handle the
-     * setup. For a standard geometry that has only one reference element
-     * the method simply does nothing.
-     */
-    discretization_->selected_geometry().update_dof_handler(dof_handler);
-
-    dof_handler.distribute_dofs(discretization_->finite_element());
-
-    n_locally_owned_ = dof_handler.locally_owned_dofs().n_elements();
-
-    /*
-     * Renumbering:
-     */
-
-    DoFRenumbering::Cuthill_McKee(dof_handler);
-
-    /*
-     * Reorder all (individual) export indices at the beginning of the
-     * locally_internal index range to achieve a better packing:
-     *
-     * Note: This function might miss export indices that come from
-     * eliminating hanging node and periodicity constraints (which we do
-     * not know at this point because they depend on the renumbering...).
-     */
-    DoFRenumbering::export_indices_first(dof_handler,
-                                         mpi_ensemble_.ensemble_communicator(),
-                                         n_locally_owned_,
-                                         1);
-
-    /*
-     * Group degrees of freedom that have the same stencil size in groups
-     * of multiples of the VectorizedArray<Number>::size().
-     *
-     * In order to determine the stencil size we have to create a first,
-     * temporary sparsity pattern:
-     */
-    create_constraints_and_sparsity_pattern();
-    n_locally_internal_ = DoFRenumbering::internal_range(
-        dof_handler, sparsity_pattern_, VectorizedArray<Number>::size());
-
-    /*
-     * Reorder all (strides of) locally internal indices that contain
-     * export indices to the start of the index range. This reordering
-     * preserves the binning introduced by
-     * DoFRenumbering::internal_range().
-     *
-     * Note: This function might miss export indices that come from
-     * eliminating hanging node and periodicity constraints (which we do
-     * not know at this point because they depend on the renumbering...).
-     * We therefore have to update n_export_indices_ later again.
-     */
-    n_export_indices_ = DoFRenumbering::export_indices_first(
-        dof_handler,
-        mpi_ensemble_.ensemble_communicator(),
-        n_locally_internal_,
-        VectorizedArray<Number>::size());
-
-    /*
-     * A small lambda to check for stride-level consistency of the internal
-     * index range:
-     */
-    const auto consistent_stride_range [[maybe_unused]] = [&]() {
-      constexpr auto group_size = VectorizedArray<Number>::size();
-      const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
-      const auto offset = n_locally_owned_ != 0 ? *locally_owned.begin() : 0;
-
-      unsigned int group_row_length = 0;
-      unsigned int i = 0;
-      for (; i < n_locally_internal_; ++i) {
-        if (i % group_size == 0) {
-          group_row_length = sparsity_pattern_.row_length(offset + i);
-        } else {
-          if (group_row_length != sparsity_pattern_.row_length(offset + i)) {
-            break;
-          }
-        }
-      }
-      return i / group_size * group_size;
-    };
-
-    /*
-     * A small lambda that performs a "logical or" over all MPI ranks:
-     */
-    const auto mpi_allreduce_logical_or = [&](const bool local_value) {
-      std::function<bool(const bool &, const bool &)> comparator =
-          [](const bool &left, const bool &right) -> bool {
-        return left || right;
-      };
-      return Utilities::MPI::all_reduce(
-          local_value, mpi_ensemble_.ensemble_communicator(), comparator);
-    };
-
-    /*
-     * Create final sparsity pattern:
-     */
-
-    create_constraints_and_sparsity_pattern();
-
-    /*
-     * We have to ensure that the locally internal numbering range is still
-     * consistent, meaning that all strides have the same stencil size.
-     * This property might not hold any more after the elimination
-     * procedure of constrained degrees of freedom (periodicity, or hanging
-     * node constraints). Therefore, the following little dance:
-     */
-
-#if DEAL_II_VERSION_GTE(9, 5, 0)
-    if (mpi_allreduce_logical_or(affine_constraints_.n_constraints() > 0)) {
-      if (mpi_allreduce_logical_or( //
-              consistent_stride_range() != n_locally_internal_)) {
-        /*
-         * In this case we try to fix up the numbering by pushing affected
-         * strides to the end and slightly lowering the n_locally_internal_
-         * marker.
-         */
-        n_locally_internal_ = DoFRenumbering::inconsistent_strides_last(
-            dof_handler,
-            sparsity_pattern_,
-            n_locally_internal_,
-            VectorizedArray<Number>::size());
-        create_constraints_and_sparsity_pattern();
-        n_locally_internal_ = consistent_stride_range();
-      }
-    }
-#endif
-
-    /*
-     * Check that after all the dof manipulation and setup we still end up
-     * with indices in [0, locally_internal) that have uniform stencil size
-     * within a stride.
-     */
-    Assert(consistent_stride_range() == n_locally_internal_,
-           dealii::ExcInternalError());
-
-    /*
-     * Set up partitioner:
-     */
 
     const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
     Assert(n_locally_owned_ == locally_owned.n_elements(),
@@ -399,6 +456,18 @@ namespace ryujin
         scalar_partitioner_, n_precomputed_values);
 
     /*
+     * A small lambda that performs a "logical or" over all MPI ranks:
+     */
+    const auto mpi_allreduce_logical_or = [&](const bool local_value) {
+      std::function<bool(const bool &, const bool &)> comparator =
+          [](const bool &left, const bool &right) -> bool {
+        return left || right;
+      };
+      return Utilities::MPI::all_reduce(
+          local_value, mpi_ensemble_.ensemble_communicator(), comparator);
+    };
+
+    /*
      * After eliminiating periodicity and hanging node constraints we need
      * to update n_export_indices_ again. This happens because we need to
      * call export_indices_first() with incomplete information (missing
@@ -431,8 +500,8 @@ namespace ryujin
 
     /*
      * Set up SIMD sparsity pattern in local numbering. Nota bene: The
-     * SparsityPatternSIMD::reinit() function will translates the pattern
-     * from global deal.II (typical) dof indexing to local indices.
+     * SparsityPatternSIMD::reinit() function translates the pattern from
+     * global deal.II (typical) dof indexing to local indices.
      */
 
     sparsity_pattern_simd_.reinit(


### PR DESCRIPTION
This PR is introduces some minor refactoring so that a cG / dG DoFHandler is always available. We need such a setup for support for residual distribution and certain parabolic subsystems.
