### PR TITLE
EulerAEOS: remove "prefer vector interface" mechanism

### DIFF
--- a/source/euler_aeos/equation_of_state.h
+++ b/source/euler_aeos/equation_of_state.h
@@ -9,7 +9,6 @@
 
 #include "convenience_macros.h"
 
-#include <deal.II/base/array_view.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/tensor.h>
@@ -64,61 +63,10 @@ namespace ryujin
       virtual double pressure(double rho, double e) const = 0;
 
       /**
-       * Variant of above function operating on a contiguous range of
-       * values. The result is stored in the first argument @p p,
-       * overriding previous contents.
-       *
-       * @note The second and third arguments are writable as well. We need
-       * to perform some unit transformations for certain tabulated
-       * equation of state libraries, such as the sesame database. Rather
-       * than creating temporaries we override values in place.
-       */
-      virtual void pressure(const dealii::ArrayView<double> &p,
-                            const dealii::ArrayView<double> &rho,
-                            const dealii::ArrayView<double> &e) const
-      {
-        Assert(p.size() == rho.size() && rho.size() == e.size(),
-               dealii::ExcMessage("vectors have different size"));
-
-        std::transform(std::begin(rho),
-                       std::end(rho),
-                       std::begin(e),
-                       std::begin(p),
-                       [&](double rho, double e) { return pressure(rho, e); });
-      }
-
-      /**
        * Return the specific internal energy @p e for a given density @p
        * rho and pressure @p p.
        */
       virtual double specific_internal_energy(double rho, double p) const = 0;
-
-      /**
-       * Variant of above function operating on a contiguous range of
-       * values. The result is stored in the first argument @p p,
-       * overriding previous contents.
-       *
-       * @note The second and third arguments are writable as well. We need
-       * to perform some unit transformations for certain tabulated
-       * equation of state libraries, such as the sesame database. Rather
-       * than creating temporaries we override values in place.
-       */
-      virtual void
-      specific_internal_energy(const dealii::ArrayView<double> &e,
-                               const dealii::ArrayView<double> &rho,
-                               const dealii::ArrayView<double> &p) const
-      {
-        Assert(p.size() == rho.size() && rho.size() == e.size(),
-               dealii::ExcMessage("vectors have different size"));
-
-        std::transform(std::begin(rho),
-                       std::end(rho),
-                       std::begin(p),
-                       std::begin(e),
-                       [&](double rho, double p) {
-                         return specific_internal_energy(rho, p);
-                       });
-      }
 
       /**
        * Return the temperature @p T for a given density @p
@@ -127,60 +75,10 @@ namespace ryujin
       virtual double temperature(double rho, double e) const = 0;
 
       /**
-       * Variant of above function operating on a contiguous range of
-       * values. The result is stored in the first argument @p T,
-       * overriding previous contents.
-       *
-       * @note The second and third arguments are writable as well. We need
-       * to perform some unit transformations for certain tabulated
-       * equation of state libraries, such as the sesame database. Rather
-       * than creating temporaries we override values in place.
-       */
-      virtual void temperature(const dealii::ArrayView<double> &T,
-                               const dealii::ArrayView<double> &rho,
-                               const dealii::ArrayView<double> &e) const
-      {
-        Assert(T.size() == rho.size() && rho.size() == e.size(),
-               dealii::ExcMessage("vectors have different size"));
-
-        std::transform(
-            std::begin(rho),
-            std::end(rho),
-            std::begin(e),
-            std::begin(T),
-            [&](double rho, double e) { return temperature(rho, e); });
-      }
-
-      /**
        * Return the sound speed @p c for a given density @p rho and
        * specific internal energy  @p e.
        */
       virtual double speed_of_sound(double rho, double e) const = 0;
-
-      /**
-       * Variant of above function operating on a contiguous range of
-       * values. The result is stored in the first argument @p p,
-       * overriding previous contents.
-       *
-       * @note The second and third arguments are writable as well. We need
-       * to perform some unit transformations for certain tabulated
-       * equation of state libraries, such as the sesame database. Rather
-       * than creating temporaries we override values in place.
-       */
-      virtual void speed_of_sound(const dealii::ArrayView<double> &c,
-                                  const dealii::ArrayView<double> &rho,
-                                  const dealii::ArrayView<double> &e) const
-      {
-        Assert(c.size() == rho.size() && rho.size() == e.size(),
-               dealii::ExcMessage("vectors have different size"));
-
-        std::transform(
-            std::begin(rho),
-            std::end(rho),
-            std::begin(e),
-            std::begin(c),
-            [&](double rho, double e) { return speed_of_sound(rho, e); });
-      }
 
       /**
        * Return the interpolation covolume constant (b).

--- a/source/euler_aeos/equation_of_state.h
+++ b/source/euler_aeos/equation_of_state.h
@@ -55,13 +55,6 @@ namespace ryujin
          * internal energy q that is used in the interpolatory NASG eos.
          */
         interpolation_q_ = 0.;
-
-        /*
-         * If necessary derived EOS can override this boolean to indicate
-         * that the dealii::ArrayView<double> variants of the pressure()
-         * function (etc.) should be preferred.
-         */
-        prefer_vector_interface_ = false;
       }
 
       /**
@@ -205,19 +198,6 @@ namespace ryujin
       ACCESSOR_READ_ONLY(interpolation_q)
 
       /**
-       * Return a boolean indicating whether the dealii::ArrayView<double>
-       * variants for the pressure(), specific_internal_energy(), and
-       * speed_of_sound() functions should be preferred.
-       *
-       * Ordinarily we use the single-valued signatures for pre-computation
-       * because this leads to slightly better throughput (due to better
-       * memory locality with how we store precomputed values) and less
-       * memory consumption. On the other hand, some tabulated equation of
-       * state libraries work best with a single call and a large dataset.
-       */
-      ACCESSOR_READ_ONLY(prefer_vector_interface)
-
-      /**
        * Return the name of the EOS as (const reference) std::string
        */
       ACCESSOR_READ_ONLY(name)
@@ -226,7 +206,6 @@ namespace ryujin
       double interpolation_b_;
       double interpolation_pinfty_;
       double interpolation_q_;
-      bool prefer_vector_interface_;
 
     private:
       const std::string name_;

--- a/source/euler_aeos/equation_of_state_sesame.h
+++ b/source/euler_aeos/equation_of_state_sesame.h
@@ -231,8 +231,6 @@ namespace ryujin
         material_id_ = 5030;
         this->add_parameter(
             "material id", material_id_, "The Sesame Material ID");
-
-        this->prefer_vector_interface_ = true;
       }
 
 

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -875,10 +875,6 @@ namespace ryujin
       const auto &U = std::get<0>(state_vector);
       auto &precomputed = std::get<1>(state_vector);
 
-      /* FIXME: come up with a better interface, disable for now. */
-      const auto &eos = this->selected_equation_of_state_;
-      AssertThrow(!eos->prefer_vector_interface(), dealii::ExcNotImplemented());
-
       /* Compute values over the diagonal: */
 
       const auto body = [&](auto sentinel, unsigned int i) {

--- a/tests/euler_aeos/equation_of_state_library.cc
+++ b/tests/euler_aeos/equation_of_state_library.cc
@@ -72,21 +72,35 @@ void test(const ryujin::EquationOfStateLibrary::EquationOfState &eos,
     std::array<double, 5> c;
     std::array<double, 5> T;
 
-    eos.pressure(dealii::ArrayView<double>(p),
-                 dealii::ArrayView<double>(rho),
-                 dealii::ArrayView<double>(e));
+    std::transform(
+        std::begin(rho),
+        std::end(rho),
+        std::begin(e),
+        std::begin(p),
+        [&](const auto rho, const auto e) { return eos.pressure(rho, e); });
 
-    eos.specific_internal_energy(dealii::ArrayView<double>(e_back),
-                                 dealii::ArrayView<double>(rho),
-                                 dealii::ArrayView<double>(p));
+    std::transform(std::begin(rho),
+                   std::end(rho),
+                   std::begin(p),
+                   std::begin(e_back),
+                   [&](const auto rho, const auto p) {
+                     return eos.specific_internal_energy(rho, p);
+                   });
 
-    eos.speed_of_sound(dealii::ArrayView<double>(c),
-                       dealii::ArrayView<double>(rho),
-                       dealii::ArrayView<double>(e));
+    std::transform(std::begin(rho),
+                   std::end(rho),
+                   std::begin(e),
+                   std::begin(c),
+                   [&](const auto rho, const auto e) {
+                     return eos.speed_of_sound(rho, e);
+                   });
 
-    eos.temperature(dealii::ArrayView<double>(T),
-                    dealii::ArrayView<double>(rho),
-                    dealii::ArrayView<double>(e));
+    std::transform(
+        std::begin(rho),
+        std::end(rho),
+        std::begin(e),
+        std::begin(T),
+        [&](const auto rho, const auto e) { return eos.temperature(rho, e); });
 
     print_array("input rho     ", rho, std::cout);
     print_array("input e       ", e, std::cout);


### PR DESCRIPTION
This needs to be redesigned. Remove for now.
