### PR TITLE
ParabolicModule: refactor parabolic state vector setup and output

### DIFF
--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -127,6 +127,8 @@ namespace ryujin
 
     using state_type = typename View::state_type;
 
+    static constexpr auto n_precomputed_values = View::n_precomputed_values;
+
     using precomputed_type = typename View::precomputed_type;
 
     using initial_precomputed_type = typename View::initial_precomputed_type;
@@ -167,6 +169,14 @@ namespace ryujin
      * @name Functons for performing explicit time steps
      */
     //@{
+
+    /**
+     * (Re)initialize the hyperbolic state vector component and the
+     * precomputed vector component of the state vector.
+     *
+     * @note This routine does not modify the parabolic state vector component.
+     */
+    void reinit_state_vector(StateVector &state_vector) const;
 
     /**
      * This function preprocesses a given state vector @p U in preparation

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -91,6 +91,45 @@ namespace ryujin
 
   /*
    * -------------------------------------------------------------------------
+   * Step 0: Reinitialize vector
+   * -------------------------------------------------------------------------
+   */
+
+
+  /**
+   * Helper function that (re)initializes the state and the precomputed
+   * component of a StateVector to proper sizes.
+   *
+   * @note This method does neither initialize nor resize the parabolic
+   * state vector component. The ParabolicModule itself has to ensure
+   * proper setup during prepare_state_vector() and solve().
+   */
+  template <typename Description, int dim, typename Number>
+  void HyperbolicModule<Description, dim, Number>::reinit_state_vector(
+      StateVector &state_vector) const
+  {
+    auto &[U, precomputed, V] = state_vector;
+    U.reinit(offline_data_->hyperbolic_vector_partitioner());
+    precomputed.reinit(offline_data_->precomputed_vector_partitioner());
+
+#ifdef DEBUG
+    /* Poison all vectors: */
+    using state_type = typename View::state_type;
+
+    constexpr auto nan = std::numeric_limits<Number>::signaling_NaN();
+
+    const unsigned int n_owned = offline_data_->n_locally_owned();
+    for (unsigned int i = 0; i < n_owned; ++i) {
+      U.write_tensor(state_type{} * nan, i);
+      precomputed.write_tensor(
+          dealii::Tensor<1, n_precomputed_values, Number>() * nan, i);
+    }
+#endif
+  }
+
+
+  /*
+   * -------------------------------------------------------------------------
    * Step 1: Apply boundary conditions and precompute values
    * -------------------------------------------------------------------------
    */

--- a/source/navier_stokes/parabolic_module.h
+++ b/source/navier_stokes/parabolic_module.h
@@ -170,11 +170,15 @@ namespace ryujin
       //@{
 
       /**
-       * Sets the invariant domain violation strategy.
+       * (Re)initialize the parabolic state vector component of the state
+       * vector.
+       *
+       * @note This routine does not modify the hyperbolic state vector or
+       * the precomputed vector component.
        */
-      void set_id_violation_strategy(const IDViolationStrategy &strategy) const
+      void reinit_state_vector(StateVector & /*state_vector*/) const
       {
-        id_violation_strategy_ = strategy;
+        // do nothing
       }
 
       /**
@@ -211,6 +215,14 @@ namespace ryujin
                                const Number old_t,
                                StateVector &new_state_vector,
                                Number tau) const;
+
+      /**
+       * Sets the invariant domain violation strategy.
+       */
+      void set_id_violation_strategy(const IDViolationStrategy &strategy) const
+      {
+        id_violation_strategy_ = strategy;
+      }
 
       //@}
       /**

--- a/source/navier_stokes/parabolic_system.h
+++ b/source/navier_stokes/parabolic_system.h
@@ -50,11 +50,6 @@ namespace ryujin
       ACCESSOR_READ_ONLY(lambda)
       ACCESSOR_READ_ONLY(cv_inverse_kappa)
 
-      unsigned int n_parabolic_state_vectors() const
-      {
-        return parabolic_component_names_.size();
-      }
-
       ACCESSOR_READ_ONLY(parabolic_component_names);
 
     private:

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -147,10 +147,49 @@ namespace ryujin
     }
 
     /**
+     * An AffineConstraints object storing constraints for the continuous
+     * ("cG") variant of the selected finite element space in (deal.II
+     * typical) global numbering.
+     *
+     * @note The affine constraints object is populated with with (a)
+     * hanging node constraints, and (b) periodicity constraints, that
+     * directly affect the chosen ansatz space.
+     *
+     * @note If the selected finite element space is continuous then this
+     * method simply returns the same object as affine_constraints().
+     */
+    ACCESSOR_READ_ONLY(affine_constraints_cg)
+
+    /**
+     * An AffineConstraints object storing constraints for the
+     * discontinuous ("dG") variant of the selected finite element space in
+     * (deal.II typical) global numbering.
+     *
+     * @note The affine constraints object is populated with with (a)
+     * hanging node constraints, and (b) periodicity constraints, that
+     * directly affect the chosen ansatz space.
+     *
+     * @note If the selected finite element space is discontinuous then
+     * this method simply returns the same object as affine_constraints().
+     */
+    ACCESSOR_READ_ONLY(affine_constraints_dg)
+
+    /**
      * An AffineConstraints object storing constraints in (deal.II typical)
      * global numbering.
+     *
+     * @note The affine constraints object is populated with with (a)
+     * hanging node constraints, and (b) periodicity constraints, that
+     * directly affect the chosen ansatz space.
      */
-    ACCESSOR_READ_ONLY(affine_constraints)
+    const dealii::AffineConstraints<Number> &affine_constraints() const
+    {
+      if (discretization_->have_discontinuous_ansatz()) {
+        return affine_constraints_dg_;
+      } else {
+        return affine_constraints_cg_;
+      }
+    }
 
     /**
      * An MPI partitioner for the (scalar) Vector storing a scalar-valued
@@ -377,7 +416,8 @@ namespace ryujin
     std::unique_ptr<dealii::DoFHandler<dim>> dof_handler_cg_;
     std::unique_ptr<dealii::DoFHandler<dim>> dof_handler_dg_;
 
-    dealii::AffineConstraints<Number> affine_constraints_;
+    dealii::AffineConstraints<Number> affine_constraints_cg_;
+    dealii::AffineConstraints<Number> affine_constraints_dg_;
 
     std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
         scalar_partitioner_;

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -98,8 +98,7 @@ namespace ryujin
      * precomputed MultiComponentVector.
      */
     void prepare(const unsigned int problem_dimension,
-                 const unsigned int n_precomputed_values,
-                 const unsigned int n_parabolic_state_vectors);
+                 const unsigned int n_precomputed_values);
 
     /**
      * Return a read-only const reference to the DoFHandler for the
@@ -170,11 +169,6 @@ namespace ryujin
      * vector-valued quantity of size HyperbolicSystem::problem_dimension.
      */
     ACCESSOR_READ_ONLY_NO_DEREFERENCE(precomputed_vector_partitioner)
-
-    /**
-     * The block size of the parabolic state vector.
-     */
-    ACCESSOR_READ_ONLY(n_parabolic_state_vectors);
 
     /**
      * The subinterval \f$[0,\texttt{n_export_indices()})\f$ contains all
@@ -393,8 +387,6 @@ namespace ryujin
 
     std::shared_ptr<const dealii::Utilities::MPI::Partitioner>
         precomputed_vector_partitioner_;
-
-    unsigned int n_parabolic_state_vectors_;
 
     unsigned int n_export_indices_;
     unsigned int n_locally_internal_;

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -71,10 +71,9 @@ namespace ryujin
 
 
   template <int dim, typename Number>
-  void OfflineData<dim, Number>::prepare(
-      const unsigned int problem_dimension,
-      const unsigned int n_precomputed_values,
-      const unsigned int n_parabolic_state_vectors)
+  void
+  OfflineData<dim, Number>::prepare(const unsigned int problem_dimension,
+                                    const unsigned int n_precomputed_values)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "OfflineData<dim, Number>::prepare()" << std::endl;
@@ -95,8 +94,6 @@ namespace ryujin
 
     if (!dof_handler().has_hp_capabilities())
       create_multigrid_data();
-
-    n_parabolic_state_vectors_ = n_parabolic_state_vectors;
   }
 
 

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -189,6 +189,7 @@ namespace ryujin
   void OfflineData<dim, Number>::ensure_simd_stride_consistency()
   {
     auto &dof_handler = this->dof_handler();
+    auto &affine_constraints = this->affine_constraints();
 
     /*
      * A small lambda to check for stride-level consistency of the internal
@@ -234,7 +235,7 @@ namespace ryujin
      * node constraints). Therefore, the following little dance:
      */
 
-    if (mpi_allreduce_logical_or(affine_constraints_.n_constraints() > 0)) {
+    if (mpi_allreduce_logical_or(affine_constraints.n_constraints() > 0)) {
       if (mpi_allreduce_logical_or( //
               consistent_stride_range() != n_locally_internal_)) {
         /*
@@ -265,20 +266,122 @@ namespace ryujin
 
   /*
    * Populates:
+   *     affine_constraints_cg_
+   *     affine_constraints_dg_
    *     n_locally_owned_
-   *     affine_constraints_
    *     sparsity_pattern_
    */
   template <int dim, typename Number>
   void OfflineData<dim, Number>::create_constraints_and_sparsity_pattern()
   {
     /*
-     * First, we set up the locally_relevant index set, determine (globally
-     * indexed) affine constraints and create a (globally indexed) sparsity
-     * pattern:
+     * First, we set up the (globally indexed) affine constraints object
+     * for the continuous dof handler. The affine constraints object solely
+     * stores (a) hanging node constraints, and (b) periodicity constraints.
      */
 
-    auto &dof_handler = this->dof_handler();
+    const auto populate_affine_constraints = //
+        [&](const auto &dof_handler, auto &affine_constraints) {
+          const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
+
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+          const auto locally_relevant =
+              DoFTools::extract_locally_relevant_dofs(dof_handler);
+#else
+          IndexSet locally_relevant;
+          DoFTools::extract_locally_relevant_dofs(dof_handler,
+                                                  locally_relevant);
+#endif
+
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+          affine_constraints.reinit(locally_owned, locally_relevant);
+#else
+          affine_constraints.reinit(locally_relevant);
+#endif
+          DoFTools::make_hanging_node_constraints(dof_handler,
+                                                  affine_constraints);
+
+#ifndef DEAL_II_WITH_TRILINOS
+          AssertThrow(
+              affine_constraints.n_constraints() == 0,
+              ExcMessage("ryujin was built without Trilinos support - no "
+                         "hanging node support available"));
+#endif
+
+          /*
+           * Enforce periodic boundary conditions. We assume that the mesh is in
+           * "normal configuration."
+           */
+
+          const auto &periodic_faces =
+              discretization_->triangulation().get_periodic_face_map();
+
+          for (const auto &[left, value] : periodic_faces) {
+            const auto &[right, orientation] = value;
+
+            typename DoFHandler<dim>::cell_iterator dof_cell_left(
+                &left.first->get_triangulation(),
+                left.first->level(),
+                left.first->index(),
+                &dof_handler);
+
+            typename DoFHandler<dim>::cell_iterator dof_cell_right(
+                &right.first->get_triangulation(),
+                right.first->level(),
+                right.first->index(),
+                &dof_handler);
+
+            if constexpr (std::is_same_v<Number, double>) {
+              DoFTools::make_periodicity_constraints(
+                  dof_cell_left->face(left.second),
+                  dof_cell_right->face(right.second),
+                  affine_constraints,
+                  ComponentMask(),
+#if DEAL_II_VERSION_GTE(9, 6, 0)
+                  orientation);
+#else
+                  /* orientation */ orientation[0],
+                  /* flip */ orientation[1],
+                  /* rotation */ orientation[2]);
+#endif
+            } else {
+              AssertThrow(false, dealii::ExcNotImplemented());
+              __builtin_trap();
+            }
+          }
+
+          affine_constraints.close();
+
+#ifdef DEBUG
+          {
+            /* Check that constraints are consistent in parallel: */
+            const std::vector<IndexSet> &locally_owned_dofs =
+                Utilities::MPI::all_gather(
+                    mpi_ensemble_.ensemble_communicator(),
+                    dof_handler.locally_owned_dofs());
+            const IndexSet locally_active =
+                dealii::DoFTools::extract_locally_active_dofs(dof_handler);
+            Assert(affine_constraints.is_consistent_in_parallel(
+                       locally_owned_dofs,
+                       locally_active,
+                       mpi_ensemble_.ensemble_communicator(),
+                       /*verbose*/ true),
+                   ExcInternalError());
+          }
+#endif
+        };
+
+    populate_affine_constraints(*dof_handler_cg_, affine_constraints_cg_);
+    /* FIXME for dG the affine constraints object will be empty. */
+    populate_affine_constraints(*dof_handler_dg_, affine_constraints_dg_);
+
+
+    /*
+     * Next, set up the (hyperbolic) sparsity pattern:
+     */
+
+    const auto &dof_handler = this->dof_handler();
+    const auto &affine_constraints = this->affine_constraints();
     const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
     Assert(n_locally_owned_ == locally_owned.n_elements(),
            dealii::ExcInternalError());
@@ -291,80 +394,6 @@ namespace ryujin
     DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant);
 #endif
 
-#if DEAL_II_VERSION_GTE(9, 6, 0)
-    affine_constraints_.reinit(locally_owned, locally_relevant);
-#else
-    affine_constraints_.reinit(locally_relevant);
-#endif
-    DoFTools::make_hanging_node_constraints(dof_handler, affine_constraints_);
-
-#ifndef DEAL_II_WITH_TRILINOS
-    AssertThrow(affine_constraints_.n_constraints() == 0,
-                ExcMessage("ryujin was built without Trilinos support - no "
-                           "hanging node support available"));
-#endif
-
-    /*
-     * Enforce periodic boundary conditions. We assume that the mesh is in
-     * "normal configuration."
-     */
-
-    const auto &periodic_faces =
-        discretization_->triangulation().get_periodic_face_map();
-
-    for (const auto &[left, value] : periodic_faces) {
-      const auto &[right, orientation] = value;
-
-      typename DoFHandler<dim>::cell_iterator dof_cell_left(
-          &left.first->get_triangulation(),
-          left.first->level(),
-          left.first->index(),
-          &dof_handler);
-
-      typename DoFHandler<dim>::cell_iterator dof_cell_right(
-          &right.first->get_triangulation(),
-          right.first->level(),
-          right.first->index(),
-          &dof_handler);
-
-      if constexpr (std::is_same_v<Number, double>) {
-        DoFTools::make_periodicity_constraints(
-            dof_cell_left->face(left.second),
-            dof_cell_right->face(right.second),
-            affine_constraints_,
-            ComponentMask(),
-#if DEAL_II_VERSION_GTE(9, 6, 0)
-            orientation);
-#else
-            /* orientation */ orientation[0],
-            /* flip */ orientation[1],
-            /* rotation */ orientation[2]);
-#endif
-      } else {
-        AssertThrow(false, dealii::ExcNotImplemented());
-        __builtin_trap();
-      }
-    }
-
-    affine_constraints_.close();
-
-#ifdef DEBUG
-    {
-      /* Check that constraints are consistent in parallel: */
-      const std::vector<IndexSet> &locally_owned_dofs =
-          Utilities::MPI::all_gather(mpi_ensemble_.ensemble_communicator(),
-                                     dof_handler.locally_owned_dofs());
-      const IndexSet locally_active =
-          dealii::DoFTools::extract_locally_active_dofs(dof_handler);
-      Assert(affine_constraints_.is_consistent_in_parallel(
-                 locally_owned_dofs,
-                 locally_active,
-                 mpi_ensemble_.ensemble_communicator(),
-                 /*verbose*/ true),
-             ExcInternalError());
-    }
-#endif
-
     sparsity_pattern_.reinit(
         dof_handler.n_dofs(), dof_handler.n_dofs(), locally_relevant);
 
@@ -373,14 +402,14 @@ namespace ryujin
        * Create dG sparsity pattern:
        */
       DoFTools::make_extended_sparsity_pattern_dg(
-          dof_handler, sparsity_pattern_, affine_constraints_, false);
+          dof_handler, sparsity_pattern_, affine_constraints, false);
     } else {
       /*
        * Create cG sparsity pattern:
        */
 #ifdef DEAL_II_WITH_TRILINOS
       DoFTools::make_sparsity_pattern(
-          dof_handler, sparsity_pattern_, affine_constraints_, false);
+          dof_handler, sparsity_pattern_, affine_constraints, false);
 #else
       /*
        * In case we use dealii::SparseMatrix<Number> for assembly we need a
@@ -389,7 +418,7 @@ namespace ryujin
        * but nevertheless we have to add it.
        */
       DoFTools::make_extended_sparsity_pattern(
-          dof_handler, sparsity_pattern_, affine_constraints_, false);
+          dof_handler, sparsity_pattern_, affine_constraints, false);
 #endif
     }
 
@@ -420,7 +449,8 @@ namespace ryujin
       const unsigned int problem_dimension,
       const unsigned int n_precomputed_values)
   {
-    auto &dof_handler = this->dof_handler();
+    const auto &dof_handler = this->dof_handler();
+    const auto &affine_constraints = this->affine_constraints();
     const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
     Assert(n_locally_owned_ == locally_owned.n_elements(),
            dealii::ExcInternalError());
@@ -474,7 +504,7 @@ namespace ryujin
      * call export_indices_first() with incomplete information (missing
      * eliminated degrees of freedom).
      */
-    if (mpi_allreduce_logical_or(affine_constraints_.n_constraints() > 0)) {
+    if (mpi_allreduce_logical_or(affine_constraints.n_constraints() > 0)) {
       /*
        * Recalculate n_export_indices_:
        */
@@ -537,7 +567,8 @@ namespace ryujin
      * Then, assemble:
      */
 
-    auto &dof_handler = this->dof_handler();
+    const auto &dof_handler = this->dof_handler();
+    const auto &affine_constraints = this->affine_constraints();
 
     measure_of_omega_ = 0.;
 
@@ -547,12 +578,12 @@ namespace ryujin
     AffineConstraints<double> affine_constraints_assembly;
     /* This small dance is necessary to translate from Number to double: */
 #if DEAL_II_VERSION_GTE(9, 6, 0)
-    affine_constraints_assembly.reinit(affine_constraints_.get_local_lines(),
-                                       affine_constraints_.get_local_lines());
+    affine_constraints_assembly.reinit(affine_constraints.get_local_lines(),
+                                       affine_constraints.get_local_lines());
 #else
-    affine_constraints_assembly.reinit(affine_constraints_.get_local_lines());
+    affine_constraints_assembly.reinit(affine_constraints.get_local_lines());
 #endif
-    for (auto line : affine_constraints_.get_lines()) {
+    for (auto line : affine_constraints.get_lines()) {
       affine_constraints_assembly.add_line(line.index);
       for (auto entry : line.entries)
         affine_constraints_assembly.add_entry(
@@ -585,7 +616,7 @@ namespace ryujin
     /* Variant using deal.II SparseMatrix with local numbering */
 
     AffineConstraints<Number> affine_constraints_assembly;
-    affine_constraints_assembly.copy_from(affine_constraints_);
+    affine_constraints_assembly.copy_from(affine_constraints);
     transform_to_local_range(*scalar_partitioner_, affine_constraints_assembly);
 
     SparsityPattern sparsity_pattern_assembly;

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -189,7 +189,6 @@ namespace ryujin
   void OfflineData<dim, Number>::ensure_simd_stride_consistency()
   {
     auto &dof_handler = this->dof_handler();
-    auto &affine_constraints = this->affine_constraints();
 
     /*
      * A small lambda to check for stride-level consistency of the internal
@@ -235,6 +234,7 @@ namespace ryujin
      * node constraints). Therefore, the following little dance:
      */
 
+    const auto &affine_constraints = this->affine_constraints();
     if (mpi_allreduce_logical_or(affine_constraints.n_constraints() > 0)) {
       if (mpi_allreduce_logical_or( //
               consistent_stride_range() != n_locally_internal_)) {
@@ -282,8 +282,6 @@ namespace ryujin
 
     const auto populate_affine_constraints = //
         [&](const auto &dof_handler, auto &affine_constraints) {
-          const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
-
 #if DEAL_II_VERSION_GTE(9, 6, 0)
           const auto locally_relevant =
               DoFTools::extract_locally_relevant_dofs(dof_handler);
@@ -294,6 +292,7 @@ namespace ryujin
 #endif
 
 #if DEAL_II_VERSION_GTE(9, 6, 0)
+          const IndexSet &locally_owned = dof_handler.locally_owned_dofs();
           affine_constraints.reinit(locally_owned, locally_relevant);
 #else
           affine_constraints.reinit(locally_relevant);

--- a/source/state_vector.h
+++ b/source/state_vector.h
@@ -32,11 +32,13 @@ namespace ryujin
     template <typename Number>
     using ScalarVector = dealii::LinearAlgebra::distributed::Vector<Number>;
 
+
     /**
      * Shorthand for dealii::LinearAlgebra::distributed::BlockVector<Number>.
      */
     template <typename Number>
     using BlockVector = dealii::LinearAlgebra::distributed::BlockVector<Number>;
+
 
     /**
      * A compound state vector formed by a std::tuple consisting of the
@@ -108,46 +110,5 @@ namespace ryujin
       }
 #endif
     }
-
-
-    /**
-     * Helper function that (re)initializes the state and the precomputed
-     * component of a StateVector to proper sizes.
-     *
-     * @note This method does neither initialize nor resize the parabolic
-     * state vector component. The ParabolicModule itself has to ensure
-     * proper setup during prepare_state_vector() and solve().
-     */
-    template <
-        typename Description,
-        int dim,
-        typename Number,
-        typename View =
-            typename Description::template HyperbolicSystemView<dim, Number>,
-        int problem_dimension = View::problem_dimension,
-        int prec_dimension = View::n_precomputed_values>
-    void reinit_state_vector(
-        StateVector<Number, problem_dimension, prec_dimension> &state_vector,
-        const OfflineData<dim, Number> &offline_data)
-    {
-      auto &[U, precomputed, V] = state_vector;
-      U.reinit(offline_data.hyperbolic_vector_partitioner());
-      precomputed.reinit(offline_data.precomputed_vector_partitioner());
-
-#ifdef DEBUG
-      /* Poison all vectors: */
-      using state_type = typename View::state_type;
-
-      constexpr auto nan = std::numeric_limits<Number>::signaling_NaN();
-
-      const unsigned int n_owned = offline_data.n_locally_owned();
-      for (unsigned int i = 0; i < n_owned; ++i) {
-        U.write_tensor(state_type{} * nan, i);
-        precomputed.write_tensor(
-            dealii::Tensor<1, prec_dimension, Number>() * nan, i);
-      }
-#endif
-    }
   } // namespace Vectors
-
 } // namespace ryujin

--- a/source/state_vector.h
+++ b/source/state_vector.h
@@ -101,22 +101,22 @@ namespace ryujin
 
       constexpr auto nan = std::numeric_limits<Number>::signaling_NaN();
       const unsigned int n_owned = offline_data.n_locally_owned();
-      const auto block_size = offline_data.n_parabolic_state_vectors();
 
       for (unsigned int i = 0; i < n_owned; ++i) {
         precomputed.write_tensor(
             dealii::Tensor<1, prec_dimension, Number>() * nan, i);
-        for (unsigned int b = 0; b < block_size; ++b) {
-          V.block(b).local_element(i) = nan;
-        }
       }
 #endif
     }
 
 
     /**
-     * Helper function that (re)initializes all components of a StateVector
-     * to proper sizes.
+     * Helper function that (re)initializes the state and the precomputed
+     * component of a StateVector to proper sizes.
+     *
+     * @note This method does neither initialize nor resize the parabolic
+     * state vector component. The ParabolicModule itself has to ensure
+     * proper setup during prepare_state_vector() and solve().
      */
     template <
         typename Description,
@@ -134,12 +134,6 @@ namespace ryujin
       U.reinit(offline_data.hyperbolic_vector_partitioner());
       precomputed.reinit(offline_data.precomputed_vector_partitioner());
 
-      const auto block_size = offline_data.n_parabolic_state_vectors();
-      V.reinit(block_size);
-      for (unsigned int i = 0; i < block_size; ++i) {
-        V.block(i).reinit(offline_data.scalar_partitioner());
-      }
-
 #ifdef DEBUG
       /* Poison all vectors: */
       using state_type = typename View::state_type;
@@ -151,9 +145,6 @@ namespace ryujin
         U.write_tensor(state_type{} * nan, i);
         precomputed.write_tensor(
             dealii::Tensor<1, prec_dimension, Number>() * nan, i);
-        for (unsigned int b = 0; b < block_size; ++b) {
-          V.block(b).local_element(i) = nan;
-        }
       }
 #endif
     }

--- a/source/stub_parabolic_module.h
+++ b/source/stub_parabolic_module.h
@@ -78,10 +78,13 @@ namespace ryujin
     //@{
 
     /**
-     * Sets the invariant domain violation strategy.
+     * (Re)initialize the parabolic state vector component of the state
+     * vector.
+     *
+     * @note This routine does not modify the hyperbolic state vector or
+     * the precomputed vector component.
      */
-    void set_id_violation_strategy(
-        const IDViolationStrategy & /*new_strategy*/) const
+    void reinit_state_vector(StateVector & /*state_vector*/) const
     {
       // do nothing
     }
@@ -145,6 +148,15 @@ namespace ryujin
                                 "function should have never been called."));
 
       new_state_vector = old_state_vector;
+    }
+
+    /**
+     * Sets the invariant domain violation strategy.
+     */
+    void set_id_violation_strategy(
+        const IDViolationStrategy & /*new_strategy*/) const
+    {
+      // do nothing
     }
 
     //@}

--- a/source/stub_parabolic_system.h
+++ b/source/stub_parabolic_system.h
@@ -37,11 +37,6 @@ namespace ryujin
      */
     StubParabolicSystem(const std::string &subsection = "/ParabolicSystem");
 
-    unsigned int n_parabolic_state_vectors() const
-    {
-      return parabolic_component_names_.size();
-    }
-
     ACCESSOR_READ_ONLY(parabolic_component_names);
 
   private:

--- a/source/time_integrator.template.h
+++ b/source/time_integrator.template.h
@@ -148,7 +148,8 @@ namespace ryujin
     /* Initialize temporary vectors: */
 
     for (auto &it : temp_) {
-      Vectors::reinit_state_vector<Description>(it, *offline_data_);
+      hyperbolic_module_->reinit_state_vector(it);
+      parabolic_module_->reinit_state_vector(it);
     }
 
     /* Reset CFL to starting value, set maximal acceptable tau_max ratio: */

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -313,7 +313,8 @@ namespace ryujin
 
         prepare_compute_kernels();
 
-        Vectors::reinit_state_vector<Description>(state_vector, offline_data_);
+        hyperbolic_module_.reinit_state_vector(state_vector);
+        parabolic_module_.reinit_state_vector(state_vector);
         std::get<0>(state_vector) =
             initial_values_.get().interpolate_hyperbolic_vector();
 
@@ -373,7 +374,8 @@ namespace ryujin
           {
             Scope scope(computing_timer_,
                         "time step [X]   - interpolate analytic solution");
-            Vectors::reinit_state_vector<Description>(analytic, offline_data_);
+            hyperbolic_module_.reinit_state_vector(analytic);
+            parabolic_module_.reinit_state_vector(analytic);
             std::get<0>(analytic) =
                 initial_values_.get().interpolate_hyperbolic_vector(t);
           }
@@ -608,7 +610,8 @@ namespace ryujin
 
     /* Now read in the state vector: */
 
-    Vectors::reinit_state_vector<Description>(state_vector, offline_data_);
+    hyperbolic_module_.reinit_state_vector(state_vector);
+    parabolic_module_.reinit_state_vector(state_vector);
 
     solution_transfer_.set_handle(transfer_handle);
     solution_transfer_.project(state_vector);
@@ -706,7 +709,9 @@ namespace ryujin
     triangulation.execute_coarsening_and_refinement();
     prepare_compute_kernels();
 
-    Vectors::reinit_state_vector<Description>(state_vector, offline_data_);
+    hyperbolic_module_.reinit_state_vector(state_vector);
+    parabolic_module_.reinit_state_vector(state_vector);
+
     solution_transfer_.project(state_vector);
     solution_transfer_.reset_handle();
 

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -270,11 +270,7 @@ namespace ryujin
     const auto prepare_compute_kernels = [&]() {
       print_info("preparing compute kernels");
 
-      unsigned int n_parabolic_state_vectors =
-          parabolic_system_.get().n_parabolic_state_vectors();
-
-      offline_data_.prepare(
-          problem_dimension, n_precomputed_values, n_parabolic_state_vectors);
+      offline_data_.prepare(problem_dimension, n_precomputed_values);
 
       hyperbolic_module_.prepare();
       parabolic_module_.prepare();

--- a/source/vtu_output.template.h
+++ b/source/vtu_output.template.h
@@ -84,7 +84,7 @@ namespace ryujin
   void VTUOutput<Description, dim, Number>::schedule_output(
       const StateVector &state_vector,
       std::string name,
-      Number t,
+      Number t [[maybe_unused]],
       unsigned int cycle,
       bool output_full,
       bool output_levelsets)
@@ -149,9 +149,11 @@ namespace ryujin
                                 postprocessor_->component_names()[i]);
     }
 
+#if DEAL_II_VERSION_GTE(9, 5, 0)
     DataOutBase::VtkFlags flags(
         t, cycle, true, DataOutBase::CompressionLevel::best_speed);
     data_out->set_flags(flags);
+#endif
 
     const auto &discretization = offline_data_->discretization();
     const auto &mapping = discretization.mapping();

--- a/source/vtu_output.template.h
+++ b/source/vtu_output.template.h
@@ -92,7 +92,6 @@ namespace ryujin
 #ifdef DEBUG_OUTPUT
     std::cout << "VTUOutput<dim, Number>::schedule_output()" << std::endl;
 #endif
-    const auto &affine_constraints = offline_data_->affine_constraints();
 
     /*
      * Extract quantities and store in ScalarVectors so that we can call
@@ -110,33 +109,48 @@ namespace ryujin
             {alpha_, smoothness_indicators_},
             vtu_output_quantities_);
 
-    /* prepare DataOut: */
+    /*
+     * Attach data vectors to DataOut object:
+     */
 
     auto data_out = std::make_unique<dealii::DataOut<dim>>();
-    data_out->attach_dof_handler(offline_data_->dof_handler());
+
+    const auto attach_data_vector = [&](auto &data, const auto &name) {
+      const auto &dof_handler_cg = offline_data_->dof_handler_cg();
+      const auto &dof_handler_dg = offline_data_->dof_handler_dg();
+
+      if (data.size() == dof_handler_cg.n_dofs()) {
+        offline_data_->affine_constraints_cg().distribute(data);
+        data.update_ghost_values();
+        data_out->add_data_vector(dof_handler_cg, data, name);
+
+      } else if (data.size() == dof_handler_dg.n_dofs()) {
+        offline_data_->affine_constraints_dg().distribute(data);
+        data.update_ghost_values();
+        data_out->add_data_vector(dof_handler_dg, data, name);
+
+      } else {
+        Assert(
+            false,
+            dealii::ExcMessage("The selected solution component »" + name +
+                               "« is associated with an unknown dof handler"));
+      }
+    };
 
     for (unsigned int d = 0; d < selected_components.size(); ++d) {
-      affine_constraints.distribute(selected_components[d]);
-      selected_components[d].update_ghost_values();
-      data_out->add_data_vector(selected_components[d],
-                                vtu_output_quantities_[d],
-                                DataOut<dim>::type_dof_data);
+      attach_data_vector(selected_components[d], vtu_output_quantities_[d]);
     }
 
     const auto n_quantities = postprocessor_->n_quantities();
-    for (unsigned int i = 0; i < n_quantities; ++i)
-      data_out->add_data_vector(postprocessor_->quantities()[i],
-                                postprocessor_->component_names()[i],
-                                DataOut<dim>::type_dof_data);
+    for (unsigned int i = 0; i < n_quantities; ++i) {
+      // FIXME maybe also refactor to use attach_data_vector()
+      data_out->add_data_vector(offline_data_->dof_handler(),
+                                postprocessor_->quantities()[i],
+                                postprocessor_->component_names()[i]);
+    }
 
-    DataOutBase::VtkFlags flags(t,
-                                cycle,
-                                true,
-#if DEAL_II_VERSION_GTE(9, 5, 0)
-                                DataOutBase::CompressionLevel::best_speed);
-#else
-                                DataOutBase::VtkFlags::best_speed);
-#endif
+    DataOutBase::VtkFlags flags(
+        t, cycle, true, DataOutBase::CompressionLevel::best_speed);
     data_out->set_flags(flags);
 
     const auto &discretization = offline_data_->discretization();


### PR DESCRIPTION
This pull request refactors the setup of the parabolic state vector component such that it is handled entirely by the ParabolicModule. Add support for outputting data vectors associated with either of the two dof handlers.
