### PR TITLE
Module refactoring: make naming of Indicator, WaveSpeedEstimator, and Limiter consistent

### DIFF
--- a/source/euler/description.h
+++ b/source/euler/description.h
@@ -43,13 +43,13 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = Euler::Indicator<dim, Number>;
+      using Indicator = Euler::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = Euler::Limiter<dim, Number>;
+      using Limiter = Euler::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = Euler::WaveSpeedEstimator<dim, Number>;
+      using WaveSpeedEstimator = Euler::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/description.h
+++ b/source/euler/description.h
@@ -43,13 +43,13 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = Euler::IndicatorView<dim, Number>;
+      using IndicatorView = Euler::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = Euler::LimiterView<dim, Number>;
+      using LimiterView = Euler::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = Euler::WaveSpeedEstimatorView<dim, Number>;
+      using WaveSpeedEstimatorView = Euler::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -527,7 +527,7 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
        *   const auto flux_i = flux_contribution(precomputed..., i, U_i);

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -20,10 +20,10 @@ namespace ryujin
   namespace Euler
   {
     template <typename ScalarNumber = double>
-    class IndicatorParameters : public dealii::ParameterAcceptor
+    class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection = "/Indicator")
+      Indicator(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
@@ -79,7 +79,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class Indicator
+    class IndicatorView
     {
     public:
       /**
@@ -101,7 +101,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = IndicatorParameters<ScalarNumber>;
+      using Parameters = Indicator<ScalarNumber>;
 
       //@}
       /**
@@ -109,15 +109,15 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator.reset(i, U_i);
+       *   indicator_view.reset(i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(js, U_j, c_ij);
        *   }
-       *   indicator.alpha(hd_i);
+       *   indicator_view.alpha(hd_i);
        * }
        * ```
        */
@@ -126,9 +126,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Indicator(const HyperbolicSystem &hyperbolic_system,
-                const Parameters &parameters,
-                const PrecomputedVector &precomputed_values)
+      IndicatorView(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -187,7 +187,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
+    IndicatorView<dim, Number>::reset(const unsigned int i,
+                                      const state_type &U_i)
     {
       /* Entropy viscosity commutator: */
 
@@ -210,7 +211,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Indicator<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
         const unsigned int *js,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -241,7 +242,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i) const
+    IndicatorView<dim, Number>::alpha(const Number hd_i) const
     {
       /* Entropy viscosity commutator: */
 

--- a/source/euler/limiter.cc
+++ b/source/euler/limiter.cc
@@ -13,12 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class Limiter<1, NUMBER>;
-    template class Limiter<2, NUMBER>;
-    template class Limiter<3, NUMBER>;
+    template class LimiterView<1, NUMBER>;
+    template class LimiterView<2, NUMBER>;
+    template class LimiterView<3, NUMBER>;
 
-    template class Limiter<1, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<2, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<3, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<1, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<2, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -20,10 +20,10 @@ namespace ryujin
   namespace Euler
   {
     template <typename ScalarNumber = double>
-    class LimiterParameters : public dealii::ParameterAcceptor
+    class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection = "/Limiter")
+      Limiter(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;
@@ -95,7 +95,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class Limiter
+    class LimiterView
     {
     public:
       /**
@@ -117,7 +117,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = LimiterParameters<ScalarNumber>;
+      using Parameters = Limiter<ScalarNumber>;
 
       //@}
       /**
@@ -138,9 +138,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Limiter(const HyperbolicSystem &hyperbolic_system,
-              const Parameters &parameters,
-              const PrecomputedVector &precomputed_values)
+      LimiterView(const HyperbolicSystem &hyperbolic_system,
+                  const Parameters &parameters,
+                  const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -178,15 +178,16 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Limiter<dim, Number> limiter;
+       * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i, flux_i);
+       *   limiter_view.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
+       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       * affine_shift);
        *   }
-       *   limiter.bounds(hd_i);
+       *   limiter_view.bounds(hd_i);
        * }
        * ```
        */
@@ -269,7 +270,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::projection_bounds_from_state(
+    LimiterView<dim, Number>::projection_bounds_from_state(
         const unsigned int i, const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -282,7 +283,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto Limiter<dim, Number>::combine_bounds(
+    DEAL_II_ALWAYS_INLINE inline auto LimiterView<dim, Number>::combine_bounds(
         const Bounds &bounds_left, const Bounds &bounds_right) const -> Bounds
     {
       const auto &[rho_min_l, rho_max_l, s_min_l] = bounds_left;
@@ -296,8 +297,9 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::fully_relax_bounds(const Bounds &bounds,
-                                             const Number &hd) const -> Bounds
+    LimiterView<dim, Number>::fully_relax_bounds(const Bounds &bounds,
+                                                 const Number &hd) const
+        -> Bounds
     {
       auto relaxed_bounds = bounds;
       auto &[rho_min, rho_max, s_min] = relaxed_bounds;
@@ -321,10 +323,10 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void
-    Limiter<dim, Number>::reset(const unsigned int /*i*/,
-                                const state_type &new_U_i,
-                                const flux_contribution_type & /*new_flux_i*/)
+    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::reset(
+        const unsigned int /*i*/,
+        const state_type &new_U_i,
+        const flux_contribution_type & /*new_flux_i*/)
     {
       U_i = new_U_i;
 
@@ -345,7 +347,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Limiter<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
         const unsigned int *js,
         const state_type &U_j,
         const flux_contribution_type & /*flux_j*/,
@@ -397,7 +399,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::bounds(const Number hd_i) const -> Bounds
+    LimiterView<dim, Number>::bounds(const Number hd_i) const -> Bounds
     {
       const auto &[rho_min, rho_max, s_min] = bounds_;
 

--- a/source/euler/limiter.template.h
+++ b/source/euler/limiter.template.h
@@ -14,11 +14,11 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const Bounds &bounds,
-                                const state_type &U,
-                                const state_type &P,
-                                const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */) const
+    LimiterView<dim, Number>::limit(const Bounds &bounds,
+                                    const state_type &U,
+                                    const state_type &P,
+                                    const Number t_min /* = Number(0.) */,
+                                    const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/euler/wave_speed_estimator.cc
+++ b/source/euler/wave_speed_estimator.cc
@@ -13,13 +13,13 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class WaveSpeedEstimator<1, NUMBER>;
-    template class WaveSpeedEstimator<2, NUMBER>;
-    template class WaveSpeedEstimator<3, NUMBER>;
+    template class WaveSpeedEstimatorView<1, NUMBER>;
+    template class WaveSpeedEstimatorView<2, NUMBER>;
+    template class WaveSpeedEstimatorView<3, NUMBER>;
 
-    template class WaveSpeedEstimator<1, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<2, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<3, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<1, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<2, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<3, dealii::VectorizedArray<NUMBER>>;
 
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/wave_speed_estimator.h
+++ b/source/euler/wave_speed_estimator.h
@@ -19,11 +19,10 @@ namespace ryujin
   namespace Euler
   {
     template <typename ScalarNumber = double>
-    class WaveSpeedEstimatorParameters : public dealii::ParameterAcceptor
+    class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimatorParameters(
-          const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
       {
         if constexpr (std::is_same<ScalarNumber, double>::value)
@@ -60,7 +59,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class WaveSpeedEstimator
+    class WaveSpeedEstimatorView
     {
     public:
       /**
@@ -92,7 +91,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = WaveSpeedEstimatorParameters<ScalarNumber>;
+      using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
       //@}
       /**
@@ -103,9 +102,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
-                         const Parameters &parameters,
-                         const PrecomputedVector &precomputed_values)
+      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
+                             const Parameters &parameters,
+                             const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)

--- a/source/euler/wave_speed_estimator.template.h
+++ b/source/euler/wave_speed_estimator.template.h
@@ -18,8 +18,8 @@ namespace ryujin
   {
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::f(const primitive_type &riemann_data,
-                                       const Number p_star) const
+    WaveSpeedEstimatorView<dim, Number>::f(const primitive_type &riemann_data,
+                                           const Number p_star) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
       const auto &gamma = view.gamma();
@@ -46,8 +46,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::df(const primitive_type &riemann_data,
-                                        const Number &p_star) const
+    WaveSpeedEstimatorView<dim, Number>::df(const primitive_type &riemann_data,
+                                            const Number &p_star) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -84,9 +84,10 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::phi(const primitive_type &riemann_data_i,
-                                         const primitive_type &riemann_data_j,
-                                         const Number p_in) const
+    WaveSpeedEstimatorView<dim, Number>::phi(
+        const primitive_type &riemann_data_i,
+        const primitive_type &riemann_data_j,
+        const Number p_in) const
     {
       const Number &u_i = riemann_data_i[1];
       const Number &u_j = riemann_data_j[1];
@@ -97,9 +98,10 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::dphi(const primitive_type &riemann_data_i,
-                                          const primitive_type &riemann_data_j,
-                                          const Number &p) const
+    WaveSpeedEstimatorView<dim, Number>::dphi(
+        const primitive_type &riemann_data_i,
+        const primitive_type &riemann_data_j,
+        const Number &p) const
     {
       return df(riemann_data_i, p) + df(riemann_data_j, p);
     }
@@ -119,7 +121,7 @@ namespace ryujin
      */
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::phi_of_p_max(
+    WaveSpeedEstimatorView<dim, Number>::phi_of_p_max(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -161,7 +163,7 @@ namespace ryujin
      */
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::lambda1_minus(
+    WaveSpeedEstimatorView<dim, Number>::lambda1_minus(
         const primitive_type &riemann_data, const Number p_star) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -186,7 +188,7 @@ namespace ryujin
      */
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::lambda3_plus(
+    WaveSpeedEstimatorView<dim, Number>::lambda3_plus(
         const primitive_type &primitive_state, const Number p_star) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -214,7 +216,7 @@ namespace ryujin
      */
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline std::array<Number, 2>
-    WaveSpeedEstimator<dim, Number>::compute_gap(
+    WaveSpeedEstimatorView<dim, Number>::compute_gap(
         const std::array<Number, 4> &riemann_data_i,
         const std::array<Number, 4> &riemann_data_j,
         const Number p_1,
@@ -249,7 +251,7 @@ namespace ryujin
      */
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::compute_lambda(
+    WaveSpeedEstimatorView<dim, Number>::compute_lambda(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j,
         const Number p_star) const
@@ -271,7 +273,7 @@ namespace ryujin
      */
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::p_star_two_rarefaction(
+    WaveSpeedEstimatorView<dim, Number>::p_star_two_rarefaction(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -327,7 +329,7 @@ namespace ryujin
      */
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::p_star_failsafe(
+    WaveSpeedEstimatorView<dim, Number>::p_star_failsafe(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -374,7 +376,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    WaveSpeedEstimator<dim, Number>::riemann_data_from_state(
+    WaveSpeedEstimatorView<dim, Number>::riemann_data_from_state(
         const state_type &U, const dealii::Tensor<1, dim, Number> &n_ij) const
         -> primitive_type
     {
@@ -402,7 +404,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    Number WaveSpeedEstimator<dim, Number>::compute(
+    Number WaveSpeedEstimatorView<dim, Number>::compute(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -582,7 +584,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::compute(
+    WaveSpeedEstimatorView<dim, Number>::compute(
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int /*i*/,

--- a/source/euler_aeos/description.h
+++ b/source/euler_aeos/description.h
@@ -44,13 +44,13 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = EulerAEOS::Indicator<dim, Number>;
+      using Indicator = EulerAEOS::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = EulerAEOS::Limiter<dim, Number>;
+      using Limiter = EulerAEOS::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = EulerAEOS::WaveSpeedEstimator<dim, Number>;
+      using WaveSpeedEstimator = EulerAEOS::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/euler_aeos/description.h
+++ b/source/euler_aeos/description.h
@@ -44,13 +44,14 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = EulerAEOS::IndicatorView<dim, Number>;
+      using IndicatorView = EulerAEOS::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = EulerAEOS::LimiterView<dim, Number>;
+      using LimiterView = EulerAEOS::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = EulerAEOS::WaveSpeedEstimatorView<dim, Number>;
+      using WaveSpeedEstimatorView =
+          EulerAEOS::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -704,7 +704,7 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
        *   const auto flux_i = flux_contribution(precomputed..., i, U_i);

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -21,10 +21,10 @@ namespace ryujin
   namespace EulerAEOS
   {
     template <typename ScalarNumber = double>
-    class IndicatorParameters : public dealii::ParameterAcceptor
+    class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection = "/Indicator")
+      Indicator(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
@@ -80,7 +80,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class Indicator
+    class IndicatorView
     {
     public:
       /**
@@ -102,7 +102,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = IndicatorParameters<ScalarNumber>;
+      using Parameters = Indicator<ScalarNumber>;
 
       //@}
       /**
@@ -110,15 +110,15 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator.reset(i, U_i);
+       *   indicator_view.reset(i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(js, U_j, c_ij);
        *   }
-       *   indicator.alpha(hd_i);
+       *   indicator_view.alpha(hd_i);
        * }
        * ```
        */
@@ -127,9 +127,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Indicator(const HyperbolicSystem &hyperbolic_system,
-                const Parameters &parameters,
-                const PrecomputedVector &precomputed_values)
+      IndicatorView(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -189,7 +189,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
+    IndicatorView<dim, Number>::reset(const unsigned int i,
+                                      const state_type &U_i)
     {
       /* Entropy viscosity commutator: */
 
@@ -216,7 +217,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Indicator<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
         const unsigned int * /*js*/,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -248,7 +249,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i) const
+    IndicatorView<dim, Number>::alpha(const Number hd_i) const
     {
       /* Entropy viscosity commutator: */
 

--- a/source/euler_aeos/limiter.cc
+++ b/source/euler_aeos/limiter.cc
@@ -13,12 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class Limiter<1, NUMBER>;
-    template class Limiter<2, NUMBER>;
-    template class Limiter<3, NUMBER>;
+    template class LimiterView<1, NUMBER>;
+    template class LimiterView<2, NUMBER>;
+    template class LimiterView<3, NUMBER>;
 
-    template class Limiter<1, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<2, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<3, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<1, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<2, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -18,10 +18,10 @@ namespace ryujin
   namespace EulerAEOS
   {
     template <typename ScalarNumber = double>
-    class LimiterParameters : public dealii::ParameterAcceptor
+    class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection = "/Limiter")
+      Limiter(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;
@@ -95,7 +95,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class Limiter
+    class LimiterView
     {
     public:
       /**
@@ -117,7 +117,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = LimiterParameters<ScalarNumber>;
+      using Parameters = Limiter<ScalarNumber>;
 
       //@}
       /**
@@ -138,9 +138,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Limiter(const HyperbolicSystem &hyperbolic_system,
-              const Parameters &parameters,
-              const PrecomputedVector &precomputed_values)
+      LimiterView(const HyperbolicSystem &hyperbolic_system,
+                  const Parameters &parameters,
+                  const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -178,15 +178,16 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Limiter<dim, Number> limiter;
+       * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i, flux_i);
+       *   limiter_view.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
+       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       * affine_shift);
        *   }
-       *   limiter.bounds(hd_i);
+       *   limiter_view.bounds(hd_i);
        * }
        * ```
        */
@@ -270,7 +271,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::projection_bounds_from_state(
+    LimiterView<dim, Number>::projection_bounds_from_state(
         const unsigned int i, const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -286,7 +287,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto Limiter<dim, Number>::combine_bounds(
+    DEAL_II_ALWAYS_INLINE inline auto LimiterView<dim, Number>::combine_bounds(
         const Bounds &bounds_left, const Bounds &bounds_right) const -> Bounds
     {
       const auto &[rho_min_l, rho_max_l, s_min_l, gamma_min_l] = bounds_left;
@@ -301,8 +302,9 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::fully_relax_bounds(const Bounds &bounds,
-                                             const Number &hd) const -> Bounds
+    LimiterView<dim, Number>::fully_relax_bounds(const Bounds &bounds,
+                                                 const Number &hd) const
+        -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -346,9 +348,9 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Limiter<dim, Number>::reset(const unsigned int i,
-                                const state_type &new_U_i,
-                                const flux_contribution_type &new_flux_i)
+    LimiterView<dim, Number>::reset(const unsigned int i,
+                                    const state_type &new_U_i,
+                                    const flux_contribution_type &new_flux_i)
     {
       U_i = new_U_i;
       flux_i = new_flux_i;
@@ -375,7 +377,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Limiter<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
         const unsigned int *js,
         const state_type &U_j,
         const flux_contribution_type &flux_j,
@@ -465,7 +467,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::bounds(const Number hd_i) const -> Bounds
+    LimiterView<dim, Number>::bounds(const Number hd_i) const -> Bounds
     {
       const auto &[rho_min, rho_max, s_min, gamma_min] = bounds_;
 

--- a/source/euler_aeos/limiter.template.h
+++ b/source/euler_aeos/limiter.template.h
@@ -14,11 +14,11 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const Bounds &bounds,
-                                const state_type &U,
-                                const state_type &P,
-                                const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */) const
+    LimiterView<dim, Number>::limit(const Bounds &bounds,
+                                    const state_type &U,
+                                    const state_type &P,
+                                    const Number t_min /* = Number(0.) */,
+                                    const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/euler_aeos/wave_speed_estimator.cc
+++ b/source/euler_aeos/wave_speed_estimator.cc
@@ -13,12 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class WaveSpeedEstimator<1, NUMBER>;
-    template class WaveSpeedEstimator<2, NUMBER>;
-    template class WaveSpeedEstimator<3, NUMBER>;
+    template class WaveSpeedEstimatorView<1, NUMBER>;
+    template class WaveSpeedEstimatorView<2, NUMBER>;
+    template class WaveSpeedEstimatorView<3, NUMBER>;
 
-    template class WaveSpeedEstimator<1, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<2, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<3, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<1, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<2, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/euler_aeos/wave_speed_estimator.h
+++ b/source/euler_aeos/wave_speed_estimator.h
@@ -19,11 +19,10 @@ namespace ryujin
   namespace EulerAEOS
   {
     template <typename ScalarNumber = double>
-    class WaveSpeedEstimatorParameters : public dealii::ParameterAcceptor
+    class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimatorParameters(
-          const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
       {
       }
@@ -40,7 +39,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class WaveSpeedEstimator
+    class WaveSpeedEstimatorView
     {
     public:
       /**
@@ -72,7 +71,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = WaveSpeedEstimatorParameters<ScalarNumber>;
+      using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
       //@}
       /**
@@ -83,9 +82,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
-                         const Parameters &parameters,
-                         const PrecomputedVector &precomputed_values)
+      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
+                             const Parameters &parameters,
+                             const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)

--- a/source/euler_aeos/wave_speed_estimator.template.h
+++ b/source/euler_aeos/wave_speed_estimator.template.h
@@ -17,8 +17,8 @@ namespace ryujin
   namespace EulerAEOS
   {
     /*
-     * The WaveSpeedEstimator is a guaranteed maximal wavespeed (GMS) estimate
-     * for the extended Riemann problem outlined in
+     * The WaveSpeedEstimatorView is a guaranteed maximal wavespeed (GMS)
+     * estimate for the extended Riemann problem outlined in
      * @cite ClaytonGuermondPopov-2022. For extenstions on handling negative
      * pressures, we follow @cite clayton2023robust (see §4.6).
      *
@@ -48,7 +48,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::c(const Number &gamma) const
+    WaveSpeedEstimatorView<dim, Number>::c(const Number &gamma) const
     {
       /*
        * We implement the continuous and monotonic function c(gamma) as
@@ -81,8 +81,10 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline Number WaveSpeedEstimator<dim, Number>::alpha(
-        const Number &rho, const Number &gamma, const Number &a) const
+    DEAL_II_ALWAYS_INLINE inline Number
+    WaveSpeedEstimatorView<dim, Number>::alpha(const Number &rho,
+                                               const Number &gamma,
+                                               const Number &a) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
       const auto covolume_b = view.eos_covolume_constant();
@@ -98,7 +100,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::p_star_RS_full(
+    WaveSpeedEstimatorView<dim, Number>::p_star_RS_full(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -214,7 +216,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::p_star_SS_full(
+    WaveSpeedEstimatorView<dim, Number>::p_star_SS_full(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -268,7 +270,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::p_star_failsafe(
+    WaveSpeedEstimatorView<dim, Number>::p_star_failsafe(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -324,7 +326,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::p_star_interpolated(
+    WaveSpeedEstimatorView<dim, Number>::p_star_interpolated(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -412,8 +414,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::f(const primitive_type &riemann_data,
-                                       const Number p_star) const
+    WaveSpeedEstimatorView<dim, Number>::f(const primitive_type &riemann_data,
+                                           const Number p_star) const
     {
       constexpr ScalarNumber min = std::numeric_limits<ScalarNumber>::min();
 
@@ -453,9 +455,10 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::phi(const primitive_type &riemann_data_i,
-                                         const primitive_type &riemann_data_j,
-                                         const Number p_in) const
+    WaveSpeedEstimatorView<dim, Number>::phi(
+        const primitive_type &riemann_data_i,
+        const primitive_type &riemann_data_j,
+        const Number p_in) const
     {
       const Number &u_i = riemann_data_i[1];
       const Number &u_j = riemann_data_j[1];
@@ -466,7 +469,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::phi_of_p_max(
+    WaveSpeedEstimatorView<dim, Number>::phi_of_p_max(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -503,7 +506,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::lambda1_minus(
+    WaveSpeedEstimatorView<dim, Number>::lambda1_minus(
         const primitive_type &riemann_data, const Number p_star) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -522,7 +525,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::lambda3_plus(
+    WaveSpeedEstimatorView<dim, Number>::lambda3_plus(
         const primitive_type &riemann_data, const Number p_star) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -541,7 +544,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::compute_lambda(
+    WaveSpeedEstimatorView<dim, Number>::compute_lambda(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j,
         const Number p_star) const
@@ -555,7 +558,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    WaveSpeedEstimator<dim, Number>::riemann_data_from_state(
+    WaveSpeedEstimatorView<dim, Number>::riemann_data_from_state(
         const state_type &U,
         const Number &p,
         const dealii::Tensor<1, dim, Number> &n_ij) const -> primitive_type
@@ -597,7 +600,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    Number WaveSpeedEstimator<dim, Number>::compute(
+    Number WaveSpeedEstimatorView<dim, Number>::compute(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -684,7 +687,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::compute(
+    WaveSpeedEstimatorView<dim, Number>::compute(
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int i,

--- a/source/euler_barotropic/description.h
+++ b/source/euler_barotropic/description.h
@@ -47,13 +47,13 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = EulerBarotropic::IndicatorView<dim, Number>;
+      using IndicatorView = EulerBarotropic::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = EulerBarotropic::LimiterView<dim, Number>;
+      using LimiterView = EulerBarotropic::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator =
+      using WaveSpeedEstimatorView =
           EulerBarotropic::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerBarotropic

--- a/source/euler_barotropic/description.h
+++ b/source/euler_barotropic/description.h
@@ -47,14 +47,14 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = EulerBarotropic::Indicator<dim, Number>;
+      using Indicator = EulerBarotropic::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = EulerBarotropic::Limiter<dim, Number>;
+      using Limiter = EulerBarotropic::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
       using WaveSpeedEstimator =
-          EulerBarotropic::WaveSpeedEstimator<dim, Number>;
+          EulerBarotropic::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerBarotropic
 } // namespace ryujin

--- a/source/euler_barotropic/hyperbolic_system.h
+++ b/source/euler_barotropic/hyperbolic_system.h
@@ -521,7 +521,7 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
        *   const auto flux_i = flux_contribution(precomputed..., i, U_i);

--- a/source/euler_barotropic/indicator.h
+++ b/source/euler_barotropic/indicator.h
@@ -21,10 +21,10 @@ namespace ryujin
   namespace EulerBarotropic
   {
     template <typename ScalarNumber = double>
-    class IndicatorParameters : public dealii::ParameterAcceptor
+    class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection = "/Indicator")
+      Indicator(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
@@ -47,7 +47,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class Indicator
+    class IndicatorView
     {
     public:
       /**
@@ -69,7 +69,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = IndicatorParameters<ScalarNumber>;
+      using Parameters = Indicator<ScalarNumber>;
 
       //@}
       /**
@@ -77,15 +77,15 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator.reset(i, U_i);
+       *   indicator_view.reset(i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(js, U_j, c_ij);
        *   }
-       *   indicator.alpha(hd_i);
+       *   indicator_view.alpha(hd_i);
        * }
        * ```
        */
@@ -94,9 +94,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Indicator(const HyperbolicSystem &hyperbolic_system,
-                const Parameters &parameters,
-                const PrecomputedVector &precomputed_values)
+      IndicatorView(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -153,7 +153,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
+    IndicatorView<dim, Number>::reset(const unsigned int i,
+                                      const state_type &U_i)
     {
       /* Entropy viscosity commutator: */
 
@@ -174,7 +175,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Indicator<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
         const unsigned int *js,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -205,7 +206,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i) const
+    IndicatorView<dim, Number>::alpha(const Number hd_i) const
     {
       /* Entropy viscosity commutator: */
 

--- a/source/euler_barotropic/limiter.cc
+++ b/source/euler_barotropic/limiter.cc
@@ -13,12 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class Limiter<1, NUMBER>;
-    template class Limiter<2, NUMBER>;
-    template class Limiter<3, NUMBER>;
+    template class LimiterView<1, NUMBER>;
+    template class LimiterView<2, NUMBER>;
+    template class LimiterView<3, NUMBER>;
 
-    template class Limiter<1, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<2, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<3, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<1, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<2, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace EulerBarotropic
 } // namespace ryujin

--- a/source/euler_barotropic/limiter.h
+++ b/source/euler_barotropic/limiter.h
@@ -18,10 +18,10 @@ namespace ryujin
   namespace EulerBarotropic
   {
     template <typename ScalarNumber = double>
-    class LimiterParameters : public dealii::ParameterAcceptor
+    class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection = "/Limiter")
+      Limiter(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;
@@ -50,7 +50,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class Limiter
+    class LimiterView
     {
     public:
       /**
@@ -72,7 +72,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = LimiterParameters<ScalarNumber>;
+      using Parameters = Limiter<ScalarNumber>;
 
       //@}
       /**
@@ -93,9 +93,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Limiter(const HyperbolicSystem &hyperbolic_system,
-              const Parameters &parameters,
-              const PrecomputedVector &precomputed_values)
+      LimiterView(const HyperbolicSystem &hyperbolic_system,
+                  const Parameters &parameters,
+                  const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -133,15 +133,16 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Limiter<dim, Number> limiter;
+       * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i, flux_i);
+       *   limiter_view.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
+       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       * affine_shift);
        *   }
-       *   limiter.bounds(hd_i);
+       *   limiter_view.bounds(hd_i);
        * }
        * ```
        */
@@ -224,7 +225,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::projection_bounds_from_state(
+    LimiterView<dim, Number>::projection_bounds_from_state(
         const unsigned int /*i*/, const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -234,7 +235,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto Limiter<dim, Number>::combine_bounds(
+    DEAL_II_ALWAYS_INLINE inline auto LimiterView<dim, Number>::combine_bounds(
         const Bounds &bounds_left, const Bounds &bounds_right) const -> Bounds
     {
       const auto &[rho_min_l, rho_max_l] = bounds_left;
@@ -246,8 +247,9 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::fully_relax_bounds(const Bounds &bounds,
-                                             const Number &hd) const -> Bounds
+    LimiterView<dim, Number>::fully_relax_bounds(const Bounds &bounds,
+                                                 const Number &hd) const
+        -> Bounds
     {
       auto relaxed_bounds = bounds;
       auto &[rho_min_relaxed, rho_max_relaxed] = relaxed_bounds;
@@ -271,9 +273,9 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Limiter<dim, Number>::reset(const unsigned int /*i*/,
-                                const state_type &new_U_i,
-                                const flux_contribution_type &new_flux_i)
+    LimiterView<dim, Number>::reset(const unsigned int /*i*/,
+                                    const state_type &new_U_i,
+                                    const flux_contribution_type &new_flux_i)
     {
       U_i = new_U_i;
       flux_i = new_flux_i;
@@ -293,7 +295,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Limiter<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
         const unsigned int * /*js*/,
         const state_type &U_j,
         const flux_contribution_type &flux_j,
@@ -339,7 +341,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::bounds(const Number hd_i) const -> Bounds
+    LimiterView<dim, Number>::bounds(const Number hd_i) const -> Bounds
     {
       const auto &[rho_min, rho_max] = bounds_;
 

--- a/source/euler_barotropic/limiter.template.h
+++ b/source/euler_barotropic/limiter.template.h
@@ -14,11 +14,11 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const Bounds &bounds,
-                                const state_type &U,
-                                const state_type &P,
-                                const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */) const
+    LimiterView<dim, Number>::limit(const Bounds &bounds,
+                                    const state_type &U,
+                                    const state_type &P,
+                                    const Number t_min /* = Number(0.) */,
+                                    const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/euler_barotropic/wave_speed_estimator.cc
+++ b/source/euler_barotropic/wave_speed_estimator.cc
@@ -13,12 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class WaveSpeedEstimator<1, NUMBER>;
-    template class WaveSpeedEstimator<2, NUMBER>;
-    template class WaveSpeedEstimator<3, NUMBER>;
+    template class WaveSpeedEstimatorView<1, NUMBER>;
+    template class WaveSpeedEstimatorView<2, NUMBER>;
+    template class WaveSpeedEstimatorView<3, NUMBER>;
 
-    template class WaveSpeedEstimator<1, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<2, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<3, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<1, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<2, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace EulerBarotropic
 } // namespace ryujin

--- a/source/euler_barotropic/wave_speed_estimator.h
+++ b/source/euler_barotropic/wave_speed_estimator.h
@@ -19,11 +19,10 @@ namespace ryujin
   namespace EulerBarotropic
   {
     template <typename ScalarNumber = double>
-    class WaveSpeedEstimatorParameters : public dealii::ParameterAcceptor
+    class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimatorParameters(
-          const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
       {
       }
@@ -39,7 +38,7 @@ namespace ryujin
      * @ingroup EulerEquations
      */
     template <int dim, typename Number = double>
-    class WaveSpeedEstimator
+    class WaveSpeedEstimatorView
     {
     public:
       /**
@@ -70,7 +69,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = WaveSpeedEstimatorParameters<ScalarNumber>;
+      using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
       //@}
       /**
@@ -81,9 +80,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
-                         const Parameters &parameters,
-                         const PrecomputedVector &precomputed_values)
+      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
+                             const Parameters &parameters,
+                             const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)

--- a/source/euler_barotropic/wave_speed_estimator.template.h
+++ b/source/euler_barotropic/wave_speed_estimator.template.h
@@ -17,7 +17,7 @@ namespace ryujin
   namespace EulerBarotropic
   {
     template <int dim, typename Number>
-    Number WaveSpeedEstimator<dim, Number>::compute(
+    Number WaveSpeedEstimatorView<dim, Number>::compute(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -39,7 +39,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::compute(
+    WaveSpeedEstimatorView<dim, Number>::compute(
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int i,

--- a/source/euler_poisson/description.h
+++ b/source/euler_poisson/description.h
@@ -29,13 +29,13 @@ namespace ryujin
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = Euler::IndicatorView<dim, Number>;
+      using IndicatorView = Euler::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = Euler::LimiterView<dim, Number>;
+      using LimiterView = Euler::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = Euler::WaveSpeedEstimatorView<dim, Number>;
+      using WaveSpeedEstimatorView = Euler::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerPoisson
 } // namespace ryujin

--- a/source/euler_poisson/description.h
+++ b/source/euler_poisson/description.h
@@ -29,13 +29,13 @@ namespace ryujin
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = Euler::Indicator<dim, Number>;
+      using Indicator = Euler::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = Euler::Limiter<dim, Number>;
+      using Limiter = Euler::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = Euler::WaveSpeedEstimator<dim, Number>;
+      using WaveSpeedEstimator = Euler::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerPoisson
 } // namespace ryujin

--- a/source/euler_poisson_aeos/description.h
+++ b/source/euler_poisson_aeos/description.h
@@ -29,13 +29,14 @@ namespace ryujin
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = EulerAEOS::IndicatorView<dim, Number>;
+      using IndicatorView = EulerAEOS::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = EulerAEOS::LimiterView<dim, Number>;
+      using LimiterView = EulerAEOS::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = EulerAEOS::WaveSpeedEstimatorView<dim, Number>;
+      using WaveSpeedEstimatorView =
+          EulerAEOS::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerPoissonAEOS
 } // namespace ryujin

--- a/source/euler_poisson_aeos/description.h
+++ b/source/euler_poisson_aeos/description.h
@@ -29,13 +29,13 @@ namespace ryujin
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = EulerAEOS::Indicator<dim, Number>;
+      using Indicator = EulerAEOS::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = EulerAEOS::Limiter<dim, Number>;
+      using Limiter = EulerAEOS::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = EulerAEOS::WaveSpeedEstimator<dim, Number>;
+      using WaveSpeedEstimator = EulerAEOS::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerPoissonAEOS
 } // namespace ryujin

--- a/source/euler_poisson_barotropic/description.h
+++ b/source/euler_poisson_barotropic/description.h
@@ -30,14 +30,14 @@ namespace ryujin
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = EulerBarotropic::Indicator<dim, Number>;
+      using Indicator = EulerBarotropic::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = EulerBarotropic::Limiter<dim, Number>;
+      using Limiter = EulerBarotropic::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
       using WaveSpeedEstimator =
-          EulerBarotropic::WaveSpeedEstimator<dim, Number>;
+          EulerBarotropic::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerPoissonBarotropic
 } // namespace ryujin

--- a/source/euler_poisson_barotropic/description.h
+++ b/source/euler_poisson_barotropic/description.h
@@ -30,13 +30,13 @@ namespace ryujin
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = EulerBarotropic::IndicatorView<dim, Number>;
+      using IndicatorView = EulerBarotropic::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = EulerBarotropic::LimiterView<dim, Number>;
+      using LimiterView = EulerBarotropic::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator =
+      using WaveSpeedEstimatorView =
           EulerBarotropic::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace EulerPoissonBarotropic

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -360,14 +360,15 @@ namespace ryujin
      * @name Run time options
      */
     //@{
-    typename Description::template Indicator<dim, Number>::Parameters
-        indicator_parameters_;
+    typename Description::template IndicatorView<dim, Number>::Parameters
+        indicator_;
 
-    typename Description::template Limiter<dim, Number>::Parameters
-        limiter_parameters_;
+    typename Description::template LimiterView<dim, Number>::Parameters
+        limiter_;
 
-    typename Description::template WaveSpeedEstimator<dim, Number>::Parameters
-        wave_speed_estimator_parameters_;
+    typename Description::template WaveSpeedEstimatorView<dim,
+                                                          Number>::Parameters
+        wave_speed_estimator_;
 
     //@}
     /**
@@ -398,7 +399,7 @@ namespace ryujin
     mutable ScalarVector alpha_;
 
     static constexpr auto n_bounds =
-        Description::template Limiter<dim, Number>::n_bounds;
+        Description::template LimiterView<dim, Number>::n_bounds;
     mutable Vectors::MultiComponentVector<Number, n_bounds> bounds_;
 
     using HyperbolicVector =

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -31,9 +31,9 @@ namespace ryujin
       const InitialValues<Description, dim, Number> &initial_values,
       const std::string &subsection /*= "HyperbolicModule"*/)
       : ParameterAcceptor(subsection)
-      , indicator_parameters_(subsection + "/indicator")
-      , limiter_parameters_(subsection + "/limiter")
-      , wave_speed_estimator_parameters_(subsection + "/wave speed estimator")
+      , indicator_(subsection + "/indicator")
+      , limiter_(subsection + "/limiter")
+      , wave_speed_estimator_(subsection + "/wave speed estimator")
       , mpi_ensemble_(mpi_ensemble)
       , computing_timer_(computing_timer)
       , offline_data_(&offline_data)
@@ -57,7 +57,7 @@ namespace ryujin
               << std::endl;
 #endif
 
-    AssertThrow(limiter_parameters_.iterations() <= 2,
+    AssertThrow(limiter_.iterations() <= 2,
                 dealii::ExcMessage(
                     "The number of limiter iterations must be between [0,2]"));
 
@@ -345,16 +345,15 @@ namespace ryujin
         using T = decltype(sentinel);
         constexpr unsigned int stride_size = get_stride_size<T>;
 
-        using WaveSpeedEstimator =
-            typename Description::template WaveSpeedEstimator<dim, T>;
-        WaveSpeedEstimator wave_speed_estimator(
-            *hyperbolic_system_,
-            wave_speed_estimator_parameters_,
-            old_precomputed);
+        using WaveSpeedEstimatorView =
+            typename Description::template WaveSpeedEstimatorView<dim, T>;
+        WaveSpeedEstimatorView wave_speed_estimator_view(
+            *hyperbolic_system_, wave_speed_estimator_, old_precomputed);
 
-        using Indicator = typename Description::template Indicator<dim, T>;
-        Indicator indicator(
-            *hyperbolic_system_, indicator_parameters_, old_precomputed);
+        using IndicatorView =
+            typename Description::template IndicatorView<dim, T>;
+        IndicatorView indicator_view(
+            *hyperbolic_system_, indicator_, old_precomputed);
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -363,7 +362,7 @@ namespace ryujin
 
         const auto U_i = old_U.template read_tensor<T>(i);
 
-        indicator.reset(i, U_i);
+        indicator_view.reset(i, U_i);
 
         const unsigned int *js = sparsity_simd.columns(i);
         for (unsigned int col_idx = 0; col_idx < row_length;
@@ -373,7 +372,7 @@ namespace ryujin
 
           const auto c_ij = cij_matrix.template read_tensor<T>(i, col_idx);
 
-          indicator.accumulate(js, U_j, c_ij);
+          indicator_view.accumulate(js, U_j, c_ij);
 
           /* Skip diagonal. */
           if (col_idx == 0)
@@ -386,7 +385,7 @@ namespace ryujin
           const auto norm = c_ij.norm();
           const auto n_ij = c_ij / norm;
           const auto lambda_max =
-              wave_speed_estimator.compute(U_i, U_j, i, js, n_ij);
+              wave_speed_estimator_view.compute(U_i, U_j, i, js, n_ij);
           const auto d_ij = norm * lambda_max;
 
           dij_matrix_.write_entry(d_ij, i, col_idx, true);
@@ -394,7 +393,7 @@ namespace ryujin
 
         const auto mass = lumped_mass_matrix.template read_entry<T>(i);
         const auto hd_i = mass * measure_of_omega_inverse;
-        alpha_.template write_entry<T>(indicator.alpha(hd_i), i);
+        alpha_.template write_entry<T>(indicator_view.alpha(hd_i), i);
       };
 
       cpu_simd_loop<Number>(loop_name(), body, 0, n_internal, n_owned);
@@ -429,12 +428,10 @@ namespace ryujin
       const auto body_boundary = [&](const auto &, const unsigned int k) {
         const auto &[i, col_idx, j] = coupling_boundary_pairs[k];
 
-        using WaveSpeedEstimator =
-            typename Description::template WaveSpeedEstimator<dim, Number>;
-        WaveSpeedEstimator wave_speed_estimator(
-            *hyperbolic_system_,
-            wave_speed_estimator_parameters_,
-            old_precomputed);
+        using WaveSpeedEstimatorView =
+            typename Description::template WaveSpeedEstimatorView<dim, Number>;
+        WaveSpeedEstimatorView wave_speed_estimator_view(
+            *hyperbolic_system_, wave_speed_estimator_, old_precomputed);
 
         /*
          * Only work on index pairs "i < j" that point to the upper
@@ -458,7 +455,7 @@ namespace ryujin
         const auto d_ij = dij_matrix_.read_entry(i, col_idx);
 
         const auto lambda_max =
-            wave_speed_estimator.compute(U_j, U_i, j, &i, n_ji);
+            wave_speed_estimator_view.compute(U_j, U_i, j, &i, n_ji);
         const auto d_ji = norm_ji * lambda_max;
 
         dij_matrix_.write_entry(std::max(d_ij, d_ji), i, col_idx);
@@ -476,12 +473,10 @@ namespace ryujin
       const auto body = [&](auto, unsigned int i) {
 
 #ifdef DEBUG_SYMMETRY_CHECK
-        using WaveSpeedEstimator =
-            typename Description::template WaveSpeedEstimator<dim, Number>;
-        WaveSpeedEstimator wave_speed_estimator(
-            *hyperbolic_system_,
-            wave_speed_estimator_parameters_,
-            old_precomputed);
+        using WaveSpeedEstimatorView =
+            typename Description::template WaveSpeedEstimatorView<dim, Number>;
+        WaveSpeedEstimatorView wave_speed_estimator_view(
+            *hyperbolic_system_, wave_speed_estimator_, old_precomputed);
 #endif
 
         /* Skip constrained degrees of freedom: */
@@ -513,7 +508,7 @@ namespace ryujin
             const auto n_ij = c_ij / norm_ij;
 
             const auto lambda_max =
-                wave_speed_estimator.compute(U_i, U_j, i, &j, n_ij);
+                wave_speed_estimator_view.compute(U_i, U_j, i, &j, n_ij);
             const auto d_ij = norm_ij * lambda_max;
 
             Assert(d_ij <= d_ji + 1.0e-12,
@@ -617,7 +612,7 @@ namespace ryujin
         using T = decltype(sentinel);
         using View =
             typename Description::template HyperbolicSystemView<dim, T>;
-        using Limiter = typename Description::template Limiter<dim, T>;
+        using LimiterView = typename Description::template LimiterView<dim, T>;
         using flux_contribution_type = typename View::flux_contribution_type;
         using state_type = typename View::state_type;
 
@@ -625,8 +620,8 @@ namespace ryujin
 
         const auto view = hyperbolic_system_->template view<dim, T>();
 
-        Limiter limiter(
-            *hyperbolic_system_, limiter_parameters_, old_precomputed);
+        LimiterView limiter_view(
+            *hyperbolic_system_, limiter_, old_precomputed);
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -669,7 +664,7 @@ namespace ryujin
           F_iH += m_i * S_iH;
         }
 
-        limiter.reset(i, U_i, flux_i);
+        limiter_view.reset(i, U_i, flux_i);
 
         [[maybe_unused]] state_type affine_shift;
 
@@ -767,7 +762,7 @@ namespace ryujin
             F_iH += d_ijH * (U_star_ji - U_star_ij);
             P_ij += (d_ijH - d_ij) * (U_star_ji - U_star_ij);
 
-            limiter.accumulate(
+            limiter_view.accumulate(
                 U_j, U_star_ij, U_star_ji, scaled_c_ij, affine_shift);
 
           } else {
@@ -776,7 +771,7 @@ namespace ryujin
             F_iH += d_ijH * (U_j - U_i);
             P_ij += (d_ijH - d_ij) * (U_j - U_i);
 
-            limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
+            limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
           }
 
           if constexpr (View::have_source_terms) {
@@ -843,7 +838,7 @@ namespace ryujin
         r_.template write_tensor<T>(F_iH, i);
 
         const auto hd_i = m_i * measure_of_omega_inverse;
-        const auto relaxed_bounds = limiter.bounds(hd_i);
+        const auto relaxed_bounds = limiter_view.bounds(hd_i);
         bounds_.template write_tensor<T>(relaxed_bounds, i);
       };
 
@@ -878,7 +873,7 @@ namespace ryujin
      * -------------------------------------------------------------------------
      */
 
-    if (limiter_parameters_.iterations() != 0) {
+    if (limiter_.iterations() != 0) {
       Scope scope(computing_timer_, scoped_name("compute p_ij, and l_ij"));
 
       auto body = [&](auto sentinel,
@@ -887,12 +882,12 @@ namespace ryujin
         using T = decltype(sentinel);
         using View =
             typename Description::template HyperbolicSystemView<dim, T>;
-        using Limiter = typename Description::template Limiter<dim, T>;
+        using LimiterView = typename Description::template LimiterView<dim, T>;
 
         constexpr unsigned int stride_size = get_stride_size<T>;
 
-        Limiter limiter(
-            *hyperbolic_system_, limiter_parameters_, old_precomputed);
+        LimiterView limiter_view(
+            *hyperbolic_system_, limiter_, old_precomputed);
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -912,7 +907,7 @@ namespace ryujin
           const unsigned int *js = sparsity_simd.columns(i) + stride_size;
           for (unsigned int col_idx = 1; col_idx < row_length;
                ++col_idx, js += stride_size) {
-            bounds = limiter.combine_bounds(
+            bounds = limiter_view.combine_bounds(
                 bounds,
                 bounds_.template read_tensor<T, std::array<T, n_bounds>>(js));
           }
@@ -977,7 +972,8 @@ namespace ryujin
            * Compute limiter coefficients:
            */
 
-          const auto &[l_ij, success] = limiter.limit(bounds, U_i_new, P_ij);
+          const auto &[l_ij, success] =
+              limiter_view.limit(bounds, U_i_new, P_ij);
           lij_matrix_.template write_entry<T>(l_ij, i, col_idx, true);
 
           /*
@@ -1021,7 +1017,7 @@ namespace ryujin
      * -------------------------------------------------------------------------
      */
 
-    const auto n_iterations = limiter_parameters_.iterations();
+    const auto n_iterations = limiter_.iterations();
     for (unsigned int pass = 0; pass < n_iterations; ++pass) {
       bool last_round = (pass + 1 == n_iterations);
 
@@ -1037,10 +1033,10 @@ namespace ryujin
         using T = decltype(sentinel);
         using View =
             typename Description::template HyperbolicSystemView<dim, T>;
-        using Limiter = typename Description::template Limiter<dim, T>;
+        using LimiterView = typename Description::template LimiterView<dim, T>;
 
-        Limiter limiter(
-            *hyperbolic_system_, limiter_parameters_, old_precomputed);
+        LimiterView limiter_view(
+            *hyperbolic_system_, limiter_, old_precomputed);
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -1093,7 +1089,7 @@ namespace ryujin
                                 pij_matrix_.template read_tensor<T>(i, col_idx);
 
           const auto &[new_l_ij, success] =
-              limiter.limit(bounds, U_i_new, new_p_ij);
+              limiter_view.limit(bounds, U_i_new, new_p_ij);
 
           /*
            * This is the second pass of the limiter. Under rare

--- a/source/navier_stokes/description.h
+++ b/source/navier_stokes/description.h
@@ -41,13 +41,13 @@ namespace ryujin
       using ParabolicModule = NavierStokes::ParabolicModule<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = Euler::Indicator<dim, Number>;
+      using Indicator = Euler::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = Euler::Limiter<dim, Number>;
+      using Limiter = Euler::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = Euler::WaveSpeedEstimator<dim, Number>;
+      using WaveSpeedEstimator = Euler::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace NavierStokes
 } // namespace ryujin

--- a/source/navier_stokes/description.h
+++ b/source/navier_stokes/description.h
@@ -41,13 +41,13 @@ namespace ryujin
       using ParabolicModule = NavierStokes::ParabolicModule<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = Euler::IndicatorView<dim, Number>;
+      using IndicatorView = Euler::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = Euler::LimiterView<dim, Number>;
+      using LimiterView = Euler::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = Euler::WaveSpeedEstimatorView<dim, Number>;
+      using WaveSpeedEstimatorView = Euler::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace NavierStokes
 } // namespace ryujin

--- a/source/scalar_conservation/description.h
+++ b/source/scalar_conservation/description.h
@@ -48,13 +48,13 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = ScalarConservation::IndicatorView<dim, Number>;
+      using IndicatorView = ScalarConservation::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = ScalarConservation::LimiterView<dim, Number>;
+      using LimiterView = ScalarConservation::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator =
+      using WaveSpeedEstimatorView =
           ScalarConservation::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace ScalarConservation

--- a/source/scalar_conservation/description.h
+++ b/source/scalar_conservation/description.h
@@ -48,14 +48,14 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = ScalarConservation::Indicator<dim, Number>;
+      using Indicator = ScalarConservation::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = ScalarConservation::Limiter<dim, Number>;
+      using Limiter = ScalarConservation::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
       using WaveSpeedEstimator =
-          ScalarConservation::WaveSpeedEstimator<dim, Number>;
+          ScalarConservation::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace ScalarConservation
 } // namespace ryujin

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -377,7 +377,7 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
        *   const auto flux_i = flux_contribution(precomputed..., i, U_i);

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -21,10 +21,10 @@ namespace ryujin
   namespace ScalarConservation
   {
     template <typename ScalarNumber = double>
-    class IndicatorParameters : public dealii::ParameterAcceptor
+    class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection = "/Indicator")
+      Indicator(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
@@ -47,7 +47,7 @@ namespace ryujin
      * @ingroup ScalarConservationEquations
      */
     template <int dim, typename Number = double>
-    class Indicator
+    class IndicatorView
     {
     public:
       /**
@@ -69,7 +69,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = IndicatorParameters<ScalarNumber>;
+      using Parameters = Indicator<ScalarNumber>;
 
       //@}
       /**
@@ -77,15 +77,15 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator.reset(i, U_i);
+       *   indicator_view.reset(i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(js, U_j, c_ij);
        *   }
-       *   indicator.alpha(hd_i);
+       *   indicator_view.alpha(hd_i);
        * }
        * ```
        */
@@ -94,9 +94,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Indicator(const HyperbolicSystem &hyperbolic_system,
-                const Parameters &parameters,
-                const PrecomputedVector &precomputed_values)
+      IndicatorView(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -152,7 +152,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
+    IndicatorView<dim, Number>::reset(const unsigned int i,
+                                      const state_type &U_i)
     {
       /* entropy viscosity commutator: */
 
@@ -170,7 +171,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Indicator<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
         const unsigned int *js,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -194,7 +195,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i) const
+    IndicatorView<dim, Number>::alpha(const Number hd_i) const
     {
       Number numerator = left - right;
       Number denominator = std::abs(left) + std::abs(right);

--- a/source/scalar_conservation/limiter.cc
+++ b/source/scalar_conservation/limiter.cc
@@ -13,12 +13,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class Limiter<1, NUMBER>;
-    template class Limiter<2, NUMBER>;
-    template class Limiter<3, NUMBER>;
+    template class LimiterView<1, NUMBER>;
+    template class LimiterView<2, NUMBER>;
+    template class LimiterView<3, NUMBER>;
 
-    template class Limiter<1, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<2, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<3, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<1, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<2, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace ScalarConservation
 } // namespace ryujin

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -17,10 +17,10 @@ namespace ryujin
   namespace ScalarConservation
   {
     template <typename ScalarNumber = double>
-    class LimiterParameters : public dealii::ParameterAcceptor
+    class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection = "/Limiter")
+      Limiter(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;
@@ -49,7 +49,7 @@ namespace ryujin
      * @ingroup ScalarConservationEquations
      */
     template <int dim, typename Number = double>
-    class Limiter
+    class LimiterView
     {
     public:
       /**
@@ -71,7 +71,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = LimiterParameters<ScalarNumber>;
+      using Parameters = Limiter<ScalarNumber>;
 
       //@}
       /**
@@ -93,9 +93,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Limiter(const HyperbolicSystem &hyperbolic_system,
-              const Parameters &parameters,
-              const PrecomputedVector &precomputed_values)
+      LimiterView(const HyperbolicSystem &hyperbolic_system,
+                  const Parameters &parameters,
+                  const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -130,15 +130,16 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Limiter<dim, Number> limiter;
+       * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i, flux_i);
+       *   limiter_view.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
+       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       * affine_shift);
        *   }
-       *   limiter.bounds(hd_i);
+       *   limiter_view.bounds(hd_i);
        * }
        * ```
        */
@@ -211,7 +212,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::projection_bounds_from_state(
+    LimiterView<dim, Number>::projection_bounds_from_state(
         const unsigned int /*i*/, const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -221,7 +222,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto Limiter<dim, Number>::combine_bounds(
+    DEAL_II_ALWAYS_INLINE inline auto LimiterView<dim, Number>::combine_bounds(
         const Bounds &bounds_left, const Bounds &bounds_right) const -> Bounds
     {
       const auto &[u_min_l, u_max_l] = bounds_left;
@@ -233,8 +234,9 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::fully_relax_bounds(const Bounds &bounds,
-                                             const Number &hd) const -> Bounds
+    LimiterView<dim, Number>::fully_relax_bounds(const Bounds &bounds,
+                                                 const Number &hd) const
+        -> Bounds
     {
       auto relaxed_bounds = bounds;
       auto &[u_min, u_max] = relaxed_bounds;
@@ -257,9 +259,9 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Limiter<dim, Number>::reset(const unsigned int /*i*/,
-                                const state_type &new_U_i,
-                                const flux_contribution_type &new_flux_i)
+    LimiterView<dim, Number>::reset(const unsigned int /*i*/,
+                                    const state_type &new_U_i,
+                                    const flux_contribution_type &new_flux_i)
     {
       U_i = new_U_i;
       flux_i = new_flux_i;
@@ -279,7 +281,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Limiter<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
         const unsigned int * /*js*/,
         const state_type &U_j,
         const flux_contribution_type &flux_j,
@@ -317,7 +319,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::bounds(const Number hd_i) const -> Bounds
+    LimiterView<dim, Number>::bounds(const Number hd_i) const -> Bounds
     {
       const auto &[u_min, u_max] = bounds_;
 

--- a/source/scalar_conservation/limiter.template.h
+++ b/source/scalar_conservation/limiter.template.h
@@ -13,11 +13,11 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const Bounds &bounds,
-                                const state_type &U,
-                                const state_type &P,
-                                const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */) const
+    LimiterView<dim, Number>::limit(const Bounds &bounds,
+                                    const state_type &U,
+                                    const state_type &P,
+                                    const Number t_min /* = Number(0.) */,
+                                    const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/scalar_conservation/wave_speed_estimator.cc
+++ b/source/scalar_conservation/wave_speed_estimator.cc
@@ -13,13 +13,13 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class WaveSpeedEstimator<1, NUMBER>;
-    template class WaveSpeedEstimator<2, NUMBER>;
-    template class WaveSpeedEstimator<3, NUMBER>;
+    template class WaveSpeedEstimatorView<1, NUMBER>;
+    template class WaveSpeedEstimatorView<2, NUMBER>;
+    template class WaveSpeedEstimatorView<3, NUMBER>;
 
-    template class WaveSpeedEstimator<1, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<2, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<3, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<1, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<2, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<3, dealii::VectorizedArray<NUMBER>>;
 
   } // namespace ScalarConservation
 } // namespace ryujin

--- a/source/scalar_conservation/wave_speed_estimator.h
+++ b/source/scalar_conservation/wave_speed_estimator.h
@@ -19,11 +19,10 @@ namespace ryujin
   namespace ScalarConservation
   {
     template <typename ScalarNumber = double>
-    class WaveSpeedEstimatorParameters : public dealii::ParameterAcceptor
+    class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimatorParameters(
-          const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
       {
         use_greedy_wavespeed_ = false;
@@ -75,7 +74,7 @@ namespace ryujin
      * @ingroup ScalarConservationEquations
      */
     template <int dim, typename Number = double>
-    class WaveSpeedEstimator
+    class WaveSpeedEstimatorView
     {
     public:
       /**
@@ -95,7 +94,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = WaveSpeedEstimatorParameters<ScalarNumber>;
+      using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
       //@}
 
@@ -107,9 +106,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
-                         const Parameters &parameters,
-                         const PrecomputedVector &precomputed_values)
+      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
+                             const Parameters &parameters,
+                             const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)

--- a/source/scalar_conservation/wave_speed_estimator.template.h
+++ b/source/scalar_conservation/wave_speed_estimator.template.h
@@ -20,7 +20,7 @@ namespace ryujin
   namespace ScalarConservation
   {
     template <int dim, typename Number>
-    Number WaveSpeedEstimator<dim, Number>::compute(
+    Number WaveSpeedEstimatorView<dim, Number>::compute(
         const Number &u_i,
         const Number &u_j,
         const precomputed_type &prec_i,
@@ -194,7 +194,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::compute(
+    WaveSpeedEstimatorView<dim, Number>::compute(
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int i,

--- a/source/shallow_water/description.h
+++ b/source/shallow_water/description.h
@@ -45,13 +45,14 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = ShallowWater::Indicator<dim, Number>;
+      using Indicator = ShallowWater::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = ShallowWater::Limiter<dim, Number>;
+      using Limiter = ShallowWater::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = ShallowWater::WaveSpeedEstimator<dim, Number>;
+      using WaveSpeedEstimator =
+          ShallowWater::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace ShallowWater
 } // namespace ryujin

--- a/source/shallow_water/description.h
+++ b/source/shallow_water/description.h
@@ -45,13 +45,13 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = ShallowWater::IndicatorView<dim, Number>;
+      using IndicatorView = ShallowWater::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = ShallowWater::LimiterView<dim, Number>;
+      using LimiterView = ShallowWater::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator =
+      using WaveSpeedEstimatorView =
           ShallowWater::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace ShallowWater

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -472,7 +472,7 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
        *   const auto flux_i = flux_contribution(precomputed..., i, U_i);

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -22,10 +22,10 @@ namespace ryujin
   namespace ShallowWater
   {
     template <typename ScalarNumber = double>
-    class IndicatorParameters : public dealii::ParameterAcceptor
+    class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection = "/Indicator")
+      Indicator(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
         evc_factor_ = ScalarNumber(1.);
@@ -48,7 +48,7 @@ namespace ryujin
      * @ingroup ShallowWaterEquations
      */
     template <int dim, typename Number = double>
-    class Indicator
+    class IndicatorView
     {
     public:
       /**
@@ -70,7 +70,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = IndicatorParameters<ScalarNumber>;
+      using Parameters = Indicator<ScalarNumber>;
 
       //@}
       /**
@@ -78,15 +78,15 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator.reset(i, U_i);
+       *   indicator_view.reset(i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(js, U_j, c_ij);
        *   }
-       *   indicator.alpha(hd_i);
+       *   indicator_view.alpha(hd_i);
        * }
        * ```
        */
@@ -95,9 +95,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Indicator(const HyperbolicSystem &hyperbolic_system,
-                const Parameters &parameters,
-                const PrecomputedVector &precomputed_values)
+      IndicatorView(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -156,7 +156,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    Indicator<dim, Number>::reset(const unsigned int i, const state_type &U_i)
+    IndicatorView<dim, Number>::reset(const unsigned int i,
+                                      const state_type &U_i)
     {
       /* entropy viscosity commutator: */
 
@@ -177,7 +178,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Indicator<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
         const unsigned int *js,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -203,7 +204,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    Indicator<dim, Number>::alpha(const Number hd_i)
+    IndicatorView<dim, Number>::alpha(const Number hd_i)
     {
       Number my_sum = 0.;
       for (unsigned int k = 0; k < problem_dimension; ++k) {

--- a/source/shallow_water/limiter.cc
+++ b/source/shallow_water/limiter.cc
@@ -15,12 +15,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class Limiter<1, NUMBER>;
-    template class Limiter<2, NUMBER>;
-    template class Limiter<3, NUMBER>;
+    template class LimiterView<1, NUMBER>;
+    template class LimiterView<2, NUMBER>;
+    template class LimiterView<3, NUMBER>;
 
-    template class Limiter<1, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<2, dealii::VectorizedArray<NUMBER>>;
-    template class Limiter<3, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<1, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<2, dealii::VectorizedArray<NUMBER>>;
+    template class LimiterView<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace ShallowWater
 } // namespace ryujin

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -19,10 +19,10 @@ namespace ryujin
   namespace ShallowWater
   {
     template <typename ScalarNumber = double>
-    class LimiterParameters : public dealii::ParameterAcceptor
+    class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection = "/Limiter")
+      Limiter(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;
@@ -69,7 +69,7 @@ namespace ryujin
      * @ingroup ShallowWaterEquations
      */
     template <int dim, typename Number = double>
-    class Limiter
+    class LimiterView
     {
     public:
       /**
@@ -91,7 +91,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = LimiterParameters<ScalarNumber>;
+      using Parameters = Limiter<ScalarNumber>;
 
       //@}
       /**
@@ -111,9 +111,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Limiter(const HyperbolicSystem &hyperbolic_system,
-              const Parameters &parameters,
-              const PrecomputedVector &precomputed_values)
+      LimiterView(const HyperbolicSystem &hyperbolic_system,
+                  const Parameters &parameters,
+                  const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -150,15 +150,16 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Limiter<dim, Number> limiter;
+       * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i, flux_i);
+       *   limiter_view.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
+       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       * affine_shift);
        *   }
-       *   limiter.bounds(hd_i);
+       *   limiter_view.bounds(hd_i);
        * }
        * ```
        */
@@ -234,7 +235,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::projection_bounds_from_state(
+    LimiterView<dim, Number>::projection_bounds_from_state(
         const unsigned int /*i*/, const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
@@ -248,9 +249,8 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::combine_bounds(const Bounds &bounds_l,
-                                         const Bounds &bounds_r) const -> Bounds
+    DEAL_II_ALWAYS_INLINE inline auto LimiterView<dim, Number>::combine_bounds(
+        const Bounds &bounds_l, const Bounds &bounds_r) const -> Bounds
     {
       const auto &[h_min_l, h_max_l, v2_max_l] = bounds_l;
       const auto &[h_min_r, h_max_r, v2_max_r] = bounds_r;
@@ -263,8 +263,9 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::fully_relax_bounds(const Bounds &bounds,
-                                             const Number &hd) const -> Bounds
+    LimiterView<dim, Number>::fully_relax_bounds(const Bounds &bounds,
+                                                 const Number &hd) const
+        -> Bounds
     {
       auto relaxed_bounds = bounds;
       auto &[h_min, h_max, v2_max] = relaxed_bounds;
@@ -288,10 +289,10 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void
-    Limiter<dim, Number>::reset(unsigned int /*i*/,
-                                const state_type &new_U_i,
-                                const flux_contribution_type & /*new_flux_i*/)
+    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::reset(
+        unsigned int /*i*/,
+        const state_type &new_U_i,
+        const flux_contribution_type & /*new_flux_i*/)
     {
       U_i = new_U_i;
 
@@ -308,7 +309,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void Limiter<dim, Number>::accumulate(
+    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
         const state_type &U_j,
         const state_type &U_star_ij,
         const state_type &U_star_ji,
@@ -364,7 +365,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    Limiter<dim, Number>::bounds(const Number hd_i) const -> Bounds
+    LimiterView<dim, Number>::bounds(const Number hd_i) const -> Bounds
     {
       const auto &[h_min, h_max, v2_max] = bounds_;
 

--- a/source/shallow_water/limiter.template.h
+++ b/source/shallow_water/limiter.template.h
@@ -15,11 +15,11 @@ namespace ryujin
   {
     template <int dim, typename Number>
     std::tuple<Number, bool>
-    Limiter<dim, Number>::limit(const Bounds &bounds,
-                                const state_type &U,
-                                const state_type &P,
-                                const Number t_min /* = Number(0.) */,
-                                const Number t_max /* = Number(1.) */) const
+    LimiterView<dim, Number>::limit(const Bounds &bounds,
+                                    const state_type &U,
+                                    const state_type &P,
+                                    const Number t_min /* = Number(0.) */,
+                                    const Number t_max /* = Number(1.) */) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/source/shallow_water/wave_speed_estimator.cc
+++ b/source/shallow_water/wave_speed_estimator.cc
@@ -15,12 +15,12 @@ namespace ryujin
   {
     /* instantiations */
 
-    template class WaveSpeedEstimator<1, NUMBER>;
-    template class WaveSpeedEstimator<2, NUMBER>;
-    template class WaveSpeedEstimator<3, NUMBER>;
+    template class WaveSpeedEstimatorView<1, NUMBER>;
+    template class WaveSpeedEstimatorView<2, NUMBER>;
+    template class WaveSpeedEstimatorView<3, NUMBER>;
 
-    template class WaveSpeedEstimator<1, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<2, dealii::VectorizedArray<NUMBER>>;
-    template class WaveSpeedEstimator<3, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<1, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<2, dealii::VectorizedArray<NUMBER>>;
+    template class WaveSpeedEstimatorView<3, dealii::VectorizedArray<NUMBER>>;
   } // namespace ShallowWater
 } // namespace ryujin

--- a/source/shallow_water/wave_speed_estimator.h
+++ b/source/shallow_water/wave_speed_estimator.h
@@ -21,11 +21,10 @@ namespace ryujin
   namespace ShallowWater
   {
     template <typename ScalarNumber = double>
-    class WaveSpeedEstimatorParameters : public dealii::ParameterAcceptor
+    class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimatorParameters(
-          const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
       {
       }
@@ -41,7 +40,7 @@ namespace ryujin
      * @ingroup ShallowWaterEquations
      */
     template <int dim, typename Number = double>
-    class WaveSpeedEstimator
+    class WaveSpeedEstimatorView
     {
     public:
       /**
@@ -73,7 +72,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = WaveSpeedEstimatorParameters<ScalarNumber>;
+      using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
       //@}
       /**
@@ -84,9 +83,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
-                         const Parameters &parameters,
-                         const PrecomputedVector &precomputed_values)
+      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
+                             const Parameters &parameters,
+                             const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)

--- a/source/shallow_water/wave_speed_estimator.template.h
+++ b/source/shallow_water/wave_speed_estimator.template.h
@@ -24,8 +24,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::f(const primitive_type &riemann_data_Z,
-                                       const Number &h) const
+    WaveSpeedEstimatorView<dim, Number>::f(const primitive_type &riemann_data_Z,
+                                           const Number &h) const
     {
       const auto view = hyperbolic_system.view<dim, Number>();
       const ScalarNumber gravity = view.gravity();
@@ -46,9 +46,10 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::phi(const primitive_type &riemann_data_i,
-                                         const primitive_type &riemann_data_j,
-                                         const Number &h) const
+    WaveSpeedEstimatorView<dim, Number>::phi(
+        const primitive_type &riemann_data_i,
+        const primitive_type &riemann_data_j,
+        const Number &h) const
     {
       const Number &u_i = riemann_data_i[1];
       const Number &u_j = riemann_data_j[1];
@@ -63,7 +64,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::lambda1_minus(
+    WaveSpeedEstimatorView<dim, Number>::lambda1_minus(
         const primitive_type &riemann_data, const Number h_star) const
     {
       const auto &[h, u, a] = riemann_data;
@@ -78,7 +79,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::lambda3_plus(
+    WaveSpeedEstimatorView<dim, Number>::lambda3_plus(
         const primitive_type &riemann_data, const Number h_star) const
     {
       const auto &[h, u, a] = riemann_data;
@@ -93,7 +94,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::compute_lambda(
+    WaveSpeedEstimatorView<dim, Number>::compute_lambda(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j,
         const Number h_star) const
@@ -107,7 +108,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
-    WaveSpeedEstimator<dim, Number>::compute_h_star(
+    WaveSpeedEstimatorView<dim, Number>::compute_h_star(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -206,7 +207,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
-    WaveSpeedEstimator<dim, Number>::riemann_data_from_state(
+    WaveSpeedEstimatorView<dim, Number>::riemann_data_from_state(
         const state_type &U, const dealii::Tensor<1, dim, Number> &n_ij) const
         -> primitive_type
     {
@@ -224,7 +225,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    inline Number WaveSpeedEstimator<dim, Number>::compute(
+    inline Number WaveSpeedEstimatorView<dim, Number>::compute(
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
@@ -238,7 +239,7 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    Number WaveSpeedEstimator<dim, Number>::compute(
+    Number WaveSpeedEstimatorView<dim, Number>::compute(
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int /*i*/,

--- a/source/skeleton/description.h
+++ b/source/skeleton/description.h
@@ -42,13 +42,14 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = Skeleton::IndicatorView<dim, Number>;
+      using IndicatorView = Skeleton::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = Skeleton::LimiterView<dim, Number>;
+      using LimiterView = Skeleton::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = Skeleton::WaveSpeedEstimatorView<dim, Number>;
+      using WaveSpeedEstimatorView =
+          Skeleton::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace Skeleton
 } // namespace ryujin

--- a/source/skeleton/description.h
+++ b/source/skeleton/description.h
@@ -42,13 +42,13 @@ namespace ryujin
           ryujin::StubParabolicModule<Description, dim, Number>;
 
       template <int dim, typename Number = double>
-      using Indicator = Skeleton::Indicator<dim, Number>;
+      using Indicator = Skeleton::IndicatorView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using Limiter = Skeleton::Limiter<dim, Number>;
+      using Limiter = Skeleton::LimiterView<dim, Number>;
 
       template <int dim, typename Number = double>
-      using WaveSpeedEstimator = Skeleton::WaveSpeedEstimator<dim, Number>;
+      using WaveSpeedEstimator = Skeleton::WaveSpeedEstimatorView<dim, Number>;
     };
   } // namespace Skeleton
 } // namespace ryujin

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -283,7 +283,7 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
        *   const auto flux_i = flux_contribution(precomputed..., i, U_i);

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -21,10 +21,10 @@ namespace ryujin
   namespace Skeleton
   {
     template <typename ScalarNumber = double>
-    class IndicatorParameters : public dealii::ParameterAcceptor
+    class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      IndicatorParameters(const std::string &subsection = "/Indicator")
+      Indicator(const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
       {
       }
@@ -38,7 +38,7 @@ namespace ryujin
      * @ingroup SkeletonEquations
      */
     template <int dim, typename Number = double>
-    class Indicator
+    class IndicatorView
     {
     public:
       /**
@@ -54,7 +54,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = IndicatorParameters<ScalarNumber>;
+      using Parameters = Indicator<ScalarNumber>;
 
       //@}
       /**
@@ -62,15 +62,15 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Indicator<dim, Number> indicator;
+       * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator.reset(i, U_i);
+       *   indicator_view.reset(i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(js, U_j, c_ij);
        *   }
-       *   indicator.alpha(hd_i);
+       *   indicator_view.alpha(hd_i);
        * }
        * ```
        */
@@ -79,9 +79,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Indicator(const HyperbolicSystem &hyperbolic_system,
-                const Parameters &parameters,
-                const PrecomputedVector &precomputed_values)
+      IndicatorView(const HyperbolicSystem &hyperbolic_system,
+                    const Parameters &parameters,
+                    const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -19,10 +19,10 @@ namespace ryujin
   namespace Skeleton
   {
     template <typename ScalarNumber = double>
-    class LimiterParameters : public dealii::ParameterAcceptor
+    class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      LimiterParameters(const std::string &subsection = "/Limiter")
+      Limiter(const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
       {
         iterations_ = 2;
@@ -43,7 +43,7 @@ namespace ryujin
      * @ingroup SkeletonEquations
      */
     template <int dim, typename Number = double>
-    class Limiter
+    class LimiterView
     {
     public:
       /**
@@ -61,7 +61,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = LimiterParameters<ScalarNumber>;
+      using Parameters = Limiter<ScalarNumber>;
 
       //@}
       /**
@@ -81,9 +81,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      Limiter(const HyperbolicSystem &hyperbolic_system,
-              const Parameters &parameters,
-              const PrecomputedVector &precomputed_values)
+      LimiterView(const HyperbolicSystem &hyperbolic_system,
+                  const Parameters &parameters,
+                  const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)
@@ -128,15 +128,16 @@ namespace ryujin
        *
        * Intended usage:
        * ```
-       * Limiter<dim, Number> limiter;
+       * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter.reset(i, U_i, flux_i);
+       *   limiter_view.reset(i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
+       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       * affine_shift);
        *   }
-       *   limiter.bounds(hd_i);
+       *   limiter_view.bounds(hd_i);
        * }
        * ```
        */

--- a/source/skeleton/wave_speed_estimator.h
+++ b/source/skeleton/wave_speed_estimator.h
@@ -19,11 +19,10 @@ namespace ryujin
   namespace Skeleton
   {
     template <typename ScalarNumber = double>
-    class WaveSpeedEstimatorParameters : public dealii::ParameterAcceptor
+    class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimatorParameters(
-          const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
       {
       }
@@ -39,7 +38,7 @@ namespace ryujin
      * @ingroup SkeletonEquations
      */
     template <int dim, typename Number = double>
-    class WaveSpeedEstimator
+    class WaveSpeedEstimatorView
     {
     public:
       /**
@@ -55,7 +54,7 @@ namespace ryujin
 
       using PrecomputedVector = typename View::PrecomputedVector;
 
-      using Parameters = WaveSpeedEstimatorParameters<ScalarNumber>;
+      using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
       //@}
       /**
@@ -66,9 +65,9 @@ namespace ryujin
       /**
        * Constructor taking a HyperbolicSystem instance as argument
        */
-      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
-                         const Parameters &parameters,
-                         const PrecomputedVector &precomputed_values)
+      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
+                             const Parameters &parameters,
+                             const PrecomputedVector &precomputed_values)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
           , precomputed_values(precomputed_values)

--- a/source/solution_transfer.h
+++ b/source/solution_transfer.h
@@ -52,12 +52,13 @@ namespace ryujin
      * The number of stored entries in the bounds array.
      */
     static constexpr unsigned int n_bounds =
-        Description::template Limiter<dim, Number>::n_bounds;
+        Description::template LimiterView<dim, Number>::n_bounds;
 
     /**
      * Array type used to store accumulated bounds.
      */
-    using Bounds = typename Description::template Limiter<dim, Number>::Bounds;
+    using Bounds =
+        typename Description::template LimiterView<dim, Number>::Bounds;
 
     //@}
     /**
@@ -155,8 +156,8 @@ namespace ryujin
      */
     //@{
 
-    typename Description::template Limiter<dim, Number>::Parameters
-        limiter_parameters_;
+    typename Description::template LimiterView<dim, Number>::Parameters
+        limiter_;
 
     //@}
     /**

--- a/source/solution_transfer.template.h
+++ b/source/solution_transfer.template.h
@@ -35,7 +35,7 @@ namespace ryujin
       const ParabolicSystem &parabolic_system,
       const std::string &subsection /* = "/SolutionTransfer" */)
       : ParameterAcceptor(subsection)
-      , limiter_parameters_(subsection + "/mass transfer limiter")
+      , limiter_(subsection + "/mass transfer limiter")
       , mpi_ensemble_(mpi_ensemble)
       , offline_data_(&offline_data)
       , hyperbolic_system_(&hyperbolic_system)
@@ -161,9 +161,10 @@ namespace ryujin
           /* precomputed needs to be valid for bounds computation */
           const auto &precomputed = std::get<1>(old_state_vector);
 
-          using Limiter = typename Description::template Limiter<dim, Number>;
-          const Limiter limiter(
-              *hyperbolic_system_, limiter_parameters_, precomputed);
+          using LimiterView =
+              typename Description::template LimiterView<dim, Number>;
+          const LimiterView limiter_view(
+              *hyperbolic_system_, limiter_, precomputed);
 
           /*
            * Collect state values for packing:
@@ -273,7 +274,8 @@ namespace ryujin
                 const auto U_i = read_tensor(U, global_i);
                 const auto local_i =
                     scalar_partitioner->global_to_local(global_i);
-                bounds = limiter.projection_bounds_from_state(local_i, U_i);
+                bounds =
+                    limiter_view.projection_bounds_from_state(local_i, U_i);
               }
 
               for (auto &it : state_values_quad)
@@ -285,8 +287,8 @@ namespace ryujin
                 const auto local_i =
                     scalar_partitioner->global_to_local(global_i);
                 const auto bounds_i =
-                    limiter.projection_bounds_from_state(local_i, U_i);
-                bounds = limiter.combine_bounds(bounds, bounds_i);
+                    limiter_view.projection_bounds_from_state(local_i, U_i);
+                bounds = limiter_view.combine_bounds(bounds, bounds_i);
 
                 for (unsigned int q = 0; q < quadrature.size(); ++q) {
                   state_values_quad[q] += U_i * fe_values.shape_value(i, q);
@@ -348,7 +350,7 @@ namespace ryujin
 
             /* Step 3: compute low-order update and P_ij matrix: */
 
-            bounds = limiter.fully_relax_bounds(bounds, total_mass);
+            bounds = limiter_view.fully_relax_bounds(bounds, total_mass);
 
             std::vector<state_type> pij_matrix(n_dofs_per_cell *
                                                n_dofs_per_cell);
@@ -376,7 +378,7 @@ namespace ryujin
 
             /* Step 4: compute l_ij matrix and apply limited update: */
 
-            const auto n_iterations = limiter_parameters_.iterations();
+            const auto n_iterations = limiter_.iterations();
             for (unsigned int pass = 0; pass < n_iterations; ++pass) {
 
               for (unsigned int i = 0; i < n_dofs_per_cell; ++i) {
@@ -384,7 +386,8 @@ namespace ryujin
 
                 for (unsigned int j = 0; j < n_dofs_per_cell; ++j) {
                   const auto &P_ij = pij_matrix[n_dofs_per_cell * i + j];
-                  const auto &[l_ij, check] = limiter.limit(bounds, U_i, P_ij);
+                  const auto &[l_ij, check] =
+                      limiter_view.limit(bounds, U_i, P_ij);
                   lij_matrix(i, j) = l_ij;
                 }
               }
@@ -735,9 +738,8 @@ namespace ryujin
 
     update_precomputed_values();
 
-    using Limiter = typename Description::template Limiter<dim, Number>;
-    const Limiter limiter(
-        *hyperbolic_system_, limiter_parameters_, precomputed);
+    using LimiterView = typename Description::template LimiterView<dim, Number>;
+    const LimiterView limiter_view(*hyperbolic_system_, limiter_, precomputed);
 
     /*
      * Step 1: compute low-order update P_ij matrix, and bounds:
@@ -763,7 +765,7 @@ namespace ryujin
       const auto U_i_star = projected_state.read_tensor(local_i) / m_i_star;
 
       auto &bounds = bounds_map[local_i]; /* by reference */
-      bounds = limiter.projection_bounds_from_state(local_i, U_i_star);
+      bounds = limiter_view.projection_bounds_from_state(local_i, U_i_star);
 
       /* The value obtained from the affine constraints object: */
       state_type U_i_interp;
@@ -778,8 +780,8 @@ namespace ryujin
         const auto U_k = new_U.read_tensor(local_k);
 
         const auto bounds_k =
-            limiter.projection_bounds_from_state(local_k, U_k);
-        bounds = limiter.combine_bounds(bounds, bounds_k);
+            limiter_view.projection_bounds_from_state(local_k, U_k);
+        bounds = limiter_view.combine_bounds(bounds, bounds_k);
 
         projected_state.add_tensor(c_k * m_i_star * U_i_star, local_k);
         projected_mass.local_element(local_k) += c_k * m_i_star;
@@ -801,7 +803,7 @@ namespace ryujin
 
     /* Step 2: Apply limiter: */
 
-    const auto n_iterations = limiter_parameters_.iterations();
+    const auto n_iterations = limiter_.iterations();
     for (unsigned int pass = 0; pass < n_iterations; ++pass) {
 
       /* Update precomputed values for bounds correction: */
@@ -820,7 +822,7 @@ namespace ryujin
          * without recombining such bounds per (unconstrained) degree of
          * freedom globally. We avoid doing the latter because it would
          * require a custom "VectorOperation" invoking
-         * Limiter::combine_bounds(), which we currently do not have at our
+         * LimiterView::combine_bounds(), which we currently do not have at our
          * disposal.
          *
          * As a simple workaround we simply recompute bounds for the
@@ -834,8 +836,8 @@ namespace ryujin
           const auto local_k = scalar_partitioner->global_to_local(global_k);
           const auto U_k = new_U.read_tensor(local_k);
           const auto bounds_k =
-              limiter.projection_bounds_from_state(local_k, U_k);
-          bounds = limiter.combine_bounds(bounds, bounds_k);
+              limiter_view.projection_bounds_from_state(local_k, U_k);
+          bounds = limiter_view.combine_bounds(bounds, bounds_k);
 
           const auto m_k = projected_mass.local_element(local_k);
           total_mass += m_k;
@@ -845,7 +847,7 @@ namespace ryujin
 
         /* Apply relaxation: */
         const auto relaxed_bounds =
-            limiter.fully_relax_bounds(bounds, total_mass);
+            limiter_view.fully_relax_bounds(bounds, total_mass);
 
         /* Compute limiter values: */
 
@@ -856,7 +858,8 @@ namespace ryujin
           const auto U_k = new_U.read_tensor(local_k);
           const auto P_ik = pik_matrix[{local_i, local_k}] * kappa_k / m_k;
 
-          const auto &[l_k, check] = limiter.limit(relaxed_bounds, U_k, P_ik);
+          const auto &[l_k, check] =
+              limiter_view.limit(relaxed_bounds, U_k, P_ik);
           l = std::min(l, l_k);
         }
 

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -21,11 +21,11 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  Limiter<dim, double>::Parameters limiter_parameters;
+  LimiterView<dim, double>::Parameters limiter;
 
   using state_type = HyperbolicSystemView<dim, double>::state_type;
 
-  using bounds_type = Limiter<dim, double>::Bounds;
+  using bounds_type = LimiterView<dim, double>::Bounds;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -34,7 +34,7 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  Limiter<dim, double> limiter(hyperbolic_system, limiter_parameters, dummy);
+  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter, dummy);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 
@@ -45,7 +45,7 @@ int main()
                   << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
                   << bounds[2] << std::endl;
 
-        const auto &[l, success] = limiter.limit(bounds, U, P);
+        const auto &[l, success] = limiter_view.limit(bounds, U, P);
 
         std::cout << "l: " << l;
         if (success)

--- a/tests/euler/wave_speed_estimator.cc
+++ b/tests/euler/wave_speed_estimator.cc
@@ -26,7 +26,7 @@ int main()
   using Number = NUMBER;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimator<dim, Number>::Parameters wave_speed_estimator_parameters;
+  WaveSpeedEstimatorView<dim, Number>::Parameters wave_speed_estimator;
 
   const auto gamma = hyperbolic_system.view<dim, Number>().gamma();
 
@@ -36,8 +36,8 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  WaveSpeedEstimator<dim> wave_speed_estimator(
-      hyperbolic_system, wave_speed_estimator_parameters, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
+      hyperbolic_system, wave_speed_estimator, dummy);
 
   std::stringstream parameters;
   parameters << "subsection WaveSpeedEstimator\n"
@@ -64,7 +64,7 @@ int main()
     std::cout << U_j[0] << " " << U_j[1] << " " << U_j[2] << std::endl;
     const auto rd_i = riemann_data(U_i);
     const auto rd_j = riemann_data(U_j);
-    const auto lambda_max = wave_speed_estimator.compute(rd_i, rd_j);
+    const auto lambda_max = wave_speed_estimator_view.compute(rd_i, rd_j);
     std::cout << lambda_max << std::endl;
     std::cout << std::endl;
     std::cout << std::endl;

--- a/tests/euler_aeos/limiter-NASG.cc
+++ b/tests/euler_aeos/limiter-NASG.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  Limiter<dim, double>::Parameters limiter_parameters;
+  LimiterView<dim, double>::Parameters limiter;
 
   const auto set_covolume = [&](const double covolume) {
     /*
@@ -43,7 +43,7 @@ int main()
 
   using state_type = HyperbolicSystemView<dim, double>::state_type;
 
-  using bounds_type = Limiter<dim, double>::Bounds;
+  using bounds_type = LimiterView<dim, double>::Bounds;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -52,7 +52,7 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  Limiter<dim, double> limiter(hyperbolic_system, limiter_parameters, dummy);
+  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter, dummy);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 
@@ -65,7 +65,7 @@ int main()
                   << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
                   << bounds[2] << std::endl;
 
-        const auto &[l, success] = limiter.limit(bounds, U, P);
+        const auto &[l, success] = limiter_view.limit(bounds, U, P);
 
         std::cout << "l: " << l;
         if (success)

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  Limiter<dim, double>::Parameters limiter_parameters;
+  LimiterView<dim, double>::Parameters limiter;
 
   const auto set_covolume = [&](const double covolume) {
     /*
@@ -41,7 +41,7 @@ int main()
 
   using state_type = HyperbolicSystemView<dim, double>::state_type;
 
-  using bounds_type = Limiter<dim, double>::Bounds;
+  using bounds_type = LimiterView<dim, double>::Bounds;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -50,7 +50,7 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  Limiter<dim, double> limiter(hyperbolic_system, limiter_parameters, dummy);
+  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter, dummy);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 
@@ -63,7 +63,7 @@ int main()
                   << "\nBounds: " << bounds[0] << " " << bounds[1] << " "
                   << bounds[2] << std::endl;
 
-        const auto &[l, success] = limiter.limit(bounds, U, P);
+        const auto &[l, success] = limiter_view.limit(bounds, U, P);
 
         std::cout << "l: " << l;
         if (success)

--- a/tests/euler_aeos/wave_speed_estimator-strict-NASG.cc
+++ b/tests/euler_aeos/wave_speed_estimator-strict-NASG.cc
@@ -22,7 +22,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimator<dim, double>::Parameters wave_speed_estimator_parameters;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -30,8 +30,8 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  WaveSpeedEstimator<dim> wave_speed_estimator(
-      hyperbolic_system, wave_speed_estimator_parameters, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
+      hyperbolic_system, wave_speed_estimator, dummy);
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"
@@ -66,7 +66,7 @@ int main()
               << std::endl;
     const auto rd_i = riemann_data(U_i);
     const auto rd_j = riemann_data(U_j);
-    const auto lambda_max = wave_speed_estimator.compute(rd_i, rd_j);
+    const auto lambda_max = wave_speed_estimator_view.compute(rd_i, rd_j);
     std::cout << lambda_max << std::endl;
   };
 

--- a/tests/euler_aeos/wave_speed_estimator-strict.cc
+++ b/tests/euler_aeos/wave_speed_estimator-strict.cc
@@ -17,7 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimator<dim, double>::Parameters wave_speed_estimator_parameters;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -25,8 +25,8 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  WaveSpeedEstimator<dim> wave_speed_estimator(
-      hyperbolic_system, wave_speed_estimator_parameters, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
+      hyperbolic_system, wave_speed_estimator, dummy);
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"
@@ -61,7 +61,7 @@ int main()
               << std::endl;
     const auto rd_i = riemann_data(U_i);
     const auto rd_j = riemann_data(U_j);
-    const auto lambda_max = wave_speed_estimator.compute(rd_i, rd_j);
+    const auto lambda_max = wave_speed_estimator_view.compute(rd_i, rd_j);
     std::cout << lambda_max << std::endl;
   };
 

--- a/tests/euler_aeos/wave_speed_estimator.cc
+++ b/tests/euler_aeos/wave_speed_estimator.cc
@@ -17,7 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimator<dim, double>::Parameters wave_speed_estimator_parameters;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -25,8 +25,8 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  WaveSpeedEstimator<dim> wave_speed_estimator(
-      hyperbolic_system, wave_speed_estimator_parameters, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
+      hyperbolic_system, wave_speed_estimator, dummy);
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"
@@ -61,7 +61,7 @@ int main()
               << std::endl;
     const auto rd_i = riemann_data(U_i);
     const auto rd_j = riemann_data(U_j);
-    const auto lambda_max = wave_speed_estimator.compute(rd_i, rd_j);
+    const auto lambda_max = wave_speed_estimator_view.compute(rd_i, rd_j);
     std::cout << lambda_max << std::endl;
   };
 

--- a/tests/euler_barotropic/limiter.cc
+++ b/tests/euler_barotropic/limiter.cc
@@ -21,11 +21,11 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  Limiter<dim, double>::Parameters limiter_parameters;
+  LimiterView<dim, double>::Parameters limiter;
 
   using state_type = HyperbolicSystemView<dim, double>::state_type;
 
-  using bounds_type = Limiter<dim, double>::Bounds;
+  using bounds_type = LimiterView<dim, double>::Bounds;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -34,7 +34,7 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  Limiter<dim, double> limiter(hyperbolic_system, limiter_parameters, dummy);
+  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter, dummy);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 
@@ -43,7 +43,7 @@ int main()
         std::cout << "State: " << U << "\nDensity: " << view.density(U)
                   << "\nBounds: " << bounds[0] << " " << bounds[1] << std::endl;
 
-        const auto &[l, success] = limiter.limit(bounds, U, P);
+        const auto &[l, success] = limiter_view.limit(bounds, U, P);
 
         std::cout << "l: " << l;
         if (success)

--- a/tests/euler_barotropic/wave_speed_estimator.cc
+++ b/tests/euler_barotropic/wave_speed_estimator.cc
@@ -17,7 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimator<dim, double>::Parameters wave_speed_estimator_parameters;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -25,8 +25,8 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  WaveSpeedEstimator<dim> wave_speed_estimator(
-      hyperbolic_system, wave_speed_estimator_parameters, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
+      hyperbolic_system, wave_speed_estimator, dummy);
 
   const auto view = hyperbolic_system.view<dim, double>();
 
@@ -51,7 +51,7 @@ int main()
     std::cout << U_j[0] << " " << U_j[1] << std::endl;
     const auto rd_i = riemann_data(U_i);
     const auto rd_j = riemann_data(U_j);
-    const auto lambda_max = wave_speed_estimator.compute(rd_i, rd_j);
+    const auto lambda_max = wave_speed_estimator_view.compute(rd_i, rd_j);
     std::cout << lambda_max << std::endl;
   };
 

--- a/tests/scalar_conservation/wave_speed_estimator.cc
+++ b/tests/scalar_conservation/wave_speed_estimator.cc
@@ -22,8 +22,7 @@ void test(const std::string &expression)
   std::cout << std::scientific;
 
   HyperbolicSystem hyperbolic_system;
-  typename WaveSpeedEstimator<dim, Number>::Parameters
-      wave_speed_estimator_parameters;
+  typename WaveSpeedEstimatorView<dim, Number>::Parameters wave_speed_estimator;
 
   const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -48,8 +47,8 @@ void test(const std::string &expression)
 
   PrecomputedVector dummy;
 
-  WaveSpeedEstimator<dim> wave_speed_estimator(
-      hyperbolic_system, wave_speed_estimator_parameters, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
+      hyperbolic_system, wave_speed_estimator, dummy);
 
   std::cout << "\n\ndim = " << dim << std::endl;
   std::cout << "f(u)={" + expression + "}" << std::endl;
@@ -76,24 +75,24 @@ void test(const std::string &expression)
 
   if constexpr (dim == 1) {
     n_ij[0] = 1.;
-    wave_speed_estimator.compute(u_i, u_j, prec_i, prec_j, n_ij);
+    wave_speed_estimator_view.compute(u_i, u_j, prec_i, prec_j, n_ij);
 
     n_ij[0] = -1.;
-    wave_speed_estimator.compute(u_i, u_j, prec_i, prec_j, n_ij);
+    wave_speed_estimator_view.compute(u_i, u_j, prec_i, prec_j, n_ij);
 
   } else if constexpr (dim == 2) {
     n_ij[0] = 1.;
     n_ij[1] = 0.;
-    wave_speed_estimator.compute(u_i, u_j, prec_i, prec_j, n_ij);
+    wave_speed_estimator_view.compute(u_i, u_j, prec_i, prec_j, n_ij);
 
     n_ij[0] = 0.;
     n_ij[1] = 1.;
-    wave_speed_estimator.compute(u_i, u_j, prec_i, prec_j, n_ij);
+    wave_speed_estimator_view.compute(u_i, u_j, prec_i, prec_j, n_ij);
 
     n_ij[0] = 1.;
     n_ij[1] = 1.;
     n_ij /= n_ij.norm();
-    wave_speed_estimator.compute(u_i, u_j, prec_i, prec_j, n_ij);
+    wave_speed_estimator_view.compute(u_i, u_j, prec_i, prec_j, n_ij);
   }
 }
 

--- a/tests/shallow_water/wave_speed_estimator.cc
+++ b/tests/shallow_water/wave_speed_estimator.cc
@@ -19,7 +19,7 @@ int main()
   HyperbolicSystem hyperbolic_system;
   const double gravity = hyperbolic_system.view<dim, double>().gravity();
 
-  WaveSpeedEstimator<dim, double>::Parameters wave_speed_estimator_parameters;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
   static constexpr unsigned int n_precomputed_values =
       HyperbolicSystemView<dim, double>::n_precomputed_values;
@@ -27,8 +27,8 @@ int main()
       Vectors::MultiComponentVector<double, n_precomputed_values>;
   precomputed_type dummy;
 
-  WaveSpeedEstimator<dim> wave_speed_estimator(
-      hyperbolic_system, wave_speed_estimator_parameters, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
+      hyperbolic_system, wave_speed_estimator, dummy);
 
   const auto riemann_data = [&](const auto &state) {
     const auto h = hyperbolic_system.view<dim, double>().water_depth_sharp(
@@ -50,8 +50,8 @@ int main()
     const auto rd_j = riemann_data(U_j);
     std::cout << "relaxation: " << rd_i[0] << " " << rd_i[1] << std::endl;
     std::cout << "relaxation: " << rd_j[0] << " " << rd_j[1] << std::endl;
-    const auto h_star = wave_speed_estimator.compute_h_star(rd_i, rd_j);
-    const auto lambda_max = wave_speed_estimator.compute(rd_i, rd_j);
+    const auto h_star = wave_speed_estimator_view.compute_h_star(rd_i, rd_j);
+    const auto lambda_max = wave_speed_estimator_view.compute(rd_i, rd_j);
     std::cout << "lambda_max: " << lambda_max << std::endl;
     std::cout << "h_star: " << h_star << std::endl;
     std::cout << std::endl;


### PR DESCRIPTION
- Euler: rename Indicator, Limiter and WaveSpeedEstimator
- EulerAEOS: rename Indicator, Limiter and WaveSpeedEstimator
- EulerBarotropic: rename Indicator, Limiter and WaveSpeedEstimator
- ScalarConservation: rename Indicator, Limiter and WaveSpeedEstimator
- ShallowWater: rename Indicator, Limiter and WaveSpeedEstimator
- Skeleton: rename Indicator, Limiter and WaveSpeedEstimator
- Description: rename the Indicator, Limiter and WaveSpeedEstimator aliases
- HyperbolicModule: follow the Indicator, Limiter and WaveSpeedEstimator rename
- SolutionTransfer: follow the Limiter rename
- Tests: rename Indicator, Limiter and WaveSpeedEstimator
