### PR TITLE
Likwid: update CMake configuration; put measurement logic into scope class

### DIFF
--- a/cmake/FindLIKWID.cmake
+++ b/cmake/FindLIKWID.cmake
@@ -23,14 +23,19 @@ find_library(LIKWID_LUA_LIBRARY
   )
 
 find_package_handle_standard_args(LIKWID DEFAULT_MSG
-  LIKWID_LIBRARY LIKWID_HWLOC_LIBRARY LIKWID_LUA_LIBRARY LIKWID_INCLUDE_DIR
+  LIKWID_LIBRARY LIKWID_INCLUDE_DIR
   )
 
 if(LIKWID_FOUND AND NOT TARGET Likdwid::Likwid)
   add_library(Likwid::Likwid INTERFACE IMPORTED)
-  target_link_libraries(Likwid::Likwid INTERFACE
-    ${LIKWID_LIBRARY} ${LIKWID_HWLOC_LIBRARY} ${LIKWID_LUA_LIBRARY}
-    )
+  target_link_libraries(Likwid::Likwid INTERFACE ${LIKWID_LIBRARY})
+
+  foreach(_lib LIKWID_HWLOC_LIBRARY LIKWID_LUA_LIBRARY)
+    if(NOT "${${_lib}}" MATCHES "-NOTFOUND")
+      target_link_libraries(Likwid::Likwid INTERFACE ${${_lib}})
+    endif()
+  endforeach()
+
   target_include_directories(Likwid::Likwid SYSTEM INTERFACE ${LIKWID_INCLUDE_DIR})
   target_compile_definitions(Likwid::Likwid INTERFACE "LIKWID_PERFMON")
 endif()

--- a/source/euler_poisson/parabolic_module.template.h
+++ b/source/euler_poisson/parabolic_module.template.h
@@ -9,7 +9,6 @@
 #include "parabolic_module.h"
 
 #include <convenience_macros.h>
-#include <instrumentation.h>
 #include <loop.h>
 #include <scope.h>
 #include <simd.h>
@@ -553,7 +552,6 @@ namespace ryujin
        */
 
       Scope scope(computing_timer_, "time step [P] 1 - enforce Gauss law");
-      LIKWID_MARKER_START("time_step_parabolic_1a");
 
       update_background_density(t);
 
@@ -610,15 +608,11 @@ namespace ryujin
           density_,
           /*zero destination*/ true);
 
-      LIKWID_MARKER_STOP("time_step_parabolic_1a");
-
       /*
        * -----------------------------------------------------------------------
        * Step 1b: solve Poisson problem
        * -----------------------------------------------------------------------
        */
-
-      LIKWID_MARKER_START("time_step_parabolic_1b");
 
       matrix_free_.get_affine_constraints(0).distribute(potential);
       matrix_free_.get_affine_constraints(0).set_zero(potential_rhs_);
@@ -669,8 +663,6 @@ namespace ryujin
       }
 
       matrix_free_.get_affine_constraints(0).distribute(potential);
-
-      LIKWID_MARKER_STOP("time_step_parabolic_1b");
     }
 
 
@@ -702,8 +694,6 @@ namespace ryujin
        * Step 1c: enforce magnetic drift velocity
        * -----------------------------------------------------------------------
        */
-
-      LIKWID_MARKER_START("time_step_parabolic_1b");
 
       update_magnetic_field(Number(0.));
 
@@ -777,8 +767,6 @@ namespace ryujin
 
       cpu_simd_loop<Number>(
           "time_step_parabolic_1c", body, 0, n_owned, n_owned);
-
-      LIKWID_MARKER_STOP("time_step_parabolic_1c");
     }
 
 
@@ -848,7 +836,6 @@ namespace ryujin
          */
 
         Scope scope(computing_timer_, "time step [P] 2 - update potential");
-        LIKWID_MARKER_START("time_step_parabolic_2a");
 
         /* Query the magnetic field at the time t + tau: */
         update_magnetic_field(t + tau);
@@ -947,8 +934,6 @@ namespace ryujin
             velocity_rhs_,
             /*zero destination*/ false);
 
-        LIKWID_MARKER_STOP("time_step_parabolic_2a");
-
         /* Time-dependent background density: */
 
         if (selected_electrostatic_configuration_->is_time_dependent()) {
@@ -1011,8 +996,6 @@ namespace ryujin
          * ---------------------------------------------------------------------
          */
 
-        LIKWID_MARKER_START("time_step_parabolic_2b");
-
         update_operator_.set_alpha(alpha);
         update_operator_.set_theta_tau(tau);
 
@@ -1054,8 +1037,6 @@ namespace ryujin
         }
 
         matrix_free_.get_affine_constraints(0).distribute(new_potential);
-
-        LIKWID_MARKER_STOP("time_step_parabolic_2b");
       }
 
       /*
@@ -1063,8 +1044,6 @@ namespace ryujin
        * Step 2c: update velocity vector field; Crank-Nicolson extrapolation
        * ---------------------------------------------------------------------
        */
-
-      LIKWID_MARKER_START("time_step_parabolic_2c");
 
       /* Project gradient of potential into velocity space: */
 
@@ -1150,8 +1129,6 @@ namespace ryujin
 
       cpu_simd_loop<Number>(
           "time_step_parabolic_2c", body, 0, n_owned, n_owned);
-
-      LIKWID_MARKER_STOP("time_step_parabolic_2c");
     }
 
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "hyperbolic_module.h"
-#include "instrumentation.h"
 #include "loop.h"
 #include "mpi_ensemble.h"
 #include "scope.h"
@@ -158,8 +157,6 @@ namespace ryujin
     Scope scope(computing_timer_,
                 "time step [H] 1 - update boundary values, precompute values");
 
-    LIKWID_MARKER_START("time_step_1");
-
     /* FIXME: not thread parallel... */
     for (const auto &entry : boundary_map) {
       const auto &[i, normal, normal_mass, boundary_mass, id, position] = entry;
@@ -184,21 +181,15 @@ namespace ryujin
       U.write_tensor(U_i, i);
     }
 
-    LIKWID_MARKER_STOP("time_step_1");
-
     U.update_ghost_values();
 
     /*
      * Compute and populate precomputed values.
      */
 
-    LIKWID_MARKER_START("time_step_1");
-
-    auto &precomputed = std::get<1>(state_vector);
     hyperbolic_system_->fill_precomputed_values(*offline_data_, state_vector);
 
-    LIKWID_MARKER_STOP("time_step_1");
-
+    auto &precomputed = std::get<1>(state_vector);
     precomputed.update_ghost_values();
   }
 

--- a/source/loop.h
+++ b/source/loop.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <instrumentation.h>
 #include <openmp.h>
 #include <simd.h>
 
@@ -45,7 +44,6 @@ namespace ryujin
     using VA = dealii::VectorizedArray<ScalarNumber>;
 
     RYUJIN_PARALLEL_REGION_BEGIN
-    LIKWID_MARKER_START(region_name.c_str());
 
     constexpr unsigned int stride_size = get_stride_size<VA>;
     const unsigned int regular = internal / stride_size * stride_size;
@@ -62,7 +60,6 @@ namespace ryujin
     for (unsigned int i = regular; i < right; i += 1)
       body(ScalarNumber(), std::forward<Args>(args)..., i);
 
-    LIKWID_MARKER_STOP(region_name.c_str());
     RYUJIN_PARALLEL_REGION_END
   }
 } // namespace ryujin

--- a/source/navier_stokes/parabolic_module.template.h
+++ b/source/navier_stokes/parabolic_module.template.h
@@ -7,7 +7,6 @@
 
 #include "parabolic_module.h"
 
-#include <instrumentation.h>
 #include <loop.h>
 #include <scope.h>
 #include <simd.h>
@@ -516,8 +515,6 @@ namespace ryujin
           mg_smoother_velocity_.initialize(level_velocity_matrices_,
                                            smoother_data);
         }
-
-        LIKWID_MARKER_STOP("time_step_parabolic_1");
       }
 
       Number e_min_old;
@@ -545,8 +542,6 @@ namespace ryujin
        */
       {
         Scope scope(computing_timer_, "time step [P] 1 - update velocities");
-
-        LIKWID_MARKER_START("time_step_parabolic_1");
 
         VelocityMatrix<dim, Number, Number> velocity_operator;
         velocity_operator.initialize(
@@ -607,8 +602,6 @@ namespace ryujin
               0.1 * (use_gmg_velocity_ ? gmg_max_iter_vel_ : 0) +
               0.1 * solver_control.last_step();
         }
-
-        LIKWID_MARKER_STOP("time_step_parabolic_1");
       }
 
       /*
@@ -617,8 +610,6 @@ namespace ryujin
       {
         Scope scope(computing_timer_,
                     "time step [P] 2 - update internal energy");
-
-        LIKWID_MARKER_START("time_step_parabolic_2");
 
         /* Compute m_i K_i^{n+1/2}:  (5.5) */
         matrix_free_.template cell_loop<ScalarVector, BlockVector>(
@@ -780,8 +771,6 @@ namespace ryujin
           }
           mg_smoother_energy_.initialize(level_energy_matrices_, smoother_data);
         }
-
-        LIKWID_MARKER_STOP("time_step_parabolic_2");
       }
 
       /*
@@ -790,8 +779,6 @@ namespace ryujin
       {
         Scope scope(computing_timer_,
                     "time step [P] 2 - update internal energy");
-
-        LIKWID_MARKER_START("time_step_parabolic_2");
 
         EnergyMatrix<dim, Number, Number> energy_operator;
         const auto &kappa = parabolic_system_->cv_inverse_kappa();
@@ -851,8 +838,6 @@ namespace ryujin
               0.1 * (use_gmg_internal_energy_ ? gmg_max_iter_en_ : 0) +
               0.1 * solver_control.last_step();
         }
-
-        LIKWID_MARKER_STOP("time_step_parabolic_2");
       }
 
       /*
@@ -863,8 +848,6 @@ namespace ryujin
        */
       {
         Scope scope(computing_timer_, "time step [P] 3 - write back vectors");
-
-        LIKWID_MARKER_START("time_step_parabolic_3");
 
         const auto body = [&](auto sentinel, unsigned int i) {
           using T = decltype(sentinel);
@@ -939,9 +922,6 @@ namespace ryujin
 
         cpu_simd_loop<Number>(
             "time_step_parabolic_3", body, 0, n_owned, n_owned);
-
-
-        LIKWID_MARKER_STOP("time_step_parabolic_3");
 
         new_U.update_ghost_values();
       }

--- a/source/scope.h
+++ b/source/scope.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "instrumentation.h"
 #include <compile_time_options.h>
 
 #include <deal.II/base/timer.h>
@@ -19,10 +20,15 @@
 namespace ryujin
 {
   /**
-   * A RAII scope for deal.II timer objects.
+   * A RAII scope for deal.II timer objects and likwid instrumentation.
    *
-   * This class does not perform MPI synchronization in contrast to the
-   * deal.II counterpart.
+   * The constructor of the class starts a timer with the specified name.
+   * If ryujin is configured with likwid then likwid instrumentation will
+   * also be started with the given section name. The destructor of the
+   * class stops the timer again and also stops likwid instrumentation.
+   *
+   * @note This class does not perform MPI synchronization in contrast to
+   * the deal.II counterpart.
    *
    * @ingroup Miscellaneous
    */
@@ -37,6 +43,7 @@ namespace ryujin
         : computing_timer_(computing_timer)
         , section_(section)
     {
+      LIKWID_MARKER_START(section_.c_str());
       computing_timer_[section_].start();
 #ifdef DEBUG_OUTPUT
       std::cout << "{scoped timer} \"" << section_ << "\" started" << std::endl;
@@ -52,6 +59,7 @@ namespace ryujin
       std::cout << "{scoped timer} \"" << section_ << "\" stopped" << std::endl;
 #endif
       computing_timer_[section_].stop();
+      LIKWID_MARKER_STOP(section_.c_str());
     }
 
   private:


### PR DESCRIPTION
This pull request cleans up our Likwid marker logic by simply using the `Scope` class that we are already utilizing for timer measurements.
