### PR TITLE
Compute kernel rework: use new loop infrastructure everywhere

### DIFF
--- a/source/euler_poisson/laplace_operator.h
+++ b/source/euler_poisson/laplace_operator.h
@@ -6,9 +6,9 @@
 #pragma once
 
 #include <deal.II/base/config.h>
+#include <loop.h>
 #include <observer_pointer.h>
 #include <offline_data.h>
-#include <openmp.h>
 #include <simd.h>
 
 #include <deal.II/base/vectorization.h>
@@ -154,7 +154,7 @@ namespace ryujin
       ScalarVector &diagonal_vector = diagonal_matrix.get_vector();
       matrix_free_->initialize_dof_vector(diagonal_vector, /*CG*/ 0);
 
-      const auto body =
+      const auto body_matrix_free =
           [](const auto &data, auto &dst, const auto &, const auto range) {
             FEEvaluation<dim, order_fe, order_quad, /*components*/ 1, Number>
                 fee_read(data, /*CG*/ 0, /*lumped quadrature*/ 1);
@@ -187,7 +187,7 @@ namespace ryujin
 
       unsigned int dummy = 0;
       matrix_free_->template cell_loop<ScalarVector, unsigned int>(
-          body,
+          body_matrix_free,
           diagonal_vector,
           dummy,
           /*zero destination*/ true);
@@ -197,18 +197,16 @@ namespace ryujin
       const auto n_owned_cg =
           diagonal_vector.get_partitioner()->locally_owned_size();
 
-      RYUJIN_PARALLEL_REGION_BEGIN
-
-      RYUJIN_OMP_FOR
-      for (unsigned int i = 0; i < n_owned_cg; ++i) {
+      const auto body_invert = [&](auto sentinel, const unsigned int i) {
         constexpr Number eps = std::numeric_limits<Number>::epsilon();
-        diagonal_vector.local_element(i) =
-            std::abs(diagonal_vector.local_element(i)) > eps
-                ? 1. / diagonal_vector.local_element(i)
-                : Number(1.);
-      }
-
-      RYUJIN_PARALLEL_REGION_END
+        using T = decltype(sentinel);
+        const auto m_i = get_entry<T>(diagonal_vector, i);
+        constexpr auto gt = dealii::SIMDComparison::greater_than;
+        const auto m_i_inv = dealii::compare_and_apply_mask<gt>(
+            std::abs(m_i), T(eps), Number(1.) / m_i, T(1.));
+        write_entry<T>(diagonal_vector, m_i_inv, i);
+      };
+      cpu_simd_loop<Number>("", body_invert, 0, n_owned_cg, n_owned_cg);
     }
 
   private:

--- a/source/euler_poisson/parabolic_module.template.h
+++ b/source/euler_poisson/parabolic_module.template.h
@@ -10,7 +10,7 @@
 
 #include <convenience_macros.h>
 #include <instrumentation.h>
-#include <openmp.h>
+#include <loop.h>
 #include <scope.h>
 #include <simd.h>
 
@@ -560,34 +560,23 @@ namespace ryujin
 
       update_background_density(t);
 
-      RYUJIN_PARALLEL_REGION_BEGIN
-
-      auto loop = [&](auto sentinel, unsigned int left, unsigned int right) {
+      const auto body_copy = [&](auto sentinel, unsigned int i) {
         using T = decltype(sentinel);
-        unsigned int stride_size = get_stride_size<T>;
         const auto view = hyperbolic_system_->template view<dim, T>();
-
-        RYUJIN_OMP_FOR
-        for (unsigned int i = left; i < right; i += stride_size) {
-          const auto U_i = U.template get_tensor<T>(i);
-          const auto rho_i = view.density(U_i);
-          write_entry<T>(density_, rho_i, i);
-        }
+        const auto U_i = U.template get_tensor<T>(i);
+        const auto rho_i = view.density(U_i);
+        write_entry<T>(density_, rho_i, i);
       };
 
-      /* Parallel non-vectorized loop: */
-      loop(Number(), n_regular, n_owned);
-      /* Parallel vectorized SIMD loop: */
-      loop(VA(), 0, n_regular);
-
-      RYUJIN_PARALLEL_REGION_END
+      cpu_simd_loop<Number>(
+          "time_step_parabolic_1a", body_copy, 0, n_regular, n_owned);
 
       density_.update_ghost_values();
 
-      const auto body = [this](const auto &data,
-                               auto &dst,
-                               const auto &src,
-                               const auto range) {
+      const auto body_matrix_free = [this](const auto &data,
+                                           auto &dst,
+                                           const auto &src,
+                                           const auto range) {
         FEEvaluation<dim, order_fe, order_quad, /*components*/ 1, Number>
             fee_potential(data, /*CG*/ 0, /*lumped quadrature*/ 1);
         FEEvaluation<dim, order_fe, order_quad, /*components*/ 1, Number>
@@ -619,7 +608,7 @@ namespace ryujin
       };
 
       matrix_free_.template cell_loop<ScalarVector, ScalarVector>(
-          body,
+          body_matrix_free,
           potential_rhs_,
           density_,
           /*zero destination*/ true);
@@ -751,63 +740,49 @@ namespace ryujin
           potential,
           /*zero destination*/ true);
 
-      RYUJIN_PARALLEL_REGION_BEGIN
-
-      auto loop = [&](auto sentinel, unsigned int left, unsigned int right) {
+      const auto body = [&](auto sentinel, unsigned int i) {
         using T = decltype(sentinel);
-        unsigned int stride_size = get_stride_size<T>;
         const auto view = hyperbolic_system_->template view<dim, T>();
 
-        RYUJIN_OMP_FOR
-        for (unsigned int i = left; i < right; i += stride_size) {
-          const auto m_i_inv = get_entry<T>(lumped_mass_matrix_inverse, i);
+        const auto m_i_inv = get_entry<T>(lumped_mass_matrix_inverse, i);
 
-          auto U_i = U.template get_tensor<T>(i);
-          const auto rho_i = view.density(U_i);
-          const auto m_i = view.momentum(U_i);
-          const auto v_i = m_i / rho_i;
+        auto U_i = U.template get_tensor<T>(i);
+        const auto rho_i = view.density(U_i);
+        const auto m_i = view.momentum(U_i);
+        const auto v_i = m_i / rho_i;
 
-          dealii::Tensor<1, (dim == 2 ? 1 : dim), T> magnetic_field;
-          for (unsigned int d = 0; d < (dim == 2 ? 1 : dim); ++d)
-            magnetic_field[d] = get_entry<T>(magnetic_field_.block(d), i);
+        dealii::Tensor<1, (dim == 2 ? 1 : dim), T> magnetic_field;
+        for (unsigned int d = 0; d < (dim == 2 ? 1 : dim); ++d)
+          magnetic_field[d] = get_entry<T>(magnetic_field_.block(d), i);
 
-          dealii::Tensor<1, dim, T> grad_phi;
-          for (unsigned int d = 0; d < dim; ++d)
-            grad_phi[d] = m_i_inv * get_entry<T>(velocity_rhs_.block(d), i);
+        dealii::Tensor<1, dim, T> grad_phi;
+        for (unsigned int d = 0; d < dim; ++d)
+          grad_phi[d] = m_i_inv * get_entry<T>(velocity_rhs_.block(d), i);
 
-          auto new_v_i = v_i;
+        auto new_v_i = v_i;
 
-          if constexpr (dim == 2) {
-            new_v_i = -magnetic_field[0] * cross_product_2d(grad_phi) /
-                      magnetic_field.norm_square();
+        if constexpr (dim == 2) {
+          new_v_i = -magnetic_field[0] * cross_product_2d(grad_phi) /
+                    magnetic_field.norm_square();
 
-          } else if constexpr (dim == 3) {
-            new_v_i = -cross_product_3d(grad_phi, magnetic_field) /
-                      magnetic_field.norm_square();
-          }
-
-          for (unsigned int d = 0; d < dim; ++d)
-            U_i[1 + d] = rho_i * new_v_i[d];
-
-          /*
-           * Update the total energy accordingly:
-           */
-          if constexpr (view.have_energy_equation) {
-            U_i[1 + dim] += Number(0.5) * rho_i *
-                            (new_v_i.norm_square() - v_i.norm_square());
-          }
-
-          U.template write_tensor<T>(U_i, i);
+        } else if constexpr (dim == 3) {
+          new_v_i = -cross_product_3d(grad_phi, magnetic_field) /
+                    magnetic_field.norm_square();
         }
+
+        for (unsigned int d = 0; d < dim; ++d)
+          U_i[1 + d] = rho_i * new_v_i[d];
+
+        /* Update the total energy accordingly: */
+        if constexpr (view.have_energy_equation)
+          U_i[1 + dim] +=
+              Number(0.5) * rho_i * (new_v_i.norm_square() - v_i.norm_square());
+
+        U.template write_tensor<T>(U_i, i);
       };
 
-      /* Parallel non-vectorized loop: */
-      loop(Number(), n_regular, n_owned);
-      /* Parallel vectorized SIMD loop: */
-      loop(VA(), 0, n_regular);
-
-      RYUJIN_PARALLEL_REGION_END
-
+      cpu_simd_loop<Number>(
+          "time_step_parabolic_1c", body, 0, n_regular, n_owned);
 
       LIKWID_MARKER_STOP("time_step_parabolic_1c");
     }
@@ -892,39 +867,29 @@ namespace ryujin
          * to be set to the correct density for UpdateOperator::vmult()
          */
 
-        RYUJIN_PARALLEL_REGION_BEGIN
-
-        auto loop = [&](auto sentinel, unsigned int left, unsigned int right) {
+        const auto body_copy = [&](auto sentinel, unsigned int i) {
           using T = decltype(sentinel);
-          unsigned int stride_size = get_stride_size<T>;
           const auto view = hyperbolic_system_->template view<dim, T>();
 
-          RYUJIN_OMP_FOR
-          for (unsigned int i = left; i < right; i += stride_size) {
-            const auto U_i = old_U.template get_tensor<T>(i);
-            const auto rho_i = view.density(U_i);
-            const auto m_i = view.momentum(U_i);
+          const auto U_i = old_U.template get_tensor<T>(i);
+          const auto rho_i = view.density(U_i);
+          const auto m_i = view.momentum(U_i);
 
-            dealii::Tensor<1, (dim == 2 ? 1 : dim), T> magnetic_field;
-            for (unsigned int d = 0; d < (dim == 2 ? 1 : dim); ++d)
-              magnetic_field[d] = get_entry<T>(magnetic_field_.block(d), i);
+          dealii::Tensor<1, (dim == 2 ? 1 : dim), T> magnetic_field;
+          for (unsigned int d = 0; d < (dim == 2 ? 1 : dim); ++d)
+            magnetic_field[d] = get_entry<T>(magnetic_field_.block(d), i);
 
-            const auto velocity_rhs =
-                tau * alpha * rho_i *
-                apply_B_n_inverse(magnetic_field, tau, m_i / rho_i);
+          const auto velocity_rhs =
+              tau * alpha * rho_i *
+              apply_B_n_inverse(magnetic_field, tau, m_i / rho_i);
 
-            write_entry<T>(density_, rho_i, i);
-            for (unsigned int d = 0; d < dim; ++d)
-              write_entry<T>(velocity_rhs_.block(d), velocity_rhs[d], i);
-          }
+          write_entry<T>(density_, rho_i, i);
+          for (unsigned int d = 0; d < dim; ++d)
+            write_entry<T>(velocity_rhs_.block(d), velocity_rhs[d], i);
         };
 
-        /* Parallel non-vectorized loop: */
-        loop(Number(), n_regular, n_owned);
-        /* Parallel vectorized SIMD loop: */
-        loop(VA(), 0, n_regular);
-
-        RYUJIN_PARALLEL_REGION_END
+        cpu_simd_loop<Number>(
+            "time_step_parabolic_2a", body_copy, 0, n_regular, n_owned);
 
         density_.update_ghost_values();
 
@@ -1154,63 +1119,48 @@ namespace ryujin
        * Update the momentum and total energy:
        */
 
-      RYUJIN_PARALLEL_REGION_BEGIN
-
-      auto loop = [&](auto sentinel, unsigned int left, unsigned int right) {
+      const auto body = [&](auto sentinel, unsigned int i) {
         using T = decltype(sentinel);
-        unsigned int stride_size = get_stride_size<T>;
         const auto view = hyperbolic_system_->template view<dim, T>();
 
-        RYUJIN_OMP_FOR
-        for (unsigned int i = left; i < right; i += stride_size) {
-          const auto m_i_inv = get_entry<T>(lumped_mass_matrix_inverse, i);
+        const auto m_i_inv = get_entry<T>(lumped_mass_matrix_inverse, i);
 
-          const auto old_U_i = old_U.template get_tensor<T>(i);
-          const auto rho_i = view.density(old_U_i);
-          const auto old_m_i = view.momentum(old_U_i);
-          const auto old_v_i = old_m_i / rho_i;
+        const auto old_U_i = old_U.template get_tensor<T>(i);
+        const auto rho_i = view.density(old_U_i);
+        const auto old_m_i = view.momentum(old_U_i);
+        const auto old_v_i = old_m_i / rho_i;
 
-          dealii::Tensor<1, (dim == 2 ? 1 : dim), T> magnetic_field;
-          for (unsigned int d = 0; d < (dim == 2 ? 1 : dim); ++d)
-            magnetic_field[d] = get_entry<T>(magnetic_field_.block(d), i);
+        dealii::Tensor<1, (dim == 2 ? 1 : dim), T> magnetic_field;
+        for (unsigned int d = 0; d < (dim == 2 ? 1 : dim); ++d)
+          magnetic_field[d] = get_entry<T>(magnetic_field_.block(d), i);
 
-          dealii::Tensor<1, dim, T> grad_phi;
-          for (unsigned int d = 0; d < dim; ++d)
-            grad_phi[d] = m_i_inv * get_entry<T>(velocity_rhs_.block(d), i);
+        dealii::Tensor<1, dim, T> grad_phi;
+        for (unsigned int d = 0; d < dim; ++d)
+          grad_phi[d] = m_i_inv * get_entry<T>(velocity_rhs_.block(d), i);
 
-          auto new_v_i =
-              apply_B_n_inverse(magnetic_field, tau, old_v_i - tau * grad_phi);
+        auto new_v_i =
+            apply_B_n_inverse(magnetic_field, tau, old_v_i - tau * grad_phi);
 
-          /* Perform an extrapolation step: */
-          if (crank_nicolson_extrapolation)
-            new_v_i = Number(2.) * new_v_i - old_v_i;
+        /* Perform an extrapolation step: */
+        if (crank_nicolson_extrapolation)
+          new_v_i = Number(2.) * new_v_i - old_v_i;
 
-          auto new_U_i = old_U_i;
-          for (unsigned int d = 0; d < dim; ++d)
-            new_U_i[1 + d] = rho_i * new_v_i[d];
+        auto new_U_i = old_U_i;
+        for (unsigned int d = 0; d < dim; ++d)
+          new_U_i[1 + d] = rho_i * new_v_i[d];
 
-          /*
-           * Update the total energy accordingly:
-           */
-          if constexpr (view.have_energy_equation) {
-            new_U_i[1 + dim] += Number(0.5) * rho_i *
-                                (new_v_i.norm_square() - old_v_i.norm_square());
-          }
+        /* Update the total energy accordingly: */
+        if constexpr (view.have_energy_equation)
+          new_U_i[1 + dim] += Number(0.5) * rho_i *
+                              (new_v_i.norm_square() - old_v_i.norm_square());
 
-          new_U.template write_tensor<T>(new_U_i, i);
-        }
+        new_U.template write_tensor<T>(new_U_i, i);
       };
 
-      /* Parallel non-vectorized loop: */
-      loop(Number(), n_regular, n_owned);
-      /* Parallel vectorized SIMD loop: */
-      loop(VA(), 0, n_regular);
-
-      RYUJIN_PARALLEL_REGION_END
+      cpu_simd_loop<Number>(
+          "time_step_parabolic_2c", body, 0, n_regular, n_owned);
 
       LIKWID_MARKER_STOP("time_step_parabolic_2c");
-
-      return;
     }
 
 

--- a/source/euler_poisson/parabolic_module.template.h
+++ b/source/euler_poisson/parabolic_module.template.h
@@ -541,10 +541,7 @@ namespace ryujin
       auto &V = std::get<2>(state_vector);
       auto &potential = V.block(0);
 
-      using VA = VectorizedArray<Number>;
-      constexpr auto simd_length = VA::size();
       const unsigned int n_owned = offline_data_->n_locally_owned();
-      const unsigned int n_regular = n_owned / simd_length * simd_length;
 
       constexpr unsigned int order_fe = 1;
       constexpr unsigned int order_quad = 2;
@@ -569,7 +566,7 @@ namespace ryujin
       };
 
       cpu_simd_loop<Number>(
-          "time_step_parabolic_1a", body_copy, 0, n_regular, n_owned);
+          "time_step_parabolic_1a", body_copy, 0, n_owned, n_owned);
 
       density_.update_ghost_values();
 
@@ -692,10 +689,7 @@ namespace ryujin
       auto &V = std::get<2>(state_vector);
       auto &potential = V.block(0);
 
-      using VA = VectorizedArray<Number>;
-      constexpr auto simd_length = VA::size();
       const unsigned int n_owned = offline_data_->n_locally_owned();
-      const unsigned int n_regular = n_owned / simd_length * simd_length;
 
       const auto &lumped_mass_matrix_inverse =
           offline_data_->lumped_mass_matrix_inverse();
@@ -782,7 +776,7 @@ namespace ryujin
       };
 
       cpu_simd_loop<Number>(
-          "time_step_parabolic_1c", body, 0, n_regular, n_owned);
+          "time_step_parabolic_1c", body, 0, n_owned, n_owned);
 
       LIKWID_MARKER_STOP("time_step_parabolic_1c");
     }
@@ -813,10 +807,7 @@ namespace ryujin
       auto &new_V = std::get<2>(new_state_vector);
       auto &new_potential = new_V.block(0);
 
-      using VA = VectorizedArray<Number>;
-      constexpr auto simd_length = VA::size();
       const unsigned int n_owned = offline_data_->n_locally_owned();
-      const unsigned int n_regular = n_owned / simd_length * simd_length;
 
       const auto &lumped_mass_matrix_inverse =
           offline_data_->lumped_mass_matrix_inverse();
@@ -889,7 +880,7 @@ namespace ryujin
         };
 
         cpu_simd_loop<Number>(
-            "time_step_parabolic_2a", body_copy, 0, n_regular, n_owned);
+            "time_step_parabolic_2a", body_copy, 0, n_owned, n_owned);
 
         density_.update_ghost_values();
 
@@ -1158,7 +1149,7 @@ namespace ryujin
       };
 
       cpu_simd_loop<Number>(
-          "time_step_parabolic_2c", body, 0, n_regular, n_owned);
+          "time_step_parabolic_2c", body, 0, n_owned, n_owned);
 
       LIKWID_MARKER_STOP("time_step_parabolic_2c");
     }

--- a/source/loop.h
+++ b/source/loop.h
@@ -21,6 +21,9 @@ namespace ryujin
    * the remainder of the index range, i.e., [internal, right) a serial
    * loop is invoked.
    *
+   * @note the index internal is rounded down to the next integer multiple
+   * of the SIMD stride size.
+   *
    * @note Here, @p body is a functor that must accept a "sentinel" type as
    * first argument and the current index i as last argument. Additional
    * `args` may be specified in the cpu_simd_loop() invocation that will be
@@ -44,21 +47,19 @@ namespace ryujin
     RYUJIN_PARALLEL_REGION_BEGIN
     LIKWID_MARKER_START(region_name.c_str());
 
-    constexpr unsigned int simd_stride_size = get_stride_size<VA>;
-    Assert(internal % simd_stride_size == 0,
-           dealii::ExcMessage("Invalid index range: internal not divisible by "
-                              "simd_stride_size."));
+    constexpr unsigned int stride_size = get_stride_size<VA>;
+    const unsigned int regular = internal / stride_size * stride_size;
 
     /* SIMD vectorized loop: */
 
     RYUJIN_OMP_FOR
-    for (unsigned int i = left; i < internal; i += simd_stride_size)
+    for (unsigned int i = left; i < regular; i += stride_size)
       body(VA(), std::forward<Args>(args)..., i);
 
     /* Serial loop: */
 
     RYUJIN_OMP_FOR
-    for (unsigned int i = internal; i < right; i += 1)
+    for (unsigned int i = regular; i < right; i += 1)
       body(ScalarNumber(), std::forward<Args>(args)..., i);
 
     LIKWID_MARKER_STOP(region_name.c_str());

--- a/source/navier_stokes/parabolic_module.template.h
+++ b/source/navier_stokes/parabolic_module.template.h
@@ -313,16 +313,12 @@ namespace ryujin
       const auto &old_U = std::get<0>(old_state_vector);
       auto &new_U = std::get<0>(new_state_vector);
 
-      using VA = VectorizedArray<Number>;
-
       const auto &lumped_mass_matrix = offline_data_->lumped_mass_matrix();
       const auto &affine_constraints = offline_data_->affine_constraints();
 
       /* Index ranges for the iteration over the sparsity pattern : */
 
-      constexpr auto simd_length = VA::size();
       const unsigned int n_owned = offline_data_->n_locally_owned();
-      const unsigned int n_regular = n_owned / simd_length * simd_length;
 
       const auto &sparsity_simd = offline_data_->sparsity_pattern_simd();
 
@@ -398,7 +394,7 @@ namespace ryujin
         };
 
         cpu_simd_loop<Number>(
-            "time_step_parabolic_1", body, 0, n_regular, n_owned);
+            "time_step_parabolic_1", body, 0, n_owned, n_owned);
 
         /*
          * Set up "strongly enforced" boundary conditions that are not stored
@@ -704,7 +700,7 @@ namespace ryujin
         };
 
         cpu_simd_loop<Number>(
-            "time_step_parabolic_2", body, 0, n_regular, n_owned);
+            "time_step_parabolic_2", body, 0, n_owned, n_owned);
 
         /*
          * Set up "strongly enforced" boundary conditions that are not stored
@@ -942,7 +938,7 @@ namespace ryujin
         };
 
         cpu_simd_loop<Number>(
-            "time_step_parabolic_3", body, 0, n_regular, n_owned);
+            "time_step_parabolic_3", body, 0, n_owned, n_owned);
 
 
         LIKWID_MARKER_STOP("time_step_parabolic_3");

--- a/source/navier_stokes/parabolic_module.template.h
+++ b/source/navier_stokes/parabolic_module.template.h
@@ -8,7 +8,7 @@
 #include "parabolic_module.h"
 
 #include <instrumentation.h>
-#include <openmp.h>
+#include <loop.h>
 #include <scope.h>
 #include <simd.h>
 
@@ -376,39 +376,29 @@ namespace ryujin
        */
       {
         Scope scope(computing_timer_, "time step [P] 1 - update velocities");
-        RYUJIN_PARALLEL_REGION_BEGIN
-        LIKWID_MARKER_START("time_step_parabolic_1");
 
-        auto loop = [&](auto sentinel, unsigned int left, unsigned int right) {
+        const auto body = [&](auto sentinel, unsigned int i) {
           using T = decltype(sentinel);
-          unsigned int stride_size = get_stride_size<T>;
 
           const auto view = hyperbolic_system_->template view<dim, T>();
 
-          RYUJIN_OMP_FOR
-          for (unsigned int i = left; i < right; i += stride_size) {
-            const auto U_i = old_U.template get_tensor<T>(i);
-            const auto rho_i = view.density(U_i);
-            const auto M_i = view.momentum(U_i);
-            const auto rho_e_i = view.internal_energy(U_i);
-            const auto m_i = get_entry<T>(lumped_mass_matrix, i);
+          const auto U_i = old_U.template get_tensor<T>(i);
+          const auto rho_i = view.density(U_i);
+          const auto M_i = view.momentum(U_i);
+          const auto rho_e_i = view.internal_energy(U_i);
+          const auto m_i = get_entry<T>(lumped_mass_matrix, i);
 
-            write_entry<T>(density_, rho_i, i);
-            /* (5.4a) */
-            for (unsigned int d = 0; d < dim; ++d) {
-              write_entry<T>(velocity_.block(d), M_i[d] / rho_i, i);
-              write_entry<T>(velocity_rhs_.block(d), m_i * (M_i[d]), i);
-            }
-            write_entry<T>(internal_energy_, rho_e_i / rho_i, i);
+          write_entry<T>(density_, rho_i, i);
+          /* (5.4a) */
+          for (unsigned int d = 0; d < dim; ++d) {
+            write_entry<T>(velocity_.block(d), M_i[d] / rho_i, i);
+            write_entry<T>(velocity_rhs_.block(d), m_i * (M_i[d]), i);
           }
+          write_entry<T>(internal_energy_, rho_e_i / rho_i, i);
         };
 
-        /* Parallel non-vectorized loop: */
-        loop(Number(), n_regular, n_owned);
-        /* Parallel vectorized SIMD loop: */
-        loop(VA(), 0, n_regular);
-
-        RYUJIN_PARALLEL_REGION_END
+        cpu_simd_loop<Number>(
+            "time_step_parabolic_1", body, 0, n_regular, n_owned);
 
         /*
          * Set up "strongly enforced" boundary conditions that are not stored
@@ -681,50 +671,40 @@ namespace ryujin
 
         const auto &lumped_mass_matrix = offline_data_->lumped_mass_matrix();
 
-        RYUJIN_PARALLEL_REGION_BEGIN
-
-        auto loop = [&](auto sentinel, unsigned int left, unsigned int right) {
+        const auto body = [&](auto sentinel, unsigned int i) {
           using T = decltype(sentinel);
-          unsigned int stride_size = get_stride_size<T>;
 
           const auto view = hyperbolic_system_->template view<dim, T>();
 
-          RYUJIN_OMP_FOR
-          for (unsigned int i = left; i < right; i += stride_size) {
-            const auto rhs_i = get_entry<T>(internal_energy_rhs_, i);
-            const auto m_i = get_entry<T>(lumped_mass_matrix, i);
-            const auto rho_i = get_entry<T>(density_, i);
-            const auto e_i = get_entry<T>(internal_energy_, i);
+          const auto rhs_i = get_entry<T>(internal_energy_rhs_, i);
+          const auto m_i = get_entry<T>(lumped_mass_matrix, i);
+          const auto rho_i = get_entry<T>(density_, i);
+          const auto e_i = get_entry<T>(internal_energy_, i);
 
-            const auto U_i = old_U.template get_tensor<T>(i);
-            const auto V_i = view.momentum(U_i) / rho_i;
+          const auto U_i = old_U.template get_tensor<T>(i);
+          const auto V_i = view.momentum(U_i) / rho_i;
 
-            dealii::Tensor<1, dim, T> V_i_new;
-            for (unsigned int d = 0; d < dim; ++d) {
-              V_i_new[d] = get_entry<T>(velocity_.block(d), i);
-            }
-
-            /*
-             * For backward Euler we have to add this algebraic correction
-             * to ensure conservation of total energy.
-             */
-            const auto correction =
-                crank_nicolson_extrapolation
-                    ? T(0.)
-                    : Number(0.5) * (V_i - V_i_new).norm_square();
-
-            /* rhs_i contains already m_i K_i^{n+1/2} */
-            const auto result = m_i * rho_i * (e_i + correction) + tau * rhs_i;
-            write_entry<T>(internal_energy_rhs_, result, i);
+          dealii::Tensor<1, dim, T> V_i_new;
+          for (unsigned int d = 0; d < dim; ++d) {
+            V_i_new[d] = get_entry<T>(velocity_.block(d), i);
           }
+
+          /*
+           * For backward Euler we have to add this algebraic correction
+           * to ensure conservation of total energy.
+           */
+          const auto correction =
+              crank_nicolson_extrapolation
+                  ? T(0.)
+                  : Number(0.5) * (V_i - V_i_new).norm_square();
+
+          /* rhs_i contains already m_i K_i^{n+1/2} */
+          const auto result = m_i * rho_i * (e_i + correction) + tau * rhs_i;
+          write_entry<T>(internal_energy_rhs_, result, i);
         };
 
-        /* Parallel non-vectorized loop: */
-        loop(Number(), n_regular, n_owned);
-        /* Parallel vectorized SIMD loop: */
-        loop(VA(), 0, n_regular);
-
-        RYUJIN_PARALLEL_REGION_END
+        cpu_simd_loop<Number>(
+            "time_step_parabolic_2", body, 0, n_regular, n_owned);
 
         /*
          * Set up "strongly enforced" boundary conditions that are not stored
@@ -888,93 +868,84 @@ namespace ryujin
       {
         Scope scope(computing_timer_, "time step [P] 3 - write back vectors");
 
-        RYUJIN_PARALLEL_REGION_BEGIN
         LIKWID_MARKER_START("time_step_parabolic_3");
 
-        auto loop = [&](auto sentinel, unsigned int left, unsigned int right) {
+        const auto body = [&](auto sentinel, unsigned int i) {
           using T = decltype(sentinel);
-          unsigned int stride_size = get_stride_size<T>;
 
           const auto view = hyperbolic_system_->template view<dim, T>();
 
-          RYUJIN_OMP_FOR
-          for (unsigned int i = left; i < right; i += stride_size) {
+          /* Skip constrained degrees of freedom: */
+          const unsigned int row_length = sparsity_simd.row_length(i);
+          if (row_length == 1)
+            return;
 
-            /* Skip constrained degrees of freedom: */
-            const unsigned int row_length = sparsity_simd.row_length(i);
-            if (row_length == 1)
-              continue;
+          auto U_i = old_U.template get_tensor<T>(i);
+          const auto rho_i = view.density(U_i);
 
-            auto U_i = old_U.template get_tensor<T>(i);
-            const auto rho_i = view.density(U_i);
+          Tensor<1, dim, T> m_i_new;
+          for (unsigned int d = 0; d < dim; ++d) {
+            m_i_new[d] = rho_i * get_entry<T>(velocity_.block(d), i);
+          }
 
-            Tensor<1, dim, T> m_i_new;
-            for (unsigned int d = 0; d < dim; ++d) {
-              m_i_new[d] = rho_i * get_entry<T>(velocity_.block(d), i);
-            }
+          auto rho_e_i_new = rho_i * get_entry<T>(internal_energy_, i);
 
-            auto rho_e_i_new = rho_i * get_entry<T>(internal_energy_, i);
+          /*
+           * Check that the backward Euler step itself (which is our "low
+           * order" update) satisfies bounds. If not, signal a restart.
+           */
+
+          if (!(T(0.) == std::max(T(0.), rho_i * e_min_old - rho_e_i_new))) {
+#ifdef DEBUG_OUTPUT
+            std::cout << std::fixed << std::setprecision(16);
+            const auto e_i_new = rho_e_i_new / rho_i;
+            std::cout << "Bounds violation: internal energy (critical)!\n"
+                      << "\t\te_min_old:         " << e_min_old << "\n"
+                      << "\t\te_min_old (delta): "
+                      << negative_part(e_i_new - e_min_old) << "\n"
+                      << "\t\te_min_new:         " << e_i_new << "\n"
+                      << std::endl;
+#endif
+            restart_needed = true;
+          }
+
+          if (crank_nicolson_extrapolation) {
+            m_i_new = Number(2.0) * m_i_new - view.momentum(U_i);
+            rho_e_i_new = Number(2.0) * rho_e_i_new - view.internal_energy(U_i);
 
             /*
-             * Check that the backward Euler step itself (which is our "low
-             * order" update) satisfies bounds. If not, signal a restart.
+             * If we do perform an extrapolation step for Crank Nicolson
+             * we have to check whether we maintain admissibility
              */
 
-            if (!(T(0.) == std::max(T(0.), rho_i * e_min_old - rho_e_i_new))) {
+            if (!(T(0.) ==
+                  std::max(T(0.), eps * rho_i * e_min_old - rho_e_i_new))) {
 #ifdef DEBUG_OUTPUT
               std::cout << std::fixed << std::setprecision(16);
               const auto e_i_new = rho_e_i_new / rho_i;
-              std::cout << "Bounds violation: internal energy (critical)!\n"
-                        << "\t\te_min_old:         " << e_min_old << "\n"
-                        << "\t\te_min_old (delta): "
-                        << negative_part(e_i_new - e_min_old) << "\n"
+
+              std::cout << "Bounds violation: high-order internal energy!"
                         << "\t\te_min_new:         " << e_i_new << "\n"
-                        << std::endl;
+                        << "\t\t-- correction required --" << std::endl;
 #endif
-              restart_needed = true;
+              correction_needed = true;
             }
-
-            if (crank_nicolson_extrapolation) {
-              m_i_new = Number(2.0) * m_i_new - view.momentum(U_i);
-              rho_e_i_new =
-                  Number(2.0) * rho_e_i_new - view.internal_energy(U_i);
-
-              /*
-               * If we do perform an extrapolation step for Crank Nicolson
-               * we have to check whether we maintain admissibility
-               */
-
-              if (!(T(0.) ==
-                    std::max(T(0.), eps * rho_i * e_min_old - rho_e_i_new))) {
-#ifdef DEBUG_OUTPUT
-                std::cout << std::fixed << std::setprecision(16);
-                const auto e_i_new = rho_e_i_new / rho_i;
-
-                std::cout << "Bounds violation: high-order internal energy!"
-                          << "\t\te_min_new:         " << e_i_new << "\n"
-                          << "\t\t-- correction required --" << std::endl;
-#endif
-                correction_needed = true;
-              }
-            }
-
-            const auto E_i_new = rho_e_i_new + 0.5 * m_i_new * m_i_new / rho_i;
-
-            for (unsigned int d = 0; d < dim; ++d)
-              U_i[1 + d] = m_i_new[d];
-            U_i[1 + dim] = E_i_new;
-
-            new_U.template write_tensor<T>(U_i, i);
           }
+
+          const auto E_i_new = rho_e_i_new + 0.5 * m_i_new * m_i_new / rho_i;
+
+          for (unsigned int d = 0; d < dim; ++d)
+            U_i[1 + d] = m_i_new[d];
+          U_i[1 + dim] = E_i_new;
+
+          new_U.template write_tensor<T>(U_i, i);
         };
 
-        /* Parallel non-vectorized loop: */
-        loop(Number(), n_regular, n_owned);
-        /* Parallel vectorized SIMD loop: */
-        loop(VA(), 0, n_regular);
+        cpu_simd_loop<Number>(
+            "time_step_parabolic_3", body, 0, n_regular, n_owned);
+
 
         LIKWID_MARKER_STOP("time_step_parabolic_3");
-        RYUJIN_PARALLEL_REGION_END
 
         new_U.update_ghost_values();
       }

--- a/source/navier_stokes/parabolic_module_gmg_operators.h
+++ b/source/navier_stokes/parabolic_module_gmg_operators.h
@@ -74,9 +74,9 @@ namespace ryujin
 
         const auto body_invert = [&](auto sentinel, const unsigned int i) {
           using T = decltype(sentinel);
-          const auto m_i = get_entry<T>(*lumped_mass_matrix, i);
+          const auto m_i = get_entry<T>(lumped_mass_matrix, i);
           const auto rho_i = get_entry<T>(density, i);
-          diagonal.local_element(i) = Number(1.0) / (rho_i * m_i);
+          write_entry<T>(diagonal, Number(1.0) / (rho_i * m_i), i);
         };
 
         cpu_simd_loop<Number>("", body_invert, 0, n_owned, n_owned);
@@ -691,7 +691,7 @@ namespace ryujin
         const auto body_invert = [&](auto sentinel, const unsigned int i) {
           using T = decltype(sentinel);
 
-          const auto m_i = get_entry<T>(*lumped_mass_matrix, i);
+          const auto m_i = get_entry<T>(lumped_mass_matrix, i);
           const auto rho_i = get_entry<T>(*density_, i);
           write_entry<T>(
               vector, Number(1.) / (m_i * rho_i + get_entry<T>(vector, i)), i);

--- a/source/navier_stokes/parabolic_module_gmg_operators.h
+++ b/source/navier_stokes/parabolic_module_gmg_operators.h
@@ -7,9 +7,9 @@
 
 #include <compile_time_options.h>
 
+#include <loop.h>
 #include <observer_pointer.h>
 #include <offline_data.h>
-#include <openmp.h>
 #include <simd.h>
 
 #include "../euler/hyperbolic_system.h"
@@ -70,14 +70,16 @@ namespace ryujin
       {
         diagonal.reinit(density, true);
 
-        DEAL_II_OPENMP_SIMD_PRAGMA
-        for (unsigned int i = 0;
-             i < density.get_partitioner()->locally_owned_size();
-             ++i) {
-          diagonal.local_element(i) =
-              Number(1.0) /
-              (density.local_element(i) * lumped_mass_matrix.local_element(i));
-        }
+        const auto n_owned = density.get_partitioner()->locally_owned_size();
+
+        const auto body_invert = [&](auto sentinel, const unsigned int i) {
+          using T = decltype(sentinel);
+          const auto m_i = get_entry<T>(*lumped_mass_matrix, i);
+          const auto rho_i = get_entry<T>(density, i);
+          diagonal.local_element(i) = Number(1.0) / (rho_i * m_i);
+        };
+
+        cpu_simd_loop<Number>("", body_invert, 0, n_owned, n_owned);
 
         /*
          * Fix up diagonal entries for constrained degrees of freedom due to
@@ -194,12 +196,9 @@ namespace ryujin
       {
         /* Apply action of m_i rho_i V_i: */
 
-        using VA = dealii::VectorizedArray<Number>;
-        constexpr auto simd_length = VA::size();
-
         const vector_type *lumped_mass_matrix = nullptr;
-        if constexpr (std::is_same<Number, Number2>::value) {
-          if constexpr (std::is_same<Number, float>::value) {
+        if constexpr (std::is_same_v<Number, Number2>) {
+          if constexpr (std::is_same_v<Number, float>) {
             if (level_ == dealii::numbers::invalid_unsigned_int)
               lumped_mass_matrix = &offline_data_->lumped_mass_matrix();
             else
@@ -216,31 +215,19 @@ namespace ryujin
 
         const unsigned int n_owned =
             lumped_mass_matrix->get_partitioner()->locally_owned_size();
-        const unsigned int size_regular = n_owned / simd_length * simd_length;
 
-        RYUJIN_PARALLEL_REGION_BEGIN
+        const auto body_mass = [&](auto sentinel, unsigned int i) {
+          using T = decltype(sentinel);
 
-        RYUJIN_OMP_FOR
-        for (unsigned int i = 0; i < size_regular; i += simd_length) {
-          const auto m_i = get_entry<VA>(*lumped_mass_matrix, i);
-          const auto rho_i = get_entry<VA>(*density_, i);
+          const auto m_i = get_entry<T>(*lumped_mass_matrix, i);
+          const auto rho_i = get_entry<T>(*density_, i);
           for (unsigned int d = 0; d < dim; ++d) {
-            const auto temp = get_entry<VA>(src.block(d), i);
-            write_entry<VA>(dst.block(d), m_i * rho_i * temp, i);
+            const auto temp = get_entry<T>(src.block(d), i);
+            write_entry<T>(dst.block(d), m_i * rho_i * temp, i);
           }
-        }
+        };
 
-        RYUJIN_PARALLEL_REGION_END
-
-        for (unsigned int i = size_regular; i < n_owned; ++i) {
-          const auto m_i = lumped_mass_matrix->local_element(i);
-          const auto rho_i = density_->local_element(i);
-
-          for (unsigned int d = 0; d < dim; ++d) {
-            const auto temp = src.block(d).local_element(i);
-            dst.block(d).local_element(i) = m_i * rho_i * temp;
-          }
-        }
+        cpu_simd_loop<Number>("", body_mass, 0, n_owned, n_owned);
 
         /* Apply action of stress tensor: + theta * \sum_j B_ij V_j: */
 
@@ -349,18 +336,15 @@ namespace ryujin
         const unsigned int n_owned =
             lumped_mass_matrix.get_partitioner()->locally_owned_size();
 
-        RYUJIN_PARALLEL_REGION_BEGIN
-
-        RYUJIN_OMP_FOR
-        for (unsigned int i = 0; i < n_owned; ++i) {
+        const auto body_invert = [&](const auto &, const unsigned int i) {
           const auto m_i = lumped_mass_matrix.local_element(i);
           const auto rho_i = density_->local_element(i);
           for (unsigned int d = 0; d < dim; ++d)
             vector.block(d).local_element(i) =
-                1. / (m_i * rho_i + vector.block(d).local_element(i));
-        }
+                Number(1.) / (m_i * rho_i + vector.block(d).local_element(i));
+        };
 
-        RYUJIN_PARALLEL_REGION_END
+        cpu_simd_loop<Number>("", body_invert, 0, n_owned, n_owned);
 
         const auto &boundary_map = offline_data_->level_boundary_map()[level_];
 
@@ -592,12 +576,9 @@ namespace ryujin
       {
         /* Apply action of m_i rho_i V_i: */
 
-        using VA = dealii::VectorizedArray<Number>;
-        constexpr auto simd_length = VA::size();
-
         const vector_type *lumped_mass_matrix = nullptr;
-        if constexpr (std::is_same<Number, Number2>::value) {
-          if constexpr (std::is_same<Number, float>::value) {
+        if constexpr (std::is_same_v<Number, Number2>) {
+          if constexpr (std::is_same_v<Number, float>) {
             if (level_ == dealii::numbers::invalid_unsigned_int)
               lumped_mass_matrix = &offline_data_->lumped_mass_matrix();
             else
@@ -614,26 +595,16 @@ namespace ryujin
 
         const unsigned int n_owned =
             lumped_mass_matrix->get_partitioner()->locally_owned_size();
-        const unsigned int size_regular = n_owned / simd_length * simd_length;
 
-        RYUJIN_PARALLEL_REGION_BEGIN
+        const auto body_mass = [&](auto sentinel, unsigned int i) {
+          using T = decltype(sentinel);
+          const auto m_i = get_entry<T>(*lumped_mass_matrix, i);
+          const auto rho_i = get_entry<T>(*density_, i);
+          const auto e_i = get_entry<T>(src, i);
+          write_entry<T>(dst, m_i * rho_i * e_i, i);
+        };
 
-        RYUJIN_OMP_FOR
-        for (unsigned int i = 0; i < size_regular; i += simd_length) {
-          const auto m_i = get_entry<VA>(*lumped_mass_matrix, i);
-          const auto rho_i = get_entry<VA>(*density_, i);
-          const auto e_i = get_entry<VA>(src, i);
-          write_entry<VA>(dst, m_i * rho_i * e_i, i);
-        }
-
-        RYUJIN_PARALLEL_REGION_END
-
-        for (unsigned int i = size_regular; i < n_owned; ++i) {
-          const auto m_i = lumped_mass_matrix->local_element(i);
-          const auto rho_i = density_->local_element(i);
-          const auto e_i = src.local_element(i);
-          dst.local_element(i) = m_i * rho_i * e_i;
-        }
+        cpu_simd_loop<Number>("", body_mass, 0, n_owned, n_owned);
 
         /* Apply action of diffusion operator \sum_j beta_ij e_j: */
 
@@ -717,17 +688,15 @@ namespace ryujin
         const unsigned int n_owned =
             lumped_mass_matrix.get_partitioner()->locally_owned_size();
 
-        RYUJIN_PARALLEL_REGION_BEGIN
+        const auto body_invert = [&](auto sentinel, const unsigned int i) {
+          using T = decltype(sentinel);
 
-        RYUJIN_OMP_FOR
-        for (unsigned int i = 0; i < n_owned; ++i) {
-          const auto m_i = lumped_mass_matrix.local_element(i);
-          const auto rho_i = density_->local_element(i);
-          vector.local_element(i) =
-              1. / (m_i * rho_i + vector.local_element(i));
-        }
-
-        RYUJIN_PARALLEL_REGION_END
+          const auto m_i = get_entry<T>(*lumped_mass_matrix, i);
+          const auto rho_i = get_entry<T>(*density_, i);
+          write_entry<T>(
+              vector, Number(1.) / (m_i * rho_i + get_entry<T>(vector, i)), i);
+        };
+        cpu_simd_loop<Number>("", body_invert, 0, n_owned, n_owned);
 
         const auto &boundary_map = offline_data_->level_boundary_map()[level_];
 

--- a/source/sparse_matrix_simd.template.h
+++ b/source/sparse_matrix_simd.template.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "openmp.h"
+#include "loop.h"
 #include "simd.h"
 #include "sparse_matrix_simd.h"
 
@@ -301,8 +301,6 @@ namespace ryujin
       const std::array<SparseMatrix, n_components> &sparse_matrix,
       bool locally_indexed /*= true*/)
   {
-    RYUJIN_PARALLEL_REGION_BEGIN
-
     /*
      * We use the indirect (and slow) access via operator()(i, j) into the
      * sparse matrix we are copying from. This allows for significantly
@@ -310,50 +308,50 @@ namespace ryujin
      * the sparse_matrix object.
      */
 
-    RYUJIN_OMP_FOR
-    for (unsigned int i = 0; i < sparsity->n_internal_dofs; i += simd_length) {
+    const auto body = [&](auto sentinel, unsigned int i) {
+      using T = decltype(sentinel);
+      constexpr unsigned int stride_size = get_stride_size<T>;
+      static_assert(stride_size == 1 || stride_size == simd_length);
 
       const unsigned int row_length = sparsity->row_length(i);
-
       const unsigned int *js = sparsity->columns(i);
-      for (unsigned int col_idx = 0; col_idx < row_length;
-           ++col_idx, js += simd_length) {
 
-        dealii::Tensor<1, n_components, VectorizedArray> temp;
-        for (unsigned int k = 0; k < simd_length; ++k)
+      for (unsigned int col_idx = 0; col_idx < row_length;
+           ++col_idx, js += stride_size) {
+
+        dealii::Tensor<1, n_components, T> temp;
+
+        if constexpr (std::is_same_v<T, VectorizedArray>) {
+          /* Special access for VectorizedArray: */
+          for (unsigned int k = 0; k < simd_length; ++k)
+            for (unsigned int d = 0; d < n_components; ++d)
+              if (locally_indexed)
+                temp[d][k] = sparse_matrix[d](i + k, js[k]);
+              else
+                temp[d][k] = sparse_matrix[d].el(
+                    sparsity->partitioner->local_to_global(i + k),
+                    sparsity->partitioner->local_to_global(js[k]));
+
+          write_entry(temp, i, col_idx, true);
+
+        } else {
           for (unsigned int d = 0; d < n_components; ++d)
             if (locally_indexed)
-              temp[d][k] = sparse_matrix[d](i + k, js[k]);
+              temp[d] = sparse_matrix[d](i, js[0]);
             else
-              temp[d][k] = sparse_matrix[d].el(
-                  sparsity->partitioner->local_to_global(i + k),
-                  sparsity->partitioner->local_to_global(js[k]));
-
-        write_entry(temp, i, col_idx, true);
+              temp[d] = sparse_matrix[d].el(
+                  sparsity->partitioner->local_to_global(i),
+                  sparsity->partitioner->local_to_global(js[0]));
+          write_entry(temp, i, col_idx);
+        }
       }
-    }
+    };
 
-    RYUJIN_OMP_FOR
-    for (unsigned int i = sparsity->n_internal_dofs;
-         i < sparsity->n_locally_owned_dofs;
-         ++i) {
-      const unsigned int row_length = sparsity->row_length(i);
-      const unsigned int *js = sparsity->columns(i);
-      for (unsigned int col_idx = 0; col_idx < row_length; ++col_idx, ++js) {
-
-        dealii::Tensor<1, n_components, Number> temp;
-        for (unsigned int d = 0; d < n_components; ++d)
-          if (locally_indexed)
-            temp[d] = sparse_matrix[d](i, js[0]);
-          else
-            temp[d] = sparse_matrix[d].el(
-                sparsity->partitioner->local_to_global(i),
-                sparsity->partitioner->local_to_global(js[0]));
-        write_entry(temp, i, col_idx);
-      }
-    }
-
-    RYUJIN_PARALLEL_REGION_END
+    cpu_simd_loop<Number>("sparse_matrix_read_in",
+                          body,
+                          0,
+                          sparsity->n_internal_dofs,
+                          sparsity->n_locally_owned_dofs);
   }
 
 
@@ -362,8 +360,6 @@ namespace ryujin
   void SparseMatrixSIMD<Number, n_components, simd_length>::read_in(
       const SparseMatrix &sparse_matrix, bool locally_indexed /*= true*/)
   {
-    RYUJIN_PARALLEL_REGION_BEGIN
-
     /*
      * We use the indirect (and slow) access via operator()(i, j) into the
      * sparse matrix we are copying from. This allows for significantly
@@ -371,48 +367,46 @@ namespace ryujin
      * the sparse_matrix object.
      */
 
-    RYUJIN_OMP_FOR
-    for (unsigned int i = 0; i < sparsity->n_internal_dofs; i += simd_length) {
+    const auto body = [&](auto sentinel, unsigned int i) {
+      using T = decltype(sentinel);
+      constexpr unsigned int stride_size = get_stride_size<T>;
+      static_assert(stride_size == 1 || stride_size == simd_length);
 
       const unsigned int row_length = sparsity->row_length(i);
-
       const unsigned int *js = sparsity->columns(i);
+
       for (unsigned int col_idx = 0; col_idx < row_length;
-           ++col_idx, js += simd_length) {
+           ++col_idx, js += stride_size) {
 
-        VectorizedArray temp = {};
-        for (unsigned int k = 0; k < simd_length; ++k)
-          if (locally_indexed)
-            temp[k] = sparse_matrix(i + k, js[k]);
-          else
-            temp[k] =
-                sparse_matrix.el(sparsity->partitioner->local_to_global(i + k),
-                                 sparsity->partitioner->local_to_global(js[k]));
+        auto temp = T{};
 
-        write_entry(temp, i, col_idx, true);
+        if constexpr (std::is_same_v<T, VectorizedArray>) {
+          for (unsigned int k = 0; k < simd_length; ++k)
+            if (locally_indexed)
+              temp[k] = sparse_matrix(i + k, js[k]);
+            else
+              temp[k] = sparse_matrix.el(
+                  sparsity->partitioner->local_to_global(i + k),
+                  sparsity->partitioner->local_to_global(js[k]));
+
+          write_entry(temp, i, col_idx, true);
+
+        } else {
+          temp = locally_indexed
+                     ? sparse_matrix(i, js[0])
+                     : sparse_matrix.el(
+                           sparsity->partitioner->local_to_global(i),
+                           sparsity->partitioner->local_to_global(js[0]));
+          write_entry(temp, i, col_idx);
+        }
       }
-    }
+    };
 
-    RYUJIN_OMP_FOR
-    for (unsigned int i = sparsity->n_internal_dofs;
-         i < sparsity->n_locally_owned_dofs;
-         ++i) {
-
-      const unsigned int row_length = sparsity->row_length(i);
-      const unsigned int *js = sparsity->columns(i);
-      for (unsigned int col_idx = 0; col_idx < row_length; ++col_idx, ++js) {
-
-        const Number temp =
-            locally_indexed
-                ? sparse_matrix(i, js[0])
-                : sparse_matrix.el(
-                      sparsity->partitioner->local_to_global(i),
-                      sparsity->partitioner->local_to_global(js[0]));
-        write_entry(temp, i, col_idx);
-      }
-    }
-
-    RYUJIN_PARALLEL_REGION_END
+    cpu_simd_loop<Number>("sparse_matrix_read_in",
+                          body,
+                          0,
+                          sparsity->n_internal_dofs,
+                          sparsity->n_locally_owned_dofs);
   }
 
 } // namespace ryujin


### PR DESCRIPTION
This pull request cleans up the last three places where we used OpenMP loops explicitly.
