### PR TITLE
Simplify the calculation of the diagonal in Laplace

### DIFF
--- a/source/euler_poisson/laplace_operator.h
+++ b/source/euler_poisson/laplace_operator.h
@@ -17,6 +17,7 @@
 #include <deal.II/lac/precondition.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
 #include <deal.II/matrix_free/matrix_free.h>
+#include <deal.II/matrix_free/tools.h>
 #include <deal.II/multigrid/mg_base.h>
 #include <deal.II/multigrid/mg_coarse.h>
 #include <deal.II/multigrid/mg_matrix.h>
@@ -121,19 +122,18 @@ namespace ryujin
 
       using namespace dealii;
 
-      const auto body = [](const auto &data,
-                           auto &dst,
-                           const auto &src,
-                           const auto range) {
+      const auto body = [this](const auto &data,
+                               auto &dst,
+                               const auto &src,
+                               const auto range) {
         FEEvaluation<dim, order_fe, order_quad, /*components*/ 1, Number> fee(
             data, /*CG*/ 0, /*full quadrature*/ 0);
 
         for (unsigned int cell = range.first; cell < range.second; ++cell) {
           fee.reinit(cell);
-          fee.gather_evaluate(src, dealii::EvaluationFlags::gradients);
-          for (unsigned int q = 0; q < fee.n_q_points; ++q)
-            fee.submit_gradient(fee.get_gradient(q), q);
-          fee.integrate_scatter(dealii::EvaluationFlags::gradients, dst);
+          fee.read_dof_values(src);
+          apply_local_operator(fee);
+          fee.distribute_local_to_global(dst);
         }
       };
 
@@ -149,48 +149,17 @@ namespace ryujin
     void compute_diagonal(
         dealii::DiagonalMatrix<ScalarHostVector> &diagonal_matrix) const
     {
-      using namespace dealii;
-
       ScalarHostVector &diagonal_vector = diagonal_matrix.get_vector();
       matrix_free_->initialize_dof_vector(diagonal_vector, /*CG*/ 0);
 
-      const auto body_matrix_free =
-          [](const auto &data, auto &dst, const auto &, const auto range) {
-            FEEvaluation<dim, order_fe, order_quad, /*components*/ 1, Number>
-                fee_read(data, /*CG*/ 0, /*lumped quadrature*/ 1);
-            FEEvaluation<dim, order_fe, order_quad, /*components*/ 1, Number>
-                fee_write(data, /*CG*/ 0, /*lumped quadrature*/ 1);
-
-            for (unsigned int cell = range.first; cell < range.second; ++cell) {
-              fee_read.reinit(cell);
-              fee_write.reinit(cell);
-
-              for (unsigned int i = 0; i < fee_read.dofs_per_cell; ++i) {
-                /* Set up shape function for degree i: */
-                for (unsigned int j = 0; j < fee_read.dofs_per_cell; ++j)
-                  fee_read.begin_dof_values()[j] =
-                      dealii::VectorizedArray<Number>();
-                fee_read.begin_dof_values()[i] =
-                    dealii::make_vectorized_array<Number>(1.);
-
-                fee_read.evaluate(dealii::EvaluationFlags::gradients);
-                for (unsigned int q = 0; q < fee_write.n_q_points; ++q)
-                  fee_write.submit_gradient(fee_read.get_gradient(q), q);
-
-                fee_write.begin_dof_values()[i] =
-                    fee_read.begin_dof_values()[i];
-              }
-
-              fee_write.distribute_local_to_global(dst);
-            }
-          };
-
-      unsigned int dummy = 0;
-      matrix_free_->template cell_loop<ScalarHostVector, unsigned int>(
-          body_matrix_free,
+      dealii::MatrixFreeTools::compute_diagonal(
+          *matrix_free_,
           diagonal_vector,
-          dummy,
-          /*zero destination*/ true);
+          &LaplaceOperator::template apply_local_operator<
+              dealii::FEEvaluation<dim, -1, 0, 1, Number>>,
+          this,
+          0,
+          1);
 
       /* invert diagonal matrix: */
 
@@ -211,6 +180,15 @@ namespace ryujin
 
   private:
     const dealii::MatrixFree<dim, Number> *matrix_free_;
+
+    template <typename Evaluator>
+    void apply_local_operator(Evaluator &eval) const
+    {
+      eval.evaluate(dealii::EvaluationFlags::gradients);
+      for (const unsigned int q : eval.quadrature_point_indices())
+        eval.submit_gradient(eval.get_gradient(q), q);
+      eval.integrate(dealii::EvaluationFlags::gradients);
+    }
   };
 
 

--- a/source/navier_stokes/parabolic_module_gmg_operators.h
+++ b/source/navier_stokes/parabolic_module_gmg_operators.h
@@ -18,6 +18,7 @@
 #include <deal.II/base/vectorization.h>
 #include <deal.II/lac/diagonal_matrix.h>
 #include <deal.II/matrix_free/fe_evaluation.h>
+#include <deal.II/matrix_free/tools.h>
 #include <deal.II/multigrid/mg_base.h>
 #include <deal.II/multigrid/mg_transfer_matrix_free.h>
 
@@ -319,46 +320,27 @@ namespace ryujin
           matrix_free_->initialize_dof_vector(vector.block(d));
         vector.collect_sizes();
 
-        unsigned int dummy = 0;
-        matrix_free_->template cell_loop<block_vector_type, unsigned int>(
-            [this](
-                const auto &data, auto &dst, const auto &, const auto range) {
-              dealii::FEEvaluation<dim, order_fe, order_quad, dim, Number>
-                  velocity(data);
-              dealii::FEEvaluation<dim, order_fe, order_quad, dim, Number>
-                  writer(data);
-
-              for (unsigned int cell = range.first; cell < range.second;
-                   ++cell) {
-                velocity.reinit(cell);
-                writer.reinit(cell);
-                for (unsigned int i = 0; i < velocity.dofs_per_cell; ++i) {
-                  for (unsigned int j = 0; j < velocity.dofs_per_cell; ++j)
-                    velocity.begin_dof_values()[j] =
-                        dealii::VectorizedArray<Number>();
-                  velocity.begin_dof_values()[i] =
-                      dealii::make_vectorized_array<Number>(1.);
-                  apply_local_operator(velocity);
-                  writer.begin_dof_values()[i] = velocity.begin_dof_values()[i];
-                }
-                writer.distribute_local_to_global(dst);
-              }
-            },
+        dealii::MatrixFreeTools::compute_diagonal(
+            *matrix_free_,
             vector,
-            dummy,
-            /* zero destination */ true);
+            &VelocityMatrix::template apply_local_operator<
+                dealii::FEEvaluation<dim, -1, 0, dim, Number>>,
+            this);
 
         const auto &lumped_mass_matrix =
             offline_data_->level_lumped_mass_matrix()[level_];
         const unsigned int n_owned =
             lumped_mass_matrix.get_partitioner()->locally_owned_size();
 
-        const auto body_invert = [&](const auto &, const unsigned int i) {
+        const auto body_invert = [&](auto sentinel, const unsigned int i) {
+          using T = decltype(sentinel);
           const auto m_i = lumped_mass_matrix.local_element(i);
           const auto rho_i = density_->local_element(i);
           for (unsigned int d = 0; d < dim; ++d)
-            vector.block(d).local_element(i) =
-                Number(1.) / (m_i * rho_i + vector.block(d).local_element(i));
+            write_entry(vector.block(d),
+                        Number(1.) /
+                            (m_i * rho_i + read_entry<T>(vector.block(d), i)),
+                        i);
         };
 
         cpu_simd_loop<Number>("", body_invert, 0, n_owned, n_owned);
@@ -413,7 +395,7 @@ namespace ryujin
 
         velocity.evaluate(dealii::EvaluationFlags::gradients);
 
-        for (unsigned int q = 0; q < velocity.n_q_points; ++q) {
+        for (const unsigned int q : velocity.quadrature_point_indices()) {
           if constexpr (dim == 1) {
             /* Workaround: no symmetric gradient for dim == 1: */
             const auto gradient = velocity.get_gradient(q);
@@ -682,34 +664,12 @@ namespace ryujin
         const vector_type &lumped_mass_matrix =
             offline_data_->level_lumped_mass_matrix()[level_];
 
-        unsigned int dummy = 0;
-        matrix_free_->template cell_loop<vector_type, unsigned int>(
-            [this](
-                const auto &data, auto &dst, const auto &, const auto range) {
-              dealii::FEEvaluation<dim, order_fe, order_quad, 1, Number> energy(
-                  data);
-              dealii::FEEvaluation<dim, order_fe, order_quad, 1, Number> writer(
-                  data);
-
-              for (unsigned int cell = range.first; cell < range.second;
-                   ++cell) {
-                energy.reinit(cell);
-                writer.reinit(cell);
-                for (unsigned int i = 0; i < energy.dofs_per_cell; ++i) {
-                  for (unsigned int j = 0; j < energy.dofs_per_cell; ++j)
-                    energy.begin_dof_values()[j] =
-                        dealii::VectorizedArray<Number>();
-                  energy.begin_dof_values()[i] =
-                      dealii::make_vectorized_array<Number>(1.);
-                  apply_local_operator(energy);
-                  writer.begin_dof_values()[i] = energy.begin_dof_values()[i];
-                }
-                writer.distribute_local_to_global(dst);
-              }
-            },
+        dealii::MatrixFreeTools::compute_diagonal(
+            *matrix_free_,
             vector,
-            dummy,
-            /* zero destination */ true);
+            &EnergyMatrix::template apply_local_operator<
+                dealii::FEEvaluation<dim, -1, 0, dim, Number>>,
+            this);
 
         const unsigned int n_owned =
             lumped_mass_matrix.get_partitioner()->locally_owned_size();


### PR DESCRIPTION
This only addresses a single place, and does not address all problems with have with the diagonal computation and handling of lumped mass matrices, but let me propose this as a way to use `dealii::MatrixFreeTools::compute_diagonal()` in a way that shares the code between the `vmult()` and the diagonal computation, and does so with less code. Right now, I did this with a class function `compute_cell_operation()`, but we might discuss if we want to make it a lambda or free function.