### PR TITLE
MPIEnsembles: refactor setup, enable declaration of ensembles in equation Description struct

### DIFF
--- a/source/mpi_ensemble.cc
+++ b/source/mpi_ensemble.cc
@@ -18,6 +18,11 @@ namespace ryujin
       , n_ensembles_(1)
       , ensemble_rank_(0)
       , n_ensemble_ranks_(1)
+      , world_group_(MPI_GROUP_NULL)
+      , ensemble_leader_group_(MPI_GROUP_NULL)
+      , ensemble_communicator_(MPI_COMM_NULL)
+      , ensemble_leader_communicator_(MPI_COMM_NULL)
+      , peer_communicator_(MPI_COMM_NULL)
   {
 #ifdef DEBUG_OUTPUT
     std::cout << "MPIEnsemble::prepare()" << std::endl;
@@ -32,6 +37,23 @@ namespace ryujin
 
     AssertThrow(n_ensembles_ > 0, dealii::ExcInternalError());
     ensemble_ = world_rank_ % n_ensembles_;
+
+    /*
+     * Special case for MPI_COMM_SELF:
+     *
+     * If the ensemble is initialized with the MPI_COMM_SELF communicator,
+     * skip setting up the communicators for the case that n_ensembles_ > 1.
+     * This only serves the purpose that we can create a TimeLoop instance
+     * long enough to query for parameters.
+     */
+
+    Assert(MPI_COMM_SELF != MPI_COMM_WORLD,
+           dealii::ExcMessage(
+               "MPIEnsemble: Internal sanity check failed. MPI_COMM_SELF and "
+               "MPI_COMM_WORLD are the same object."));
+
+    if (mpi_communicator == MPI_COMM_SELF && n_ensembles_ > 1)
+      return;
 
     AssertThrow(
         n_world_ranks_ >= n_ensembles_,
@@ -106,14 +128,19 @@ namespace ryujin
 
   MPIEnsemble::~MPIEnsemble()
   {
-    MPI_Group_free(&world_group_);
+    if (world_group_ != MPI_GROUP_NULL)
+      MPI_Group_free(&world_group_);
     for (auto &it : ensemble_groups_)
       MPI_Group_free(&it);
-    MPI_Group_free(&ensemble_leader_group_);
+    if (ensemble_leader_group_ != MPI_GROUP_NULL)
+      MPI_Group_free(&ensemble_leader_group_);
 
-    MPI_Comm_free(&ensemble_communicator_);
-    MPI_Comm_free(&ensemble_leader_communicator_);
-    MPI_Comm_free(&peer_communicator_);
+    if (ensemble_communicator_ != MPI_COMM_NULL)
+      MPI_Comm_free(&ensemble_communicator_);
+    if (ensemble_leader_communicator_ != MPI_COMM_NULL)
+      MPI_Comm_free(&ensemble_leader_communicator_);
+    if (peer_communicator_ != MPI_COMM_NULL)
+      MPI_Comm_free(&peer_communicator_);
   }
 
 } /* namespace ryujin */

--- a/source/mpi_ensemble_container.h
+++ b/source/mpi_ensemble_container.h
@@ -87,4 +87,19 @@ namespace ryujin
   };
 
 
+  /**
+   * A trait class that determines whether a given equation Description
+   * struct contains a method or field "n_mpi_ensembles".
+   */
+  namespace
+  {
+    template <typename C>
+    static auto test(...) -> std::false_type;
+
+    template <typename C>
+    static auto test(int) -> decltype(C::n_mpi_ensembles(), std::true_type());
+  } // namespace
+
+  template <typename T>
+  constexpr bool has_n_mpi_ensembles_v = decltype(test<T>(0))::value;
 } /* namespace ryujin */

--- a/source/mpi_ensemble_container.h
+++ b/source/mpi_ensemble_container.h
@@ -47,7 +47,7 @@ namespace ryujin
     {
       const auto &ensemble = mpi_ensemble.ensemble();
       const auto &n_ensembles = mpi_ensemble.n_ensembles();
-      unsigned int digits = dealii::Utilities::needed_digits(n_ensembles);
+      unsigned int digits = dealii::Utilities::needed_digits(n_ensembles - 1);
 
       payload_.resize(n_ensembles);
       for (int n = 0; n < n_ensembles; ++n) {

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -251,9 +251,11 @@ namespace ryujin
       base_name_ensemble_ = base_name_;
       if (mpi_ensemble_.n_ensembles() > 1) {
         print_info("setting up MPI ensemble");
-        base_name_ensemble_ += "-ensemble_" + dealii::Utilities::int_to_string(
-                                                  mpi_ensemble_.ensemble(),
-                                                  mpi_ensemble_.n_ensembles());
+        unsigned int digits =
+            dealii::Utilities::needed_digits(mpi_ensemble_.n_ensembles() - 1);
+        base_name_ensemble_ +=
+            "-ensemble_" +
+            dealii::Utilities::int_to_string(mpi_ensemble_.ensemble(), digits);
       }
     }
 

--- a/source/time_loop.template.h
+++ b/source/time_loop.template.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "instrumentation.h"
+#include "mpi_ensemble_container.h"
 #include "scope.h"
 #include "state_vector.h"
 #include "time_loop.h"
@@ -28,7 +28,13 @@ namespace ryujin
   template <typename Description, int dim, typename Number>
   TimeLoop<Description, dim, Number>::TimeLoop(const MPI_Comm &mpi_comm)
       : ParameterAcceptor("/A - TimeLoop")
-      , mpi_ensemble_(mpi_comm)
+      , mpi_ensemble_(mpi_comm,
+                      [] {
+                        if constexpr (has_n_mpi_ensembles_v<Description>)
+                          return Description::n_mpi_ensembles();
+                        else
+                          return 1;
+                      }())
       , hyperbolic_system_(mpi_ensemble_, "/B - Equation")
       , parabolic_system_(mpi_ensemble_, "/B - Equation")
       , discretization_(mpi_ensemble_, "/C - Discretization")


### PR DESCRIPTION
This pull request refactors the setup of MPI ensembles. We now rely on a `n_mpi_ensembles()` method in the Description struct that declares the number of required MPI ensembles for the given equation.
