### PR TITLE
OfflineData: switch from ScalarHostVector to ScalarVector

### DIFF
--- a/source/euler_poisson/parabolic_module.template.h
+++ b/source/euler_poisson/parabolic_module.template.h
@@ -728,7 +728,8 @@ namespace ryujin
         using T = decltype(sentinel);
         const auto view = hyperbolic_system_->template view<dim, T>();
 
-        const auto m_i_inv = get_entry<T>(lumped_mass_matrix_inverse, i);
+        const auto m_i_inv =
+            lumped_mass_matrix_inverse.template get_entry<T>(i);
 
         auto U_i = U.template get_tensor<T>(i);
         const auto rho_i = view.density(U_i);
@@ -1095,7 +1096,8 @@ namespace ryujin
         using T = decltype(sentinel);
         const auto view = hyperbolic_system_->template view<dim, T>();
 
-        const auto m_i_inv = get_entry<T>(lumped_mass_matrix_inverse, i);
+        const auto m_i_inv =
+            lumped_mass_matrix_inverse.template get_entry<T>(i);
 
         const auto old_U_i = old_U.template get_tensor<T>(i);
         const auto rho_i = view.density(old_U_i);

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -394,7 +394,7 @@ namespace ryujin
           dij_matrix_.write_entry(d_ij, i, col_idx, true);
         }
 
-        const auto mass = get_entry<T>(lumped_mass_matrix, i);
+        const auto mass = lumped_mass_matrix.template get_entry<T>(i);
         const auto hd_i = mass * measure_of_omega_inverse;
         write_entry<T>(alpha_, indicator.alpha(hd_i), i);
       };
@@ -535,7 +535,7 @@ namespace ryujin
         /* write diagonal element */
         dij_matrix_.write_entry(d_sum, i, 0);
 
-        const Number mass = lumped_mass_matrix.local_element(i);
+        const Number mass = lumped_mass_matrix.get_entry(i);
         const Number local_tau = cfl_ * mass / (Number(-2.) * d_sum);
 
         Number current_value = local_tau_max.load();
@@ -634,8 +634,9 @@ namespace ryujin
         auto U_i_new = U_i;
 
         const auto alpha_i = get_entry<T>(alpha_, i);
-        const auto m_i = get_entry<T>(lumped_mass_matrix, i);
-        const auto m_i_inv = get_entry<T>(lumped_mass_matrix_inverse, i);
+        const auto m_i = lumped_mass_matrix.template get_entry<T>(i);
+        const auto m_i_inv =
+            lumped_mass_matrix_inverse.template get_entry<T>(i);
 
         const auto flux_i = view.flux_contribution(
             old_precomputed, initial_precomputed_, i, U_i);
@@ -917,8 +918,10 @@ namespace ryujin
 
         [[maybe_unused]] T m_i;
         if constexpr (have_discontinuous_ansatz)
-          m_i = get_entry<T>(lumped_mass_matrix, i);
-        const auto m_i_inv = get_entry<T>(lumped_mass_matrix_inverse, i);
+          m_i = lumped_mass_matrix.template get_entry<T>(i);
+
+        const auto m_i_inv =
+            lumped_mass_matrix_inverse.template get_entry<T>(i);
 
         const auto U_i_new = new_U.template get_tensor<T>(i);
 
@@ -944,7 +947,7 @@ namespace ryujin
           if constexpr (have_discontinuous_ansatz) {
             /* Use full consistent mass matrix inverse: */
 
-            const auto m_j = get_entry<T>(lumped_mass_matrix, js);
+            const auto m_j = lumped_mass_matrix.template get_entry<T>(js);
             const auto m_ij_inv =
                 mass_matrix_inverse.template get_entry<T>(i, col_idx);
             const auto b_ij = m_i * m_ij_inv - kronecker_ij;
@@ -955,7 +958,8 @@ namespace ryujin
           } else {
             /* Use Neumann series expansion: */
 
-            const auto m_j_inv = get_entry<T>(lumped_mass_matrix_inverse, js);
+            const auto m_j_inv =
+                lumped_mass_matrix_inverse.template get_entry<T>(js);
             const auto m_ij = mass_matrix.template get_entry<T>(i, col_idx);
             const auto b_ij = kronecker_ij - m_ij * m_j_inv;
             const auto b_ji = kronecker_ij - m_ij * m_i_inv;

--- a/source/multicomponent_vector.h
+++ b/source/multicomponent_vector.h
@@ -156,6 +156,15 @@ namespace ryujin
                             unsigned int component,
                             const Functor &functor = std::identity{});
 
+      /**
+       * Variant of the method above that reads values out of a
+       * dealii::Vector in (rank-) local numbering.
+       */
+      template <typename Functor = std::identity>
+      void insert_component(const dealii::Vector<Number> &scalar_vector,
+                            unsigned int component,
+                            const Functor &functor = std::identity{});
+
       //@}
       /**
        * @name Access to scalar or tensor-valued entries from various
@@ -395,6 +404,30 @@ namespace ryujin
       for (unsigned int i = 0; i < local_size; ++i)
         this->local_element(i * n_components + component) =
             functor(scalar_vector.local_element(i));
+    }
+
+
+    template <typename Number, int n_components, int simd_length>
+    template <typename Functor>
+    void
+    MultiComponentVector<Number, n_components, simd_length>::insert_component(
+        const dealii::Vector<Number> &scalar_vector,
+        unsigned int component,
+        const Functor &functor)
+    {
+      Assert(n_components > 0,
+             dealii::ExcMessage(
+                 "Cannot insert into a vector with zero components."));
+      AssertIndexRange(component, n_components);
+
+      Assert(n_components * scalar_vector.size() >=
+                 this->get_partitioner()->locally_owned_size(),
+             dealii::ExcMessage("Called with a scalar_vector argument that has "
+                                "incompatible local range."));
+      const auto local_size = scalar_vector.size();
+      for (unsigned int i = 0; i < local_size; ++i)
+        this->local_element(i * n_components + component) =
+            functor(scalar_vector[i]);
     }
 
 

--- a/source/navier_stokes/parabolic_module.template.h
+++ b/source/navier_stokes/parabolic_module.template.h
@@ -381,7 +381,7 @@ namespace ryujin
           const auto rho_i = view.density(U_i);
           const auto M_i = view.momentum(U_i);
           const auto rho_e_i = view.internal_energy(U_i);
-          const auto m_i = get_entry<T>(lumped_mass_matrix, i);
+          const auto m_i = lumped_mass_matrix.template get_entry<T>(i);
 
           write_entry<T>(density_, rho_i, i);
           /* (5.4a) */
@@ -664,7 +664,7 @@ namespace ryujin
           const auto view = hyperbolic_system_->template view<dim, T>();
 
           const auto rhs_i = get_entry<T>(internal_energy_rhs_, i);
-          const auto m_i = get_entry<T>(lumped_mass_matrix, i);
+          const auto m_i = lumped_mass_matrix.template get_entry<T>(i);
           const auto rho_i = get_entry<T>(density_, i);
           const auto e_i = get_entry<T>(internal_energy_, i);
 

--- a/source/navier_stokes/parabolic_module_gmg_operators.h
+++ b/source/navier_stokes/parabolic_module_gmg_operators.h
@@ -64,7 +64,8 @@ namespace ryujin
        * Compute the inverse of a given density \f$ \rho_i \f$ and a given
        * lumped mass matrix \f$ m_i \f$, viz., \f$d_i=1/(\rho_i m_i)\f$.
        */
-      void reinit(const vector_type &lumped_mass_matrix,
+      template <typename Vector>
+      void reinit(const Vector &lumped_mass_matrix,
                   const vector_type &density,
                   const dealii::AffineConstraints<Number> &affine_constraints)
       {
@@ -74,7 +75,14 @@ namespace ryujin
 
         const auto body_invert = [&](auto sentinel, const unsigned int i) {
           using T = decltype(sentinel);
-          const auto m_i = get_entry<T>(lumped_mass_matrix, i);
+
+          T m_i;
+          if constexpr (std::is_same_v<Vector, vector_type>) {
+            m_i = get_entry<T>(lumped_mass_matrix, i);
+          } else {
+            m_i = lumped_mass_matrix.template get_entry<T>(i);
+          }
+
           const auto rho_i = get_entry<T>(density, i);
           write_entry<T>(diagonal, Number(1.0) / (rho_i * m_i), i);
         };
@@ -196,30 +204,40 @@ namespace ryujin
       {
         /* Apply action of m_i rho_i V_i: */
 
-        const vector_type *lumped_mass_matrix = nullptr;
-        if constexpr (std::is_same_v<Number, Number2>) {
-          if constexpr (std::is_same_v<Number, float>) {
-            if (level_ == dealii::numbers::invalid_unsigned_int)
-              lumped_mass_matrix = &offline_data_->lumped_mass_matrix();
-            else
-              lumped_mass_matrix =
-                  &offline_data_->level_lumped_mass_matrix()[level_];
+        /* FIXME: we should really clean up this mess: */
+        const auto get_lumped_mass = [&](auto sentinel, unsigned int i) {
+          using T = decltype(sentinel);
+          if constexpr (std::is_same_v<Number, Number2>) {
+            if constexpr (std::is_same_v<Number, float>) {
+              if (level_ == dealii::numbers::invalid_unsigned_int) {
+                const auto &lumped = offline_data_->lumped_mass_matrix();
+                return lumped.template get_entry<T>(i);
+              } else {
+                const auto &level_lumped =
+                    offline_data_->level_lumped_mass_matrix()[level_];
+                return get_entry<T>(level_lumped, i);
+              }
+            } else {
+              Assert(level_ == dealii::numbers::invalid_unsigned_int,
+                     dealii::ExcInternalError());
+              const auto &lumped = offline_data_->lumped_mass_matrix();
+              return lumped.template get_entry<T>(i);
+            }
           } else {
-            Assert(level_ == dealii::numbers::invalid_unsigned_int,
-                   dealii::ExcInternalError());
-            lumped_mass_matrix = &offline_data_->lumped_mass_matrix();
+            const auto &level_lumped =
+                offline_data_->level_lumped_mass_matrix()[level_];
+            return get_entry<T>(level_lumped, i);
           }
-        } else
-          lumped_mass_matrix =
-              &offline_data_->level_lumped_mass_matrix()[level_];
+        };
 
         const unsigned int n_owned =
-            lumped_mass_matrix->get_partitioner()->locally_owned_size();
+            dst.block(0).get_partitioner()->locally_owned_size();
 
         const auto body_mass = [&](auto sentinel, unsigned int i) {
           using T = decltype(sentinel);
 
-          const auto m_i = get_entry<T>(*lumped_mass_matrix, i);
+          const auto m_i = get_lumped_mass(T(), i);
+
           const auto rho_i = get_entry<T>(*density_, i);
           for (unsigned int d = 0; d < dim; ++d) {
             const auto temp = get_entry<T>(src.block(d), i);
@@ -301,9 +319,6 @@ namespace ryujin
           matrix_free_->initialize_dof_vector(vector.block(d));
         vector.collect_sizes();
 
-        const auto &lumped_mass_matrix =
-            offline_data_->level_lumped_mass_matrix()[level_];
-
         unsigned int dummy = 0;
         matrix_free_->template cell_loop<block_vector_type, unsigned int>(
             [this](
@@ -333,6 +348,8 @@ namespace ryujin
             dummy,
             /* zero destination */ true);
 
+        const auto &lumped_mass_matrix =
+            offline_data_->level_lumped_mass_matrix()[level_];
         const unsigned int n_owned =
             lumped_mass_matrix.get_partitioner()->locally_owned_size();
 
@@ -576,29 +593,38 @@ namespace ryujin
       {
         /* Apply action of m_i rho_i V_i: */
 
-        const vector_type *lumped_mass_matrix = nullptr;
-        if constexpr (std::is_same_v<Number, Number2>) {
-          if constexpr (std::is_same_v<Number, float>) {
-            if (level_ == dealii::numbers::invalid_unsigned_int)
-              lumped_mass_matrix = &offline_data_->lumped_mass_matrix();
-            else
-              lumped_mass_matrix =
-                  &offline_data_->level_lumped_mass_matrix()[level_];
+        /* FIXME: we should really clean up this mess: */
+        const auto get_lumped_mass = [&](auto sentinel, unsigned int i) {
+          using T = decltype(sentinel);
+          if constexpr (std::is_same_v<Number, Number2>) {
+            if constexpr (std::is_same_v<Number, float>) {
+              if (level_ == dealii::numbers::invalid_unsigned_int) {
+                const auto &lumped = offline_data_->lumped_mass_matrix();
+                return lumped.template get_entry<T>(i);
+              } else {
+                const auto &level_lumped =
+                    offline_data_->level_lumped_mass_matrix()[level_];
+                return get_entry<T>(level_lumped, i);
+              }
+            } else {
+              Assert(level_ == dealii::numbers::invalid_unsigned_int,
+                     dealii::ExcInternalError());
+              const auto &lumped = offline_data_->lumped_mass_matrix();
+              return lumped.template get_entry<T>(i);
+            }
           } else {
-            Assert(level_ == dealii::numbers::invalid_unsigned_int,
-                   dealii::ExcInternalError());
-            lumped_mass_matrix = &offline_data_->lumped_mass_matrix();
+            const auto &level_lumped =
+                offline_data_->level_lumped_mass_matrix()[level_];
+            return get_entry<T>(level_lumped, i);
           }
-        } else
-          lumped_mass_matrix =
-              &offline_data_->level_lumped_mass_matrix()[level_];
+        };
 
         const unsigned int n_owned =
-            lumped_mass_matrix->get_partitioner()->locally_owned_size();
+            dst.get_partitioner()->locally_owned_size();
 
         const auto body_mass = [&](auto sentinel, unsigned int i) {
           using T = decltype(sentinel);
-          const auto m_i = get_entry<T>(*lumped_mass_matrix, i);
+          const auto m_i = get_lumped_mass(T(), i);
           const auto rho_i = get_entry<T>(*density_, i);
           const auto e_i = get_entry<T>(src, i);
           write_entry<T>(dst, m_i * rho_i * e_i, i);

--- a/source/offline_data.h
+++ b/source/offline_data.h
@@ -52,14 +52,14 @@ namespace ryujin
   {
   public:
     /**
+     * @copydoc ryujin::ScalarVector
+     */
+    using ScalarVector = Vectors::ScalarVector<Number>;
+
+    /**
      * @copydoc ryujin::ScalarHostVector
      */
     using ScalarHostVector = Vectors::ScalarHostVector<Number>;
-
-    /**
-     * Scalar vector storing single-precision floats
-     */
-    using ScalarHostVectorFloat = Vectors::ScalarHostVector<float>;
 
     /**
      * A tuple describing (local) dof index, boundary normal, normal mass,
@@ -450,9 +450,10 @@ namespace ryujin
     SparseMatrixSIMD<Number> mass_matrix_;
     SparseMatrixSIMD<Number> mass_matrix_inverse_;
 
-    ScalarHostVector lumped_mass_matrix_;
-    ScalarHostVector lumped_mass_matrix_inverse_;
+    ScalarVector lumped_mass_matrix_;
+    ScalarVector lumped_mass_matrix_inverse_;
 
+    using ScalarHostVectorFloat = Vectors::ScalarHostVector<float>;
     std::vector<ScalarHostVectorFloat> level_lumped_mass_matrix_;
 
     SparseMatrixSIMD<Number> betaij_matrix_;

--- a/source/offline_data.template.h
+++ b/source/offline_data.template.h
@@ -552,8 +552,9 @@ namespace ryujin
     if (discretization_->have_discontinuous_ansatz())
       mass_matrix_inverse_.reinit(sparsity_pattern_simd_);
 
-    lumped_mass_matrix_.reinit(scalar_partitioner_);
-    lumped_mass_matrix_inverse_.reinit(scalar_partitioner_);
+    lumped_mass_matrix_.reinit_with_scalar_partitioner(scalar_partitioner_);
+    lumped_mass_matrix_inverse_.reinit_with_scalar_partitioner(
+        scalar_partitioner_);
 
     betaij_matrix_.reinit(sparsity_pattern_simd_);
     cij_matrix_.reinit(sparsity_pattern_simd_);
@@ -958,6 +959,7 @@ namespace ryujin
 
     {
 #ifdef DEAL_II_WITH_TRILINOS
+      using ScalarHostVector = Vectors::ScalarHostVector<Number>;
       ScalarHostVector one(scalar_partitioner_);
       one = 1.;
       affine_constraints_assembly.set_zero(one);
@@ -965,18 +967,13 @@ namespace ryujin
       ScalarHostVector local_lumped_mass_matrix(scalar_partitioner_);
       mass_matrix_tmp.vmult(local_lumped_mass_matrix, one);
       local_lumped_mass_matrix.compress(VectorOperation::add);
-
-      for (unsigned int i = 0; i < scalar_partitioner_->locally_owned_size();
-           ++i) {
-        lumped_mass_matrix_.local_element(i) =
-            local_lumped_mass_matrix.local_element(i);
-        lumped_mass_matrix_inverse_.local_element(i) =
-            1. / lumped_mass_matrix_.local_element(i);
-      }
-      lumped_mass_matrix_.update_ghost_values();
-      lumped_mass_matrix_inverse_.update_ghost_values();
-
 #else
+      /*
+       * Work around the little detail that dealii::SparseMatrix does not
+       * allow vmult() with a distributed vector. On a globally refined
+       * grid, contracting the mass matrix in this manner still works
+       * without knowledge of the ghost range.
+       */
 
       dealii::Vector<Number> one(mass_matrix_tmp.m());
       one = 1.;
@@ -984,16 +981,16 @@ namespace ryujin
 
       dealii::Vector<Number> local_lumped_mass_matrix(mass_matrix_tmp.m());
       mass_matrix_tmp.vmult(local_lumped_mass_matrix, one);
-
-      for (unsigned int i = 0; i < scalar_partitioner_->locally_owned_size();
-           ++i) {
-        lumped_mass_matrix_.local_element(i) = local_lumped_mass_matrix(i);
-        lumped_mass_matrix_inverse_.local_element(i) =
-            1. / lumped_mass_matrix_.local_element(i);
-      }
-      lumped_mass_matrix_.update_ghost_values();
-      lumped_mass_matrix_inverse_.update_ghost_values();
 #endif
+
+      lumped_mass_matrix_.insert_component(local_lumped_mass_matrix, 0);
+      lumped_mass_matrix_.update_ghost_values();
+
+      lumped_mass_matrix_inverse_.insert_component(
+          local_lumped_mass_matrix, 0, [](const Number &value) {
+            return Number(1.) / value;
+          });
+      lumped_mass_matrix_inverse_.update_ghost_values();
     }
 
     /*
@@ -1107,10 +1104,14 @@ namespace ryujin
                 if (std::abs(v_i * v_j) > 100. * eps) {
                   const auto &ansatz = discretization_->ansatz();
 
-                  const auto glob_i = local_dof_indices[i];
-                  const auto glob_j = neighbor_local_dof_indices[f_index][j];
-                  const auto m_i = lumped_mass_matrix_[glob_i];
-                  const auto m_j = lumped_mass_matrix_[glob_j];
+                  const auto global_i = local_dof_indices[i];
+                  const auto global_j = neighbor_local_dof_indices[f_index][j];
+                  const auto local_i =
+                      scalar_partitioner_->global_to_local(global_i);
+                  const auto local_j =
+                      scalar_partitioner_->global_to_local(global_j);
+                  const auto m_i = lumped_mass_matrix_.get_entry(local_i);
+                  const auto m_j = lumped_mass_matrix_.get_entry(local_j);
                   const auto hd_ij =
                       Number(0.5) * (m_i + m_j) / measure_of_omega_;
 
@@ -1222,7 +1223,7 @@ namespace ryujin
 
     double total_mass = 0.;
     for (unsigned int i = 0; i < n_locally_owned_; ++i)
-      total_mass += lumped_mass_matrix_.local_element(i);
+      total_mass += lumped_mass_matrix_.get_entry(i);
     total_mass =
         Utilities::MPI::sum(total_mass, mpi_ensemble_.ensemble_communicator());
 
@@ -1242,7 +1243,7 @@ namespace ryujin
         continue;
 
       auto sum =
-          mass_matrix_.get_entry(i, 0) - lumped_mass_matrix_.local_element(i);
+          mass_matrix_.get_entry(i, 0) - lumped_mass_matrix_.get_entry(i);
 
       /* skip diagonal */
       constexpr auto simd_length = VectorizedArray<Number>::size();


### PR DESCRIPTION
- **MultiComponentVector: add insert_component() variant for a scalar dealii Vector**
- **OfflineData: switch lumped mass matrices over to ScalarVector wrapper**
- **HyperbolicModule: update interface for ScalarVector**
- **EulerPoisson: update interface for ScalarVector**
- **NavierStokes: update interface for ScalarVector**
