### PR TITLE
GPU Support: refactor class interfaces to the new View<.> design

### DIFF
--- a/source/euler/description.h
+++ b/source/euler/description.h
@@ -33,23 +33,20 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = Euler::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView = Euler::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = ryujin::StubParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           ryujin::StubParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = Euler::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = Euler::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = Euler::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = Euler::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView = Euler::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator = Euler::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -331,12 +331,27 @@ namespace ryujin
           Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * states:
+       */
+      using PrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber, n_precomputed_values>;
+
+      /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
           Vectors::MultiComponentVector<ScalarNumber,
                                         n_initial_precomputed_values>;
+
+      /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * initial states:
+       */
+      using InitialPrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber,
+                                            n_initial_precomputed_values>;
 
       //@}
       /**
@@ -542,14 +557,14 @@ namespace ryujin
        * For the Euler equations we simply compute <code>f(U_i)</code>.
        */
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector &ipv,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView &ipv,
                         const unsigned int i,
                         const state_type &U_i) const;
 
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector &ipv,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView &ipv,
                         const unsigned int *js,
                         const state_type &U_j) const;
 
@@ -579,12 +594,12 @@ namespace ryujin
       /** We do not have source terms: */
       static constexpr bool have_source_terms = false;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int i,
                               const state_type &U_i,
                               const ScalarNumber tau) const = delete;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int *js,
                               const state_type &U_j,
                               const ScalarNumber tau) const = delete;
@@ -1206,8 +1221,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector & /*pv*/,
-        const InitialPrecomputedVector & /*ipv*/,
+        const PrecomputedVectorView & /*pv*/,
+        const InitialPrecomputedVectorView & /*ipv*/,
         const unsigned int /*i*/,
         const state_type &U_i) const -> flux_contribution_type
     {
@@ -1218,8 +1233,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector & /*pv*/,
-        const InitialPrecomputedVector & /*ipv*/,
+        const PrecomputedVectorView & /*pv*/,
+        const InitialPrecomputedVectorView & /*ipv*/,
         const unsigned int * /*js*/,
         const state_type &U_j) const -> flux_contribution_type
     {

--- a/source/euler/hyperbolic_system.h
+++ b/source/euler/hyperbolic_system.h
@@ -52,6 +52,13 @@ namespace ryujin
       HyperbolicSystem(const std::string &subsection = "/HyperbolicSystem");
 
       /**
+       * Alias for the view on the hyperbolic system for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = HyperbolicSystemView<dim, Number>;
+
+      /**
        * Return a view on the Hyperbolic System for a given dimension @p
        * dim and choice of number type @p Number (which can be a scalar
        * float, or double, as well as a VectorizedArray holding packed
@@ -60,7 +67,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return HyperbolicSystemView<dim, Number>{*this};
+        return View<dim, Number>{*this};
       }
 
       /**

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -99,7 +99,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Indicator<ScalarNumber>;
 
@@ -112,10 +112,10 @@ namespace ryujin
        * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator_view.reset(i, U_i);
+       *   indicator_view.reset(pv, i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator_view.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(pv, js, U_j, c_ij);
        *   }
        *   indicator_view.alpha(hd_i);
        * }
@@ -127,11 +127,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters,
-                    const PrecomputedVector &precomputed_values)
+                    const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -139,13 +137,16 @@ namespace ryujin
        * Reset temporary storage and initialize for a new row corresponding
        * to state vector U_i.
        */
-      void reset(const unsigned int i, const state_type &U_i);
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
+                 const state_type &U_i);
 
       /**
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const dealii::Tensor<1, dim, Number> &c_ij);
 
@@ -164,7 +165,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;
@@ -187,7 +187,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    IndicatorView<dim, Number>::reset(const unsigned int i,
+    IndicatorView<dim, Number>::reset(const PrecomputedVectorView &pv,
+                                      const unsigned int i,
                                       const state_type &U_i)
     {
       /* Entropy viscosity commutator: */
@@ -195,7 +196,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[new_s_i, new_eta_i] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       const auto rho_i = view.density(U_i);
       rho_i_inverse = Number(1.) / rho_i;
@@ -212,6 +213,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
+        const PrecomputedVectorView &pv,
         const unsigned int *js,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -221,7 +223,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[s_j, eta_j] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(js);
+          pv.template read_tensor<Number, precomputed_type>(js);
 
       const auto rho_j = view.density(U_j);
       const auto rho_j_inverse = Number(1.) / rho_j;

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -152,8 +152,8 @@ namespace ryujin
        * object as arguments
        */
       IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
-          : view(view)
-          , indicator(indicator)
+          : view_(view)
+          , indicator_(indicator)
       {
       }
 
@@ -187,16 +187,16 @@ namespace ryujin
        */
       //@{
 
-      const View view;
-      const Indicator<ScalarNumber> &indicator;
+      const View view_;
+      const Indicator<ScalarNumber> &indicator_;
 
-      Number rho_i_inverse = 0.;
-      Number eta_i = 0.;
-      flux_type f_i;
-      state_type d_eta_i;
+      Number rho_i_inverse_ = 0.;
+      Number eta_i_ = 0.;
+      flux_type f_i_;
+      state_type d_eta_i_;
 
-      Number left = 0.;
-      state_type right;
+      Number left_ = 0.;
+      state_type right_;
 
       //@}
     };
@@ -220,16 +220,16 @@ namespace ryujin
       const auto &[new_s_i, new_eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
-      const auto rho_i = view.density(U_i);
-      rho_i_inverse = Number(1.) / rho_i;
-      eta_i = new_eta_i;
+      const auto rho_i = view_.density(U_i);
+      rho_i_inverse_ = Number(1.) / rho_i;
+      eta_i_ = new_eta_i;
 
-      d_eta_i = view.harten_entropy_derivative(U_i);
-      d_eta_i[0] -= eta_i * rho_i_inverse;
-      f_i = view.f(U_i);
+      d_eta_i_ = view_.harten_entropy_derivative(U_i);
+      d_eta_i_[0] -= eta_i_ * rho_i_inverse_;
+      f_i_ = view_.f(U_i);
 
-      left = 0.;
-      right = 0.;
+      left_ = 0.;
+      right_ = 0.;
     }
 
 
@@ -245,19 +245,19 @@ namespace ryujin
       const auto &[s_j, eta_j] =
           pv.template read_tensor<Number, precomputed_type>(js);
 
-      const auto rho_j = view.density(U_j);
+      const auto rho_j = view_.density(U_j);
       const auto rho_j_inverse = Number(1.) / rho_j;
 
-      const auto m_j = view.momentum(U_j);
-      const auto f_j = view.f(U_j);
+      const auto m_j = view_.momentum(U_j);
+      const auto f_j = view_.f(U_j);
 
       const auto entropy_flux =
-          (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
+          (eta_j * rho_j_inverse - eta_i_ * rho_i_inverse_) * (m_j * c_ij);
 
-      left += entropy_flux;
+      left_ += entropy_flux;
       for (unsigned int k = 0; k < problem_dimension; ++k) {
-        const auto component = (f_j[k] - f_i[k]) * c_ij;
-        right[k] += component;
+        const auto component = (f_j[k] - f_i_[k]) * c_ij;
+        right_[k] += component;
       }
     }
 
@@ -268,17 +268,17 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      Number numerator = left;
-      Number denominator = std::abs(left);
+      Number numerator = left_;
+      Number denominator = std::abs(left_);
       for (unsigned int k = 0; k < problem_dimension; ++k) {
-        numerator -= d_eta_i[k] * right[k];
-        denominator += std::abs(d_eta_i[k] * right[k]);
+        numerator -= d_eta_i_[k] * right_[k];
+        denominator += std::abs(d_eta_i_[k] * right_[k]);
       }
 
       const auto quotient =
-          std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
+          std::abs(numerator) / (denominator + hd_i * std::abs(eta_i_));
 
-      return std::min(Number(1.), indicator.evc_factor() * quotient);
+      return std::min(Number(1.), indicator_.evc_factor() * quotient);
     }
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -148,12 +148,12 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and an Indicator
        * object as arguments
        */
-      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
           : view(view)
-          , parameters(parameters)
+          , indicator(indicator)
       {
       }
 
@@ -188,7 +188,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Indicator<ScalarNumber> &parameters;
+      const Indicator<ScalarNumber> &indicator;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;
@@ -278,7 +278,7 @@ namespace ryujin
       const auto quotient =
           std::abs(numerator) / (denominator + hd_i * std::abs(eta_i));
 
-      return std::min(Number(1.), parameters.evc_factor() * quotient);
+      return std::min(Number(1.), indicator.evc_factor() * quotient);
     }
   } // namespace Euler
 } // namespace ryujin

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -217,12 +217,12 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      const auto &[new_s_i, new_eta_i] =
+      const auto &[s_i, eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
       const auto rho_i = view_.density(U_i);
       rho_i_inverse_ = Number(1.) / rho_i;
-      eta_i_ = new_eta_i;
+      eta_i_ = eta_i;
 
       d_eta_i_ = view_.harten_entropy_derivative(U_i);
       d_eta_i_[0] -= eta_i_ * rho_i_inverse_;

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -10,6 +10,7 @@
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -19,12 +20,17 @@ namespace ryujin
 {
   namespace Euler
   {
+    template <int dim, typename Number = double>
+    class IndicatorView;
+
     template <typename ScalarNumber = double>
     class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      Indicator(const std::string &subsection = "/Indicator")
+      Indicator(const HyperbolicSystem &hyperbolic_system,
+                const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
@@ -34,7 +40,20 @@ namespace ryujin
 
       ACCESSOR_READ_ONLY(evc_factor);
 
+      /**
+       * Return a view on the Indicator for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return IndicatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       ScalarNumber evc_factor_;
     };
 
@@ -78,7 +97,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class IndicatorView
     {
     public:
@@ -124,11 +143,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      IndicatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -163,7 +182,7 @@ namespace ryujin
        */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       Number rho_i_inverse = 0.;
@@ -193,8 +212,6 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto &[new_s_i, new_eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
@@ -219,8 +236,6 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
       /* Entropy viscosity commutator: */
-
-      const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[s_j, eta_j] =
           pv.template read_tensor<Number, precomputed_type>(js);

--- a/source/euler/indicator.h
+++ b/source/euler/indicator.h
@@ -41,6 +41,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(evc_factor);
 
       /**
+       * Alias for the view on the indicator for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = IndicatorView<dim, Number>;
+
+      /**
        * Return a view on the Indicator for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -48,7 +55,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return IndicatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -120,8 +127,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Indicator<ScalarNumber>;
-
       //@}
       /**
        * @name Stencil-based computation of indicators
@@ -143,10 +148,10 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      IndicatorView(const View &view, const Parameters &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -183,7 +188,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Indicator<ScalarNumber> &parameters;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;

--- a/source/euler/initial_state_astro_jet.h
+++ b/source/euler/initial_state_astro_jet.h
@@ -30,11 +30,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_1d = typename Description::
-          template HyperbolicSystemView<1, Number>::state_type;
+      using state_type_1d =
+          typename HyperbolicSystem::template View<1, Number>::state_type;
 
       AstroJet(const HyperbolicSystem &hyperbolic_system,
                const std::string subsection)

--- a/source/euler/initial_state_becker_solution.h
+++ b/source/euler/initial_state_becker_solution.h
@@ -48,8 +48,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       BeckerSolution(const HyperbolicSystem &hyperbolic_system,
@@ -208,8 +207,8 @@ namespace ryujin
                          (R_infty * velocity_left_ * velocity_right_ - v * v);
         Assert(e > 0., dealii::ExcInternalError());
 
-        using state_type_1d = typename Description::
-            template HyperbolicSystemView<1, Number>::state_type;
+        using state_type_1d =
+            typename HyperbolicSystem::template View<1, Number>::state_type;
 
         state_type_1d result;
         result[0] = Number(rho);

--- a/source/euler/initial_state_contrast.h
+++ b/source/euler/initial_state_contrast.h
@@ -28,11 +28,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_1d = typename Description::
-          template HyperbolicSystemView<1, Number>::state_type;
+      using state_type_1d =
+          typename HyperbolicSystem::template View<1, Number>::state_type;
 
       Contrast(const HyperbolicSystem &hyperbolic_system,
                const std::string subsection)

--- a/source/euler/initial_state_exact_riemann_solution.h
+++ b/source/euler/initial_state_exact_riemann_solution.h
@@ -39,8 +39,7 @@ namespace ryujin
       //@{
 
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       using ScalarNumber = typename View::ScalarNumber;
@@ -197,8 +196,8 @@ namespace ryujin
 #endif
         }
 
-        using state_type_1d = typename Description::
-            template HyperbolicSystemView<1, Number>::state_type;
+        using state_type_1d =
+            typename HyperbolicSystem::template View<1, Number>::state_type;
         static_assert(state_type_1d::dimension <=
                       dealii::Tensor<1, 3, Number>::dimension);
 

--- a/source/euler/initial_state_four_state_contrast.h
+++ b/source/euler/initial_state_four_state_contrast.h
@@ -31,11 +31,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_2d = typename Description::
-          template HyperbolicSystemView<2, Number>::state_type;
+      using state_type_2d =
+          typename HyperbolicSystem::template View<2, Number>::state_type;
 
       FourStateContrast(const HyperbolicSystem &hyperbolic_system,
                         const std::string &subsection)

--- a/source/euler/initial_state_function.h
+++ b/source/euler/initial_state_function.h
@@ -25,8 +25,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       Function(const HyperbolicSystem &hyperbolic_system,

--- a/source/euler/initial_state_icf_like.h
+++ b/source/euler/initial_state_icf_like.h
@@ -31,11 +31,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_1d = typename Description::
-          template HyperbolicSystemView<1, Number>::state_type;
+      using state_type_1d =
+          typename HyperbolicSystem::template View<1, Number>::state_type;
 
       ICFLike(const HyperbolicSystem &hyperbolic_system,
               const std::string subsection)
@@ -88,8 +87,8 @@ namespace ryujin
         const auto convert_states = [&]() {
           const auto view = hyperbolic_system_.template view<dim, Number>();
 
-          using state_type_1d = typename Description::
-              template HyperbolicSystemView<1, Number>::state_type;
+          using state_type_1d =
+              typename HyperbolicSystem::template View<1, Number>::state_type;
           static_assert(state_type_1d::dimension <=
                         dealii::Tensor<1, 3, Number>::dimension);
 

--- a/source/euler/initial_state_isentropic_vortex.h
+++ b/source/euler/initial_state_isentropic_vortex.h
@@ -29,8 +29,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       IsentropicVortex(const HyperbolicSystem &hyperbolic_system,

--- a/source/euler/initial_state_leblanc.h
+++ b/source/euler/initial_state_leblanc.h
@@ -32,8 +32,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       using ScalarNumber = typename View::ScalarNumber;

--- a/source/euler/initial_state_library.template.h
+++ b/source/euler/initial_state_library.template.h
@@ -21,8 +21,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/euler/initial_state_library_euler.h
+++ b/source/euler/initial_state_library_euler.h
@@ -45,8 +45,7 @@ namespace ryujin
       };
 
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<1, double>;
+      using View = typename HyperbolicSystem::template View<1, double>;
 
       add(make_unique<AstroJet<Description, dim, Number>>(h, s));
       add(make_unique<BeckerSolution<Description, dim, Number>>(h, s));

--- a/source/euler/initial_state_noh.h
+++ b/source/euler/initial_state_noh.h
@@ -29,8 +29,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       Noh(const HyperbolicSystem &hyperbolic_system,

--- a/source/euler/initial_state_radial_contrast.h
+++ b/source/euler/initial_state_radial_contrast.h
@@ -32,11 +32,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_1d = typename Description::
-          template HyperbolicSystemView<1, Number>::state_type;
+      using state_type_1d =
+          typename HyperbolicSystem::template View<1, Number>::state_type;
 
       RadialContrast(const HyperbolicSystem &hyperbolic_system,
                      const std::string &subsection)

--- a/source/euler/initial_state_ramp_up.h
+++ b/source/euler/initial_state_ramp_up.h
@@ -26,11 +26,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_1d = typename Description::
-          template HyperbolicSystemView<1, Number>::state_type;
+      using state_type_1d =
+          typename HyperbolicSystem::template View<1, Number>::state_type;
 
       RampUp(const HyperbolicSystem &hyperbolic_system,
              const std::string subsection)

--- a/source/euler/initial_state_rarefaction.h
+++ b/source/euler/initial_state_rarefaction.h
@@ -30,8 +30,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       using state_type_1d = std::array<Number, 4>;

--- a/source/euler/initial_state_shock_front.h
+++ b/source/euler/initial_state_shock_front.h
@@ -30,8 +30,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       ShockFront(const HyperbolicSystem &hyperbolic_system,
@@ -92,8 +91,8 @@ namespace ryujin
                               (gamma_ - Number(1.))) /
                              (gamma_ + Number(1.));
 
-          using state_type_1d = typename Description::
-              template HyperbolicSystemView<1, Number>::state_type;
+          using state_type_1d =
+              typename HyperbolicSystem::template View<1, Number>::state_type;
 
           if constexpr (View::have_energy_equation) {
             state_left_ =

--- a/source/euler/initial_state_smooth_wave.h
+++ b/source/euler/initial_state_smooth_wave.h
@@ -30,11 +30,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_1d = typename Description::
-          template HyperbolicSystemView<1, Number>::state_type;
+      using state_type_1d =
+          typename HyperbolicSystem::template View<1, Number>::state_type;
 
       using ScalarNumber = typename View::ScalarNumber;
 

--- a/source/euler/initial_state_three_state_contrast.h
+++ b/source/euler/initial_state_three_state_contrast.h
@@ -31,11 +31,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_1d = typename Description::
-          template HyperbolicSystemView<1, Number>::state_type;
+      using state_type_1d =
+          typename HyperbolicSystem::template View<1, Number>::state_type;
 
       ThreeStateContrast(const HyperbolicSystem &hyperbolic_system,
                          const std::string &subsection)

--- a/source/euler/initial_state_uniform.h
+++ b/source/euler/initial_state_uniform.h
@@ -27,11 +27,10 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
-      using state_type_1d = typename Description::
-          template HyperbolicSystemView<1, Number>::state_type;
+      using state_type_1d =
+          typename HyperbolicSystem::template View<1, Number>::state_type;
 
       Uniform(const HyperbolicSystem &hyperbolic_system,
               const std::string subsection)

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -164,8 +164,8 @@ namespace ryujin
        * object as arguments
        */
       LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
-          : view(view)
-          , limiter(limiter)
+          : view_(view)
+          , limiter_(limiter)
       {
       }
 
@@ -270,16 +270,16 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const View view;
-      const Limiter<ScalarNumber> &limiter;
+      const View view_;
+      const Limiter<ScalarNumber> &limiter_;
 
-      state_type U_i;
+      state_type U_i_;
 
       Bounds bounds_;
 
-      Number rho_relaxation_numerator;
-      Number rho_relaxation_denominator;
-      Number s_interp_max;
+      Number rho_relaxation_numerator_;
+      Number rho_relaxation_denominator_;
+      Number s_interp_max_;
 
       //@}
     };
@@ -299,7 +299,7 @@ namespace ryujin
         const unsigned int i,
         const state_type &U_i) const -> Bounds
     {
-      const auto rho_i = view.density(U_i);
+      const auto rho_i = view_.density(U_i);
       const auto &[s_i, eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
@@ -336,7 +336,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= limiter.relaxation_factor();
+      r *= limiter_.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       rho_min *= std::max(Number(1.) - r, Number(eps));
@@ -354,7 +354,7 @@ namespace ryujin
         const state_type &new_U_i,
         const flux_contribution_type & /*new_flux_i*/)
     {
-      U_i = new_U_i;
+      U_i_ = new_U_i;
 
       /* Bounds: */
 
@@ -366,9 +366,9 @@ namespace ryujin
 
       /* Relaxation: */
 
-      rho_relaxation_numerator = Number(0.);
-      rho_relaxation_denominator = Number(0.);
-      s_interp_max = Number(0.);
+      rho_relaxation_numerator_ = Number(0.);
+      rho_relaxation_denominator_ = Number(0.);
+      s_interp_max_ = Number(0.);
     }
 
 
@@ -391,11 +391,11 @@ namespace ryujin
       /* Bounds: */
       auto &[rho_min, rho_max, s_min] = bounds_;
 
-      const auto rho_i = view.density(U_i);
-      const auto m_i = view.momentum(U_i);
-      const auto rho_j = view.density(U_j);
-      const auto m_j = view.momentum(U_j);
-      const auto rho_affine_shift = view.density(affine_shift);
+      const auto rho_i = view_.density(U_i_);
+      const auto m_i = view_.momentum(U_i_);
+      const auto rho_j = view_.density(U_j);
+      const auto m_j = view_.momentum(U_j);
+      const auto rho_affine_shift = view_.density(affine_shift);
 
       /* bar state shifted by an affine shift: */
       const auto rho_ij_bar =
@@ -413,12 +413,12 @@ namespace ryujin
 
       /* Use a uniform weight. */
       const auto beta_ij = Number(1.);
-      rho_relaxation_numerator += beta_ij * (rho_i + rho_j);
-      rho_relaxation_denominator += std::abs(beta_ij);
+      rho_relaxation_numerator_ += beta_ij * (rho_i + rho_j);
+      rho_relaxation_denominator_ += std::abs(beta_ij);
 
       const Number s_interp =
-          view.specific_entropy((U_i + U_j) * ScalarNumber(.5));
-      s_interp_max = std::max(s_interp_max, s_interp);
+          view_.specific_entropy((U_i_ + U_j) * ScalarNumber(.5));
+      s_interp_max_ = std::max(s_interp_max_, s_interp);
     }
 
 
@@ -436,12 +436,12 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const auto rho_relaxation =
-          ScalarNumber(2. * limiter.relaxation_factor()) *
-          std::abs(rho_relaxation_numerator) /
-          (std::abs(rho_relaxation_denominator) + Number(eps));
+          ScalarNumber(2. * limiter_.relaxation_factor()) *
+          std::abs(rho_relaxation_numerator_) /
+          (std::abs(rho_relaxation_denominator_) + Number(eps));
 
       const auto entropy_relaxation =
-          limiter.relaxation_factor() * (s_interp_max - s_min);
+          limiter_.relaxation_factor() * (s_interp_max_ - s_min);
 
       rho_min_relaxed = std::max(rho_min_relaxed, rho_min - rho_relaxation);
       rho_max_relaxed = std::min(rho_max_relaxed, rho_max + rho_relaxation);

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -348,13 +348,13 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::reset(
-        const PrecomputedVectorView & /*pv*/,
-        const unsigned int /*i*/,
-        const state_type &new_U_i,
-        const flux_contribution_type & /*new_flux_i*/)
+    DEAL_II_ALWAYS_INLINE inline void
+    LimiterView<dim, Number>::reset(const PrecomputedVectorView & /*pv*/,
+                                    const unsigned int /*i*/,
+                                    const state_type &U_i,
+                                    const flux_contribution_type & /*flux_i*/)
     {
-      U_i_ = new_U_i;
+      U_i_ = U_i;
 
       /* Bounds: */
 

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -160,12 +160,12 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a Limiter
        * object as arguments
        */
-      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
           : view(view)
-          , parameters(parameters)
+          , limiter(limiter)
       {
       }
 
@@ -271,7 +271,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Limiter<ScalarNumber> &parameters;
+      const Limiter<ScalarNumber> &limiter;
 
       state_type U_i;
 
@@ -336,7 +336,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= parameters.relaxation_factor();
+      r *= limiter.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       rho_min *= std::max(Number(1.) - r, Number(eps));
@@ -436,12 +436,12 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const auto rho_relaxation =
-          ScalarNumber(2. * parameters.relaxation_factor()) *
+          ScalarNumber(2. * limiter.relaxation_factor()) *
           std::abs(rho_relaxation_numerator) /
           (std::abs(rho_relaxation_denominator) + Number(eps));
 
       const auto entropy_relaxation =
-          parameters.relaxation_factor() * (s_interp_max - s_min);
+          limiter.relaxation_factor() * (s_interp_max - s_min);
 
       rho_min_relaxed = std::max(rho_min_relaxed, rho_min - rho_relaxation);
       rho_max_relaxed = std::min(rho_max_relaxed, rho_max + rho_relaxation);

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -13,18 +13,24 @@
 #include <deal.II/base/config.h>
 #include <multicomponent_vector.h>
 #include <newton.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 namespace ryujin
 {
   namespace Euler
   {
+    template <int dim, typename Number = double>
+    class LimiterView;
+
     template <typename ScalarNumber = double>
     class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      Limiter(const std::string &subsection = "/Limiter")
+      Limiter(const HyperbolicSystem &hyperbolic_system,
+              const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         iterations_ = 2;
         add_parameter(
@@ -56,7 +62,20 @@ namespace ryujin
       ACCESSOR_READ_ONLY(newton_max_iterations);
       ACCESSOR_READ_ONLY(relaxation_factor);
 
+      /**
+       * Return a view on the Limiter for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return LimiterView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       unsigned int iterations_;
       ScalarNumber newton_tolerance_;
       unsigned int newton_max_iterations_;
@@ -94,7 +113,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class LimiterView
     {
     public:
@@ -136,11 +155,11 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      LimiterView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -246,7 +265,7 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       state_type U_i;
@@ -275,7 +294,6 @@ namespace ryujin
         const unsigned int i,
         const state_type &U_i) const -> Bounds
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto rho_i = view.density(U_i);
       const auto &[s_i, eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
@@ -364,8 +382,6 @@ namespace ryujin
       // equations verify that this does the right thing.
       Assert(std::max(affine_shift.norm(), Number(0.)) == Number(0.),
              dealii::ExcNotImplemented());
-
-      const auto view = hyperbolic_system.view<dim, Number>();
 
       /* Bounds: */
       auto &[rho_min, rho_max, s_min] = bounds_;

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -115,7 +115,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Limiter<ScalarNumber>;
 
@@ -139,11 +139,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters,
-                  const PrecomputedVector &precomputed_values)
+                  const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -151,7 +149,8 @@ namespace ryujin
        * Given a state @p U_i and an index @p i return "strict" bounds,
        * i.e., a minimal convex set containing the state.
        */
-      Bounds projection_bounds_from_state(const unsigned int i,
+      Bounds projection_bounds_from_state(const PrecomputedVectorView &pv,
+                                          const unsigned int i,
                                           const state_type &U_i) const;
 
       /**
@@ -181,10 +180,10 @@ namespace ryujin
        * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter_view.reset(i, U_i, flux_i);
+       *   limiter_view.reset(pv, i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       *     limiter_view.accumulate(pv, js, U_j, flux_j, scaled_c_ij,
        * affine_shift);
        *   }
        *   limiter_view.bounds(hd_i);
@@ -196,7 +195,8 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int i,
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
                  const state_type &U_i,
                  const flux_contribution_type &flux_i);
 
@@ -204,7 +204,8 @@ namespace ryujin
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
@@ -247,7 +248,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
 
@@ -271,12 +271,14 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     LimiterView<dim, Number>::projection_bounds_from_state(
-        const unsigned int i, const state_type &U_i) const -> Bounds
+        const PrecomputedVectorView &pv,
+        const unsigned int i,
+        const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
       const auto rho_i = view.density(U_i);
       const auto &[s_i, eta_i] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       return {/*rho_min*/ rho_i, /*rho_max*/ rho_i, /*s_min*/ s_i};
     }
@@ -324,6 +326,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::reset(
+        const PrecomputedVectorView & /*pv*/,
         const unsigned int /*i*/,
         const state_type &new_U_i,
         const flux_contribution_type & /*new_flux_i*/)
@@ -348,6 +351,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
+        const PrecomputedVectorView &pv,
         const unsigned int *js,
         const state_type &U_j,
         const flux_contribution_type & /*flux_j*/,
@@ -381,7 +385,7 @@ namespace ryujin
       rho_max = std::max(rho_max, rho_ij_bar);
 
       const auto &[s_j, eta_j] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(js);
+          pv.template read_tensor<Number, precomputed_type>(js);
       s_min = std::min(s_min, s_j);
 
       /* Relaxation: */

--- a/source/euler/limiter.h
+++ b/source/euler/limiter.h
@@ -63,6 +63,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(relaxation_factor);
 
       /**
+       * Alias for the view on the limiter for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = LimiterView<dim, Number>;
+
+      /**
        * Return a view on the Limiter for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -70,7 +77,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return LimiterView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -136,8 +143,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Limiter<ScalarNumber>;
-
       //@}
       /**
        * @name Computation and manipulation of bounds
@@ -155,10 +160,10 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      LimiterView(const View &view, const Parameters &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -266,7 +271,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Limiter<ScalarNumber> &parameters;
 
       state_type U_i;
 

--- a/source/euler/limiter.template.h
+++ b/source/euler/limiter.template.h
@@ -24,8 +24,8 @@ namespace ryujin
       Number t_r = t_max;
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
-      const auto small = view.vacuum_state_relaxation_small();
-      const auto large = view.vacuum_state_relaxation_large();
+      const auto small = view_.vacuum_state_relaxation_small();
+      const auto large = view_.vacuum_state_relaxation_large();
       const ScalarNumber relax_small = ScalarNumber(1. + small * eps);
       const ScalarNumber relax = ScalarNumber(1. + large * eps);
 
@@ -36,8 +36,8 @@ namespace ryujin
        */
 
       {
-        const auto &rho_U = view.density(U);
-        const auto &rho_P = view.density(P);
+        const auto &rho_U = view_.density(U);
+        const auto &rho_P = view_.density(P);
 
         const auto &rho_min = std::get<0>(bounds);
         const auto &rho_max = std::get<1>(bounds);
@@ -46,9 +46,9 @@ namespace ryujin
          * Verify that rho_U is within bounds. This property might be
          * violated for relative CFL numbers larger than 1.
          */
-        const auto test_min = view.filter_vacuum_density(
+        const auto test_min = view_.filter_vacuum_density(
             std::max(Number(0.), rho_U - relax * rho_max));
-        const auto test_max = view.filter_vacuum_density(
+        const auto test_max = view_.filter_vacuum_density(
             std::max(Number(0.), rho_min - relax * rho_U));
         if (!(test_min == Number(0.) && test_max == Number(0.))) {
 #ifdef DEBUG_OUTPUT
@@ -109,10 +109,10 @@ namespace ryujin
         /*
          * Verify that the new state is within bounds:
          */
-        const auto rho_new = view.density(U + t_r * P);
-        const auto test_new_min = view.filter_vacuum_density(
+        const auto rho_new = view_.density(U + t_r * P);
+        const auto test_new_min = view_.filter_vacuum_density(
             std::max(Number(0.), rho_new - relax * rho_max));
-        const auto test_new_max = view.filter_vacuum_density(
+        const auto test_new_max = view_.filter_vacuum_density(
             std::max(Number(0.), rho_min - relax * rho_new));
         if (!(test_new_min == Number(0.) && test_new_max == Number(0.))) {
 #ifdef DEBUG_OUTPUT
@@ -140,7 +140,7 @@ namespace ryujin
 
       Number t_l = t_min; // good state
 
-      const ScalarNumber gamma = view.gamma();
+      const ScalarNumber gamma = view_.gamma();
       const ScalarNumber gp1 = gamma + ScalarNumber(1.);
 
       {
@@ -168,12 +168,12 @@ namespace ryujin
         std::cout << "t_r: (start) " << t_r << std::endl;
 #endif
 
-        for (unsigned int n = 0; n < limiter.newton_max_iterations(); ++n) {
+        for (unsigned int n = 0; n < limiter_.newton_max_iterations(); ++n) {
 
           const auto U_r = U + t_r * P;
-          const auto rho_r = view.density(U_r);
+          const auto rho_r = view_.density(U_r);
           const auto rho_r_gamma = ryujin::pow(rho_r, gamma);
-          const auto rho_e_r = view.internal_energy(U_r);
+          const auto rho_e_r = view_.internal_energy(U_r);
 
           auto psi_r =
               relax_small * rho_r * rho_e_r - s_min * rho_r * rho_r_gamma;
@@ -215,9 +215,9 @@ namespace ryujin
 #endif
 
           const auto U_l = U + t_l * P;
-          const auto rho_l = view.density(U_l);
+          const auto rho_l = view_.density(U_l);
           const auto rho_l_gamma = ryujin::pow(rho_l, gamma);
-          const auto rho_e_l = view.internal_energy(U_l);
+          const auto rho_e_l = view_.internal_energy(U_l);
 
           auto psi_l =
               relax_small * rho_l * rho_e_l - s_min * rho_l * rho_l_gamma;
@@ -253,7 +253,7 @@ namespace ryujin
            * Break if the window between t_l and t_r is within the prescribed
            * tolerance:
            */
-          const Number tolerance(limiter.newton_tolerance());
+          const Number tolerance(limiter_.newton_tolerance());
           if (std::max(Number(0.), t_r - t_l - tolerance) == Number(0.)) {
 #ifdef DEBUG_OUTPUT_LIMITER
             std::cout << "break: t_l and t_r within tolerance" << std::endl;
@@ -267,9 +267,9 @@ namespace ryujin
 
           /* We got unlucky and have to perform a Newton step: */
 
-          const auto drho = view.density(P);
-          const auto drho_e_l = view.internal_energy_derivative(U_l) * P;
-          const auto drho_e_r = view.internal_energy_derivative(U_r) * P;
+          const auto drho = view_.density(P);
+          const auto drho_e_l = view_.internal_energy_derivative(U_l) * P;
+          const auto drho_e_r = view_.internal_energy_derivative(U_r) * P;
           const auto dpsi_l =
               rho_l * drho_e_l + (rho_e_l - gp1 * s_min * rho_l_gamma) * drho;
           const auto dpsi_r =
@@ -294,9 +294,9 @@ namespace ryujin
          */
         {
           const auto U_new = U + t_l * P;
-          const auto rho_new = view.density(U_new);
+          const auto rho_new = view_.density(U_new);
           const auto rho_new_gamma = ryujin::pow(rho_new, gamma);
-          const auto rho_e_new = view.internal_energy(U_new);
+          const auto rho_e_new = view_.internal_energy(U_new);
 
           auto psi_new = relax_small * rho_new * rho_e_new -
                          s_min * rho_new * rho_new_gamma;

--- a/source/euler/limiter.template.h
+++ b/source/euler/limiter.template.h
@@ -20,8 +20,6 @@ namespace ryujin
                                     const Number t_min /* = Number(0.) */,
                                     const Number t_max /* = Number(1.) */) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       bool success = true;
       Number t_r = t_max;
 

--- a/source/euler/limiter.template.h
+++ b/source/euler/limiter.template.h
@@ -168,7 +168,7 @@ namespace ryujin
         std::cout << "t_r: (start) " << t_r << std::endl;
 #endif
 
-        for (unsigned int n = 0; n < parameters.newton_max_iterations(); ++n) {
+        for (unsigned int n = 0; n < limiter.newton_max_iterations(); ++n) {
 
           const auto U_r = U + t_r * P;
           const auto rho_r = view.density(U_r);
@@ -253,7 +253,7 @@ namespace ryujin
            * Break if the window between t_l and t_r is within the prescribed
            * tolerance:
            */
-          const Number tolerance(parameters.newton_tolerance());
+          const Number tolerance(limiter.newton_tolerance());
           if (std::max(Number(0.), t_r - t_l - tolerance) == Number(0.)) {
 #ifdef DEBUG_OUTPUT_LIMITER
             std::cout << "break: t_l and t_r within tolerance" << std::endl;

--- a/source/euler/wave_speed_estimator.h
+++ b/source/euler/wave_speed_estimator.h
@@ -130,8 +130,8 @@ namespace ryujin
       WaveSpeedEstimatorView(
           const View &view,
           const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
-          : view(view)
-          , wave_speed_estimator(wave_speed_estimator)
+          : view_(view)
+          , wave_speed_estimator_(wave_speed_estimator)
       {
       }
 
@@ -300,8 +300,8 @@ namespace ryujin
                               const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      const View view;
-      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
+      const View view_;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator_;
       //@}
     };
   } // namespace Euler

--- a/source/euler/wave_speed_estimator.h
+++ b/source/euler/wave_speed_estimator.h
@@ -50,6 +50,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(newton_max_iterations);
 
       /**
+       * Alias for the view on the wave speed estimator for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = WaveSpeedEstimatorView<dim, Number>;
+
+      /**
        * Return a view on the WaveSpeedEstimator for a given dimension @p dim
        * and choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -57,7 +64,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return WaveSpeedEstimatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -110,8 +117,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = WaveSpeedEstimator<ScalarNumber>;
-
       //@}
       /**
        * @name Compute wavespeed estimates
@@ -119,10 +124,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+      WaveSpeedEstimatorView(const View &view,
+                             const WaveSpeedEstimator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -294,7 +300,7 @@ namespace ryujin
 
     private:
       const View view;
-      const Parameters &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &parameters;
       //@}
     };
   } // namespace Euler

--- a/source/euler/wave_speed_estimator.h
+++ b/source/euler/wave_speed_estimator.h
@@ -89,7 +89,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
@@ -103,11 +103,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters,
-                             const PrecomputedVector &precomputed_values)
+                             const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -126,7 +124,8 @@ namespace ryujin
        * Returns a tuple consisting of lambda max and the number of Newton
        * iterations used in the solver to find it.
        */
-      Number compute(const state_type &U_i,
+      Number compute(const PrecomputedVectorView &pv,
+                     const state_type &U_i,
                      const state_type &U_j,
                      const unsigned int i,
                      const unsigned int *js,
@@ -277,7 +276,6 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace Euler

--- a/source/euler/wave_speed_estimator.h
+++ b/source/euler/wave_speed_estimator.h
@@ -124,13 +124,14 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a WaveSpeedEstimator
        * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view,
-                             const WaveSpeedEstimator<ScalarNumber> &parameters)
+      WaveSpeedEstimatorView(
+          const View &view,
+          const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
           : view(view)
-          , parameters(parameters)
+          , wave_speed_estimator(wave_speed_estimator)
       {
       }
 
@@ -300,7 +301,7 @@ namespace ryujin
 
     private:
       const View view;
-      const WaveSpeedEstimator<ScalarNumber> &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
       //@}
     };
   } // namespace Euler

--- a/source/euler/wave_speed_estimator.h
+++ b/source/euler/wave_speed_estimator.h
@@ -9,6 +9,7 @@
 
 #include "hyperbolic_system.h"
 
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/point.h>
@@ -18,12 +19,17 @@ namespace ryujin
 {
   namespace Euler
   {
+    template <int dim, typename Number = double>
+    class WaveSpeedEstimatorView;
+
     template <typename ScalarNumber = double>
     class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
+                         const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         if constexpr (std::is_same<ScalarNumber, double>::value)
           newton_tolerance_ = 1.e-10;
@@ -43,7 +49,20 @@ namespace ryujin
       ACCESSOR_READ_ONLY(newton_tolerance);
       ACCESSOR_READ_ONLY(newton_max_iterations);
 
+      /**
+       * Return a view on the WaveSpeedEstimator for a given dimension @p dim
+       * and choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return WaveSpeedEstimatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       ScalarNumber newton_tolerance_;
       unsigned int newton_max_iterations_;
     };
@@ -58,7 +77,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class WaveSpeedEstimatorView
     {
     public:
@@ -100,11 +119,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -274,7 +293,7 @@ namespace ryujin
                               const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
       //@}
     };

--- a/source/euler/wave_speed_estimator.template.h
+++ b/source/euler/wave_speed_estimator.template.h
@@ -585,6 +585,7 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
     WaveSpeedEstimatorView<dim, Number>::compute(
+        const PrecomputedVectorView & /*pv*/,
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int /*i*/,

--- a/source/euler/wave_speed_estimator.template.h
+++ b/source/euler/wave_speed_estimator.template.h
@@ -21,7 +21,7 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::f(const primitive_type &riemann_data,
                                            const Number p_star) const
     {
-      const auto &gamma = view.gamma();
+      const auto &gamma = view_.gamma();
 
       const auto &[rho, u, p, a] = riemann_data;
 
@@ -49,10 +49,10 @@ namespace ryujin
                                             const Number &p_star) const
     {
       using ScalarNumber = typename get_value_type<Number>::type;
-      const auto &gamma = view.gamma();
-      const auto &gamma_inverse = view.gamma_inverse();
-      const auto &gamma_minus_one_inverse = view.gamma_minus_one_inverse();
-      const auto &gamma_plus_one_inverse = view.gamma_plus_one_inverse();
+      const auto &gamma = view_.gamma();
+      const auto &gamma_inverse = view_.gamma_inverse();
+      const auto &gamma_minus_one_inverse = view_.gamma_minus_one_inverse();
+      const auto &gamma_plus_one_inverse = view_.gamma_plus_one_inverse();
 
       const auto &[rho, u, p, a] = riemann_data;
 
@@ -122,7 +122,7 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto &gamma = view.gamma();
+      const auto &gamma = view_.gamma();
 
       const auto &[rho_i, u_i, p_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, a_j] = riemann_data_j;
@@ -162,8 +162,8 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::lambda1_minus(
         const primitive_type &riemann_data, const Number p_star) const
     {
-      const auto &gamma = view.gamma();
-      const auto &gamma_inverse = view.gamma_inverse();
+      const auto &gamma = view_.gamma();
+      const auto &gamma_inverse = view_.gamma_inverse();
       const auto factor =
           (gamma + ScalarNumber(1.0)) * ScalarNumber(0.5) * gamma_inverse;
 
@@ -186,8 +186,8 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::lambda3_plus(
         const primitive_type &primitive_state, const Number p_star) const
     {
-      const auto &gamma = view.gamma();
-      const auto &gamma_inverse = view.gamma_inverse();
+      const auto &gamma = view_.gamma();
+      const auto &gamma_inverse = view_.gamma_inverse();
       const Number factor =
           (gamma + ScalarNumber(1.0)) * ScalarNumber(0.5) * gamma_inverse;
 
@@ -271,9 +271,9 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto &gamma = view.gamma();
-      const auto &gamma_inverse = view.gamma_inverse();
-      const auto &gamma_minus_one_inverse = view.gamma_minus_one_inverse();
+      const auto &gamma = view_.gamma();
+      const auto &gamma_inverse = view_.gamma_inverse();
+      const auto &gamma_minus_one_inverse = view_.gamma_minus_one_inverse();
 
       const auto &[rho_i, u_i, p_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, a_j] = riemann_data_j;
@@ -326,7 +326,7 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto &gamma = view.gamma();
+      const auto &gamma = view_.gamma();
 
       const auto &[rho_i, u_i, p_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, a_j] = riemann_data_j;
@@ -372,19 +372,19 @@ namespace ryujin
         const state_type &U, const dealii::Tensor<1, dim, Number> &n_ij) const
         -> primitive_type
     {
-      const auto rho = view.density(U);
+      const auto rho = view_.density(U);
       const auto rho_inverse = Number(1.0) / rho;
 
-      const auto m = view.momentum(U);
+      const auto m = view_.momentum(U);
       const auto proj_m = n_ij * m;
       const auto perp = m - proj_m * n_ij;
 
-      const auto E =
-          view.total_energy(U) - Number(0.5) * perp.norm_square() * rho_inverse;
+      const auto E = view_.total_energy(U) -
+                     Number(0.5) * perp.norm_square() * rho_inverse;
 
       using state_type_1d =
           typename HyperbolicSystemView<1, Number>::state_type;
-      const auto view_1d = view.template view<1, Number>();
+      const auto view_1d = view_.template view<1, Number>();
 
       const auto state = state_type_1d{{rho, proj_m, E}};
       const auto p = view_1d.pressure(state);
@@ -485,7 +485,7 @@ namespace ryujin
        * If we do no Newton iteration, cut it short:
        */
 
-      if (wave_speed_estimator.newton_max_iterations() == 0) {
+      if (wave_speed_estimator_.newton_max_iterations() == 0) {
         const auto lambda_max =
             compute_lambda(riemann_data_i, riemann_data_j, p_2);
 
@@ -527,11 +527,12 @@ namespace ryujin
       std::cout << "l_m: (start) " << lambda_max << std::endl;
 #endif
 
-      for (unsigned int i = 0; i < wave_speed_estimator.newton_max_iterations();
+      for (unsigned int i = 0;
+           i < wave_speed_estimator_.newton_max_iterations();
            ++i) {
 
         /* We accept our current guess if we reach the tolerance... */
-        const Number tolerance(wave_speed_estimator.newton_tolerance());
+        const Number tolerance(wave_speed_estimator_.newton_tolerance());
         if (std::max(Number(0.), gap - tolerance) == Number(0.)) {
 #ifdef DEBUG_WAVE_SPEED_ESTIMATOR
           std::cout << "converged after " << i << " iterations." << std::endl;

--- a/source/euler/wave_speed_estimator.template.h
+++ b/source/euler/wave_speed_estimator.template.h
@@ -485,7 +485,7 @@ namespace ryujin
        * If we do no Newton iteration, cut it short:
        */
 
-      if (parameters.newton_max_iterations() == 0) {
+      if (wave_speed_estimator.newton_max_iterations() == 0) {
         const auto lambda_max =
             compute_lambda(riemann_data_i, riemann_data_j, p_2);
 
@@ -527,10 +527,11 @@ namespace ryujin
       std::cout << "l_m: (start) " << lambda_max << std::endl;
 #endif
 
-      for (unsigned int i = 0; i < parameters.newton_max_iterations(); ++i) {
+      for (unsigned int i = 0; i < wave_speed_estimator.newton_max_iterations();
+           ++i) {
 
         /* We accept our current guess if we reach the tolerance... */
-        const Number tolerance(parameters.newton_tolerance());
+        const Number tolerance(wave_speed_estimator.newton_tolerance());
         if (std::max(Number(0.), gap - tolerance) == Number(0.)) {
 #ifdef DEBUG_WAVE_SPEED_ESTIMATOR
           std::cout << "converged after " << i << " iterations." << std::endl;

--- a/source/euler/wave_speed_estimator.template.h
+++ b/source/euler/wave_speed_estimator.template.h
@@ -21,7 +21,6 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::f(const primitive_type &riemann_data,
                                            const Number p_star) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto &gamma = view.gamma();
 
       const auto &[rho, u, p, a] = riemann_data;
@@ -49,8 +48,6 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::df(const primitive_type &riemann_data,
                                             const Number &p_star) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       using ScalarNumber = typename get_value_type<Number>::type;
       const auto &gamma = view.gamma();
       const auto &gamma_inverse = view.gamma_inverse();
@@ -125,7 +122,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto &gamma = view.gamma();
 
       const auto &[rho_i, u_i, p_i, a_i] = riemann_data_i;
@@ -166,7 +162,6 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::lambda1_minus(
         const primitive_type &riemann_data, const Number p_star) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto &gamma = view.gamma();
       const auto &gamma_inverse = view.gamma_inverse();
       const auto factor =
@@ -191,7 +186,6 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::lambda3_plus(
         const primitive_type &primitive_state, const Number p_star) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto &gamma = view.gamma();
       const auto &gamma_inverse = view.gamma_inverse();
       const Number factor =
@@ -277,7 +271,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto &gamma = view.gamma();
       const auto &gamma_inverse = view.gamma_inverse();
       const auto &gamma_minus_one_inverse = view.gamma_minus_one_inverse();
@@ -333,7 +326,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto &gamma = view.gamma();
 
       const auto &[rho_i, u_i, p_i, a_i] = riemann_data_i;
@@ -380,8 +372,6 @@ namespace ryujin
         const state_type &U, const dealii::Tensor<1, dim, Number> &n_ij) const
         -> primitive_type
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto rho = view.density(U);
       const auto rho_inverse = Number(1.0) / rho;
 
@@ -394,7 +384,7 @@ namespace ryujin
 
       using state_type_1d =
           typename HyperbolicSystemView<1, Number>::state_type;
-      const auto view_1d = hyperbolic_system.view<1, Number>();
+      const auto view_1d = view.template view<1, Number>();
 
       const auto state = state_type_1d{{rho, proj_m, E}};
       const auto p = view_1d.pressure(state);

--- a/source/euler_aeos/description.h
+++ b/source/euler_aeos/description.h
@@ -34,24 +34,20 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = EulerAEOS::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView = EulerAEOS::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = ryujin::StubParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           ryujin::StubParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = EulerAEOS::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = EulerAEOS::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = EulerAEOS::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = EulerAEOS::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView =
-          EulerAEOS::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator = EulerAEOS::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -76,6 +76,13 @@ namespace ryujin
       HyperbolicSystem(const std::string &subsection = "/HyperbolicSystem");
 
       /**
+       * Alias for the view on the hyperbolic system for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = HyperbolicSystemView<dim, Number>;
+
+      /**
        * Return a view on the Hyperbolic System for a given dimension @p
        * dim and choice of number type @p Number (which can be a scalar
        * float, or double, as well as a VectorizedArray holding packed
@@ -84,7 +91,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return HyperbolicSystemView<dim, Number>{*this};
+        return View<dim, Number>{*this};
       }
 
       /**

--- a/source/euler_aeos/hyperbolic_system.h
+++ b/source/euler_aeos/hyperbolic_system.h
@@ -488,12 +488,27 @@ namespace ryujin
           Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * states:
+       */
+      using PrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber, n_precomputed_values>;
+
+      /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
           Vectors::MultiComponentVector<ScalarNumber,
                                         n_initial_precomputed_values>;
+
+      /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * initial states:
+       */
+      using InitialPrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber,
+                                            n_initial_precomputed_values>;
 
       //@}
       /**
@@ -719,14 +734,14 @@ namespace ryujin
        * For the Euler equations we simply compute <code>f(U_i)</code>.
        */
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector &piv,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView &piv,
                         const unsigned int i,
                         const state_type &U_i) const;
 
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector &piv,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView &piv,
                         const unsigned int *js,
                         const state_type &U_j) const;
 
@@ -757,12 +772,12 @@ namespace ryujin
       /** We do not have source terms */
       static constexpr bool have_source_terms = false;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int i,
                               const state_type &U_i,
                               const ScalarNumber tau) const = delete;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int *js,
                               const state_type &U_j,
                               const ScalarNumber tau) const = delete;
@@ -1558,8 +1573,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector &pv,
-        const InitialPrecomputedVector & /*piv*/,
+        const PrecomputedVectorView &pv,
+        const InitialPrecomputedVectorView & /*piv*/,
         const unsigned int i,
         const state_type &U_i) const -> flux_contribution_type
     {
@@ -1572,8 +1587,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector &pv,
-        const InitialPrecomputedVector & /*piv*/,
+        const PrecomputedVectorView &pv,
+        const InitialPrecomputedVectorView & /*piv*/,
         const unsigned int *js,
         const state_type &U_j) const -> flux_contribution_type
     {

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -153,8 +153,8 @@ namespace ryujin
        * object as arguments
        */
       IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
-          : view(view)
-          , indicator(indicator)
+          : view_(view)
+          , indicator_(indicator)
       {
       }
 
@@ -188,17 +188,17 @@ namespace ryujin
        */
       //@{
 
-      const View view;
-      const Indicator<ScalarNumber> &indicator;
+      const View view_;
+      const Indicator<ScalarNumber> &indicator_;
 
-      Number rho_i_inverse = 0.;
-      Number eta_i = 0.;
-      flux_type f_i;
-      state_type d_eta_i;
-      Number gamma_min;
+      Number rho_i_inverse_ = 0.;
+      Number eta_i_ = 0.;
+      flux_type f_i_;
+      state_type d_eta_i_;
+      Number gamma_min_;
 
-      Number left = 0.;
-      state_type right;
+      Number left_ = 0.;
+      state_type right_;
 
       //@}
     };
@@ -222,20 +222,21 @@ namespace ryujin
       const auto &[p_i, gamma_min_i, s_i, new_eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
-      gamma_min = gamma_min_i;
+      gamma_min_ = gamma_min_i;
 
-      const auto rho_i = view.density(U_i);
-      rho_i_inverse = Number(1.) / rho_i;
-      eta_i = new_eta_i;
+      const auto rho_i = view_.density(U_i);
+      rho_i_inverse_ = Number(1.) / rho_i;
+      eta_i_ = new_eta_i;
 
-      d_eta_i = view.surrogate_harten_entropy_derivative(U_i, eta_i, gamma_min);
-      d_eta_i[0] -= eta_i * rho_i_inverse;
+      d_eta_i_ =
+          view_.surrogate_harten_entropy_derivative(U_i, eta_i_, gamma_min_);
+      d_eta_i_[0] -= eta_i_ * rho_i_inverse_;
 
-      const auto surrogate_p_i = view.surrogate_pressure(U_i, gamma_min);
-      f_i = view.f(U_i, surrogate_p_i);
+      const auto surrogate_p_i = view_.surrogate_pressure(U_i, gamma_min_);
+      f_i_ = view_.f(U_i, surrogate_p_i);
 
-      left = 0.;
-      right = 0.;
+      left_ = 0.;
+      right_ = 0.;
     }
 
 
@@ -248,23 +249,23 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      const auto eta_j = view.surrogate_harten_entropy(U_j, gamma_min);
+      const auto eta_j = view_.surrogate_harten_entropy(U_j, gamma_min_);
 
-      const auto rho_j = view.density(U_j);
+      const auto rho_j = view_.density(U_j);
       const auto rho_j_inverse = Number(1.) / rho_j;
 
-      const auto m_j = view.momentum(U_j);
+      const auto m_j = view_.momentum(U_j);
 
-      const auto surrogate_p_j = view.surrogate_pressure(U_j, gamma_min);
-      const auto f_j = view.f(U_j, surrogate_p_j);
+      const auto surrogate_p_j = view_.surrogate_pressure(U_j, gamma_min_);
+      const auto f_j = view_.f(U_j, surrogate_p_j);
 
       const auto entropy_flux =
-          (eta_j * rho_j_inverse - eta_i * rho_i_inverse) * (m_j * c_ij);
+          (eta_j * rho_j_inverse - eta_i_ * rho_i_inverse_) * (m_j * c_ij);
 
-      left += entropy_flux;
+      left_ += entropy_flux;
       for (unsigned int k = 0; k < problem_dimension; ++k) {
-        const auto component = (f_j[k] - f_i[k]) * c_ij;
-        right[k] += component;
+        const auto component = (f_j[k] - f_i_[k]) * c_ij;
+        right_[k] += component;
       }
     }
 
@@ -275,17 +276,17 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      Number numerator = left;
-      Number denominator = std::abs(left);
+      Number numerator = left_;
+      Number denominator = std::abs(left_);
       for (unsigned int k = 0; k < problem_dimension; ++k) {
-        numerator -= d_eta_i[k] * right[k];
-        denominator += std::abs(d_eta_i[k] * right[k]);
+        numerator -= d_eta_i_[k] * right_[k];
+        denominator += std::abs(d_eta_i_[k] * right_[k]);
       }
 
-      const auto quotient = safe_division(std::abs(numerator),
-                                          denominator + hd_i * std::abs(eta_i));
+      const auto quotient = safe_division(
+          std::abs(numerator), denominator + hd_i * std::abs(eta_i_));
 
-      return std::min(Number(1.), indicator.evc_factor() * quotient);
+      return std::min(Number(1.), indicator_.evc_factor() * quotient);
     }
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -42,6 +42,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(evc_factor);
 
       /**
+       * Alias for the view on the indicator for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = IndicatorView<dim, Number>;
+
+      /**
        * Return a view on the Indicator for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -49,7 +56,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return IndicatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -121,8 +128,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Indicator<ScalarNumber>;
-
       //@}
       /**
        * @name Stencil-based computation of indicators
@@ -144,10 +149,10 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      IndicatorView(const View &view, const Parameters &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -184,7 +189,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Indicator<ScalarNumber> &parameters;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -10,6 +10,7 @@
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -20,12 +21,17 @@ namespace ryujin
 {
   namespace EulerAEOS
   {
+    template <int dim, typename Number = double>
+    class IndicatorView;
+
     template <typename ScalarNumber = double>
     class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      Indicator(const std::string &subsection = "/Indicator")
+      Indicator(const HyperbolicSystem &hyperbolic_system,
+                const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
@@ -35,7 +41,20 @@ namespace ryujin
 
       ACCESSOR_READ_ONLY(evc_factor);
 
+      /**
+       * Return a view on the Indicator for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return IndicatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       ScalarNumber evc_factor_;
     };
 
@@ -79,7 +98,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class IndicatorView
     {
     public:
@@ -125,11 +144,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      IndicatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -164,7 +183,7 @@ namespace ryujin
        */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       Number rho_i_inverse = 0.;
@@ -195,8 +214,6 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto &[p_i, gamma_min_i, s_i, new_eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
@@ -225,8 +242,6 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
       /* Entropy viscosity commutator: */
-
-      const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto eta_j = view.surrogate_harten_entropy(U_j, gamma_min);
 

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -149,12 +149,12 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and an Indicator
        * object as arguments
        */
-      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
           : view(view)
-          , parameters(parameters)
+          , indicator(indicator)
       {
       }
 
@@ -189,7 +189,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Indicator<ScalarNumber> &parameters;
+      const Indicator<ScalarNumber> &indicator;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;
@@ -285,7 +285,7 @@ namespace ryujin
       const auto quotient = safe_division(std::abs(numerator),
                                           denominator + hd_i * std::abs(eta_i));
 
-      return std::min(Number(1.), parameters.evc_factor() * quotient);
+      return std::min(Number(1.), indicator.evc_factor() * quotient);
     }
   } // namespace EulerAEOS
 } // namespace ryujin

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -219,14 +219,14 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      const auto &[p_i, gamma_min_i, s_i, new_eta_i] =
+      const auto &[p_i, gamma_min_i, s_i, eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
       gamma_min_ = gamma_min_i;
 
       const auto rho_i = view_.density(U_i);
       rho_i_inverse_ = Number(1.) / rho_i;
-      eta_i_ = new_eta_i;
+      eta_i_ = eta_i;
 
       d_eta_i_ =
           view_.surrogate_harten_entropy_derivative(U_i, eta_i_, gamma_min_);

--- a/source/euler_aeos/indicator.h
+++ b/source/euler_aeos/indicator.h
@@ -100,7 +100,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Indicator<ScalarNumber>;
 
@@ -113,10 +113,10 @@ namespace ryujin
        * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator_view.reset(i, U_i);
+       *   indicator_view.reset(pv, i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator_view.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(pv, js, U_j, c_ij);
        *   }
        *   indicator_view.alpha(hd_i);
        * }
@@ -128,11 +128,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters,
-                    const PrecomputedVector &precomputed_values)
+                    const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -140,13 +138,16 @@ namespace ryujin
        * Reset temporary storage and initialize for a new row corresponding
        * to state vector U_i.
        */
-      void reset(const unsigned int i, const state_type &U_i);
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
+                 const state_type &U_i);
 
       /**
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const dealii::Tensor<1, dim, Number> &c_ij);
 
@@ -165,7 +166,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       Number rho_i_inverse = 0.;
       Number eta_i = 0.;
@@ -189,7 +189,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    IndicatorView<dim, Number>::reset(const unsigned int i,
+    IndicatorView<dim, Number>::reset(const PrecomputedVectorView &pv,
+                                      const unsigned int i,
                                       const state_type &U_i)
     {
       /* Entropy viscosity commutator: */
@@ -197,7 +198,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[p_i, gamma_min_i, s_i, new_eta_i] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       gamma_min = gamma_min_i;
 
@@ -218,6 +219,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
+        const PrecomputedVectorView & /*pv*/,
         const unsigned int * /*js*/,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)

--- a/source/euler_aeos/initial_state_library.template.h
+++ b/source/euler_aeos/initial_state_library.template.h
@@ -21,8 +21,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -11,18 +11,24 @@
 
 #include <multicomponent_vector.h>
 #include <newton.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 namespace ryujin
 {
   namespace EulerAEOS
   {
+    template <int dim, typename Number = double>
+    class LimiterView;
+
     template <typename ScalarNumber = double>
     class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      Limiter(const std::string &subsection = "/Limiter")
+      Limiter(const HyperbolicSystem &hyperbolic_system,
+              const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         iterations_ = 2;
         add_parameter(
@@ -54,7 +60,20 @@ namespace ryujin
       ACCESSOR_READ_ONLY(newton_max_iterations);
       ACCESSOR_READ_ONLY(relaxation_factor);
 
+      /**
+       * Return a view on the Limiter for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return LimiterView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       unsigned int iterations_;
       ScalarNumber newton_tolerance_;
       unsigned int newton_max_iterations_;
@@ -94,7 +113,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class LimiterView
     {
     public:
@@ -136,11 +155,11 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      LimiterView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -246,7 +265,7 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       state_type U_i;
@@ -276,7 +295,6 @@ namespace ryujin
         const unsigned int i,
         const state_type &U_i) const -> Bounds
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto rho_i = view.density(U_i);
       const auto &[p_i, gamma_min_i, s_i, eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
@@ -308,8 +326,6 @@ namespace ryujin
                                                  const Number &hd) const
         -> Bounds
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto &[rho_min, rho_max, s_min, gamma_min] = bounds;
 
       auto relaxed_bounds = bounds;
@@ -394,8 +410,6 @@ namespace ryujin
       // equations verify that this does the right thing.
       Assert(std::max(affine_shift.norm(), Number(0.)) == Number(0.),
              dealii::ExcNotImplemented());
-
-      const auto view = hyperbolic_system.view<dim, Number>();
 
       /* Bounds: */
       auto &[rho_min, rho_max, s_min, gamma_min] = bounds_;

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -61,6 +61,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(relaxation_factor);
 
       /**
+       * Alias for the view on the limiter for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = LimiterView<dim, Number>;
+
+      /**
        * Return a view on the Limiter for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -68,7 +75,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return LimiterView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -136,8 +143,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Limiter<ScalarNumber>;
-
       //@}
       /**
        * @name Computation and manipulation of bounds
@@ -155,10 +160,10 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      LimiterView(const View &view, const Parameters &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -266,7 +271,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Limiter<ScalarNumber> &parameters;
 
       state_type U_i;
       flux_contribution_type flux_i;

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -160,12 +160,12 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a Limiter
        * object as arguments
        */
-      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
           : view(view)
-          , parameters(parameters)
+          , limiter(limiter)
       {
       }
 
@@ -271,7 +271,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Limiter<ScalarNumber> &parameters;
+      const Limiter<ScalarNumber> &limiter;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -344,7 +344,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= parameters.relaxation_factor();
+      r *= limiter.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       rho_min_relaxed *= std::max(Number(1.) - r, Number(eps));
@@ -502,12 +502,12 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const auto rho_relaxation =
-          ScalarNumber(2. * parameters.relaxation_factor()) *
+          ScalarNumber(2. * limiter.relaxation_factor()) *
           std::abs(rho_relaxation_numerator) /
           (std::abs(rho_relaxation_denominator) + Number(eps));
 
       const auto entropy_relaxation =
-          parameters.relaxation_factor() * (s_interp_max - s_min);
+          limiter.relaxation_factor() * (s_interp_max - s_min);
 
       rho_min_relaxed = std::max(rho_min_relaxed, rho_min - rho_relaxation);
       rho_max_relaxed = std::min(rho_max_relaxed, rho_max + rho_relaxation);

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -164,8 +164,8 @@ namespace ryujin
        * object as arguments
        */
       LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
-          : view(view)
-          , limiter(limiter)
+          : view_(view)
+          , limiter_(limiter)
       {
       }
 
@@ -270,17 +270,17 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const View view;
-      const Limiter<ScalarNumber> &limiter;
+      const View view_;
+      const Limiter<ScalarNumber> &limiter_;
 
-      state_type U_i;
-      flux_contribution_type flux_i;
+      state_type U_i_;
+      flux_contribution_type flux_i_;
 
       Bounds bounds_;
 
-      Number rho_relaxation_numerator;
-      Number rho_relaxation_denominator;
-      Number s_interp_max;
+      Number rho_relaxation_numerator_;
+      Number rho_relaxation_denominator_;
+      Number s_interp_max_;
 
       //@}
     };
@@ -300,7 +300,7 @@ namespace ryujin
         const unsigned int i,
         const state_type &U_i) const -> Bounds
     {
-      const auto rho_i = view.density(U_i);
+      const auto rho_i = view_.density(U_i);
       const auto &[p_i, gamma_min_i, s_i, eta_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
@@ -344,7 +344,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= limiter.relaxation_factor();
+      r *= limiter_.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       rho_min_relaxed *= std::max(Number(1.) - r, Number(eps));
@@ -358,7 +358,7 @@ namespace ryujin
        */
 
       const auto numerator = (gamma_min + Number(1.)) * rho_max;
-      const auto covolume_b = view.eos_covolume_constant();
+      const auto covolume_b = view_.eos_covolume_constant();
       const auto denominator =
           gamma_min - Number(1.) + ScalarNumber(2.) * covolume_b * rho_max;
       const auto rho_compressibility_bound = numerator / denominator;
@@ -376,8 +376,8 @@ namespace ryujin
                                     const state_type &new_U_i,
                                     const flux_contribution_type &new_flux_i)
     {
-      U_i = new_U_i;
-      flux_i = new_flux_i;
+      U_i_ = new_U_i;
+      flux_i_ = new_flux_i;
 
       /* Bounds: */
 
@@ -394,9 +394,9 @@ namespace ryujin
 
       /* Relaxation: */
 
-      rho_relaxation_numerator = Number(0.);
-      rho_relaxation_denominator = Number(0.);
-      s_interp_max = Number(0.);
+      rho_relaxation_numerator_ = Number(0.);
+      rho_relaxation_denominator_ = Number(0.);
+      s_interp_max_ = Number(0.);
     }
 
 
@@ -419,16 +419,16 @@ namespace ryujin
       /* Bounds: */
       auto &[rho_min, rho_max, s_min, gamma_min] = bounds_;
 
-      const auto rho_i = view.density(U_i);
-      const auto rho_j = view.density(U_j);
+      const auto rho_i = view_.density(U_i_);
+      const auto rho_j = view_.density(U_j);
 
       /* bar state shifted by an affine shift: */
       const auto U_ij_bar =
-          ScalarNumber(0.5) * (U_i + U_j) -
-          ScalarNumber(0.5) * contract(add(flux_j, -flux_i), scaled_c_ij) +
+          ScalarNumber(0.5) * (U_i_ + U_j) -
+          ScalarNumber(0.5) * contract(add(flux_j, -flux_i_), scaled_c_ij) +
           affine_shift;
 
-      const auto rho_ij_bar = view.density(U_ij_bar);
+      const auto rho_ij_bar = view_.density(U_ij_bar);
 
       /* Density bounds: */
 
@@ -439,12 +439,12 @@ namespace ryujin
 
       /* Use a uniform weight. */
       const auto beta_ij = Number(1.);
-      rho_relaxation_numerator += beta_ij * (rho_i + rho_j);
-      rho_relaxation_denominator += std::abs(beta_ij);
+      rho_relaxation_numerator_ += beta_ij * (rho_i + rho_j);
+      rho_relaxation_denominator_ += std::abs(beta_ij);
 
       /* Surrogate entropy bounds and relaxation: */
 
-      if (view.compute_strict_bounds()) {
+      if (view_.compute_strict_bounds()) {
         /*
          * Compute strict bounds precisely as outlined in @cite ryujin-2023-4
          *
@@ -455,17 +455,17 @@ namespace ryujin
          *    bounds relaxation:
          */
 
-        const auto s_j = view.surrogate_specific_entropy(U_j, gamma_min);
+        const auto s_j = view_.surrogate_specific_entropy(U_j, gamma_min);
 
         const auto s_ij_bar =
-            view.surrogate_specific_entropy(U_ij_bar, gamma_min);
+            view_.surrogate_specific_entropy(U_ij_bar, gamma_min);
 
-        const Number s_interp = view.surrogate_specific_entropy(
-            (U_i + U_j) * ScalarNumber(.5), gamma_min);
+        const Number s_interp = view_.surrogate_specific_entropy(
+            (U_i_ + U_j) * ScalarNumber(.5), gamma_min);
 
         s_min = std::min(s_min, s_j);
         s_min = std::min(s_min, s_ij_bar);
-        s_interp_max = std::max(s_interp_max, s_interp);
+        s_interp_max_ = std::max(s_interp_max_, s_interp);
 
       } else {
         /*
@@ -478,11 +478,11 @@ namespace ryujin
             pv.template read_tensor<Number, precomputed_type>(js);
 
         const auto s_ij_bar =
-            view.surrogate_specific_entropy(U_ij_bar, gamma_min);
+            view_.surrogate_specific_entropy(U_ij_bar, gamma_min);
 
         s_min = std::min(s_min, s_j);
         s_min = std::min(s_min, s_ij_bar);
-        s_interp_max = std::max(s_interp_max, s_ij_bar);
+        s_interp_max_ = std::max(s_interp_max_, s_ij_bar);
       }
     }
 
@@ -502,12 +502,12 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const auto rho_relaxation =
-          ScalarNumber(2. * limiter.relaxation_factor()) *
-          std::abs(rho_relaxation_numerator) /
-          (std::abs(rho_relaxation_denominator) + Number(eps));
+          ScalarNumber(2. * limiter_.relaxation_factor()) *
+          std::abs(rho_relaxation_numerator_) /
+          (std::abs(rho_relaxation_denominator_) + Number(eps));
 
       const auto entropy_relaxation =
-          limiter.relaxation_factor() * (s_interp_max - s_min);
+          limiter_.relaxation_factor() * (s_interp_max_ - s_min);
 
       rho_min_relaxed = std::max(rho_min_relaxed, rho_min - rho_relaxation);
       rho_max_relaxed = std::min(rho_max_relaxed, rho_max + rho_relaxation);

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -115,7 +115,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Limiter<ScalarNumber>;
 
@@ -139,11 +139,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters,
-                  const PrecomputedVector &precomputed_values)
+                  const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -151,7 +149,8 @@ namespace ryujin
        * Given a state @p U_i and an index @p i return "strict" bounds,
        * i.e., a minimal convex set containing the state.
        */
-      Bounds projection_bounds_from_state(const unsigned int i,
+      Bounds projection_bounds_from_state(const PrecomputedVectorView &pv,
+                                          const unsigned int i,
                                           const state_type &U_i) const;
 
       /**
@@ -181,10 +180,10 @@ namespace ryujin
        * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter_view.reset(i, U_i, flux_i);
+       *   limiter_view.reset(pv, i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       *     limiter_view.accumulate(pv, js, U_j, flux_j, scaled_c_ij,
        * affine_shift);
        *   }
        *   limiter_view.bounds(hd_i);
@@ -196,7 +195,8 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int i,
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
                  const state_type &U_i,
                  const flux_contribution_type &flux_i);
 
@@ -204,7 +204,8 @@ namespace ryujin
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
@@ -247,7 +248,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -272,12 +272,14 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     LimiterView<dim, Number>::projection_bounds_from_state(
-        const unsigned int i, const state_type &U_i) const -> Bounds
+        const PrecomputedVectorView &pv,
+        const unsigned int i,
+        const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
       const auto rho_i = view.density(U_i);
       const auto &[p_i, gamma_min_i, s_i, eta_i] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       return {/*rho_min*/ rho_i,
               /*rho_max*/ rho_i,
@@ -348,7 +350,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    LimiterView<dim, Number>::reset(const unsigned int i,
+    LimiterView<dim, Number>::reset(const PrecomputedVectorView &pv,
+                                    const unsigned int i,
                                     const state_type &new_U_i,
                                     const flux_contribution_type &new_flux_i)
     {
@@ -364,7 +367,7 @@ namespace ryujin
       s_min = Number(std::numeric_limits<ScalarNumber>::max());
 
       const auto &[p_i, gamma_min_i, s_i, eta_i] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       gamma_min = gamma_min_i;
 
@@ -378,6 +381,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
+        const PrecomputedVectorView &pv,
         const unsigned int *js,
         const state_type &U_j,
         const flux_contribution_type &flux_j,
@@ -452,8 +456,7 @@ namespace ryujin
          * relaxation as well.
          */
         const auto [p_j, gamma_min_j, s_j, eta_j] =
-            precomputed_values.template read_tensor<Number, precomputed_type>(
-                js);
+            pv.template read_tensor<Number, precomputed_type>(js);
 
         const auto s_ij_bar =
             view.surrogate_specific_entropy(U_ij_bar, gamma_min);

--- a/source/euler_aeos/limiter.h
+++ b/source/euler_aeos/limiter.h
@@ -373,11 +373,11 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline void
     LimiterView<dim, Number>::reset(const PrecomputedVectorView &pv,
                                     const unsigned int i,
-                                    const state_type &new_U_i,
-                                    const flux_contribution_type &new_flux_i)
+                                    const state_type &U_i,
+                                    const flux_contribution_type &flux_i)
     {
-      U_i_ = new_U_i;
-      flux_i_ = new_flux_i;
+      U_i_ = U_i;
+      flux_i_ = flux_i;
 
       /* Bounds: */
 

--- a/source/euler_aeos/limiter.template.h
+++ b/source/euler_aeos/limiter.template.h
@@ -20,8 +20,6 @@ namespace ryujin
                                     const Number t_min /* = Number(0.) */,
                                     const Number t_max /* = Number(1.) */) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       bool success = true;
       Number t_r = t_max;
 

--- a/source/euler_aeos/limiter.template.h
+++ b/source/euler_aeos/limiter.template.h
@@ -24,8 +24,8 @@ namespace ryujin
       Number t_r = t_max;
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
-      const auto small = view.vacuum_state_relaxation_small();
-      const auto large = view.vacuum_state_relaxation_large();
+      const auto small = view_.vacuum_state_relaxation_small();
+      const auto large = view_.vacuum_state_relaxation_large();
       const ScalarNumber relax_small = ScalarNumber(1. + small * eps);
       const ScalarNumber relax = ScalarNumber(1. + large * eps);
 
@@ -36,8 +36,8 @@ namespace ryujin
        */
 
       {
-        const auto &rho_U = view.density(U);
-        const auto &rho_P = view.density(P);
+        const auto &rho_U = view_.density(U);
+        const auto &rho_P = view_.density(P);
 
         const auto &rho_min = std::get<0>(bounds);
         const auto &rho_max = std::get<1>(bounds);
@@ -46,9 +46,9 @@ namespace ryujin
          * Verify that rho_U is within bounds. This property might be
          * violated for relative CFL numbers larger than 1.
          */
-        const auto test_min = view.filter_vacuum_density(
+        const auto test_min = view_.filter_vacuum_density(
             std::max(Number(0.), rho_U - relax * rho_max));
-        const auto test_max = view.filter_vacuum_density(
+        const auto test_max = view_.filter_vacuum_density(
             std::max(Number(0.), rho_min - relax * rho_U));
         if (!(test_min == Number(0.) && test_max == Number(0.))) {
 #ifdef DEBUG_OUTPUT
@@ -107,10 +107,10 @@ namespace ryujin
         /*
          * Verify that the new state is within bounds:
          */
-        const auto rho_new = view.density(U + t_r * P);
-        const auto test_new_min = view.filter_vacuum_density(
+        const auto rho_new = view_.density(U + t_r * P);
+        const auto test_new_min = view_.filter_vacuum_density(
             std::max(Number(0.), rho_new - relax * rho_max));
-        const auto test_new_max = view.filter_vacuum_density(
+        const auto test_new_max = view_.filter_vacuum_density(
             std::max(Number(0.), rho_min - relax * rho_new));
         if (!(test_new_min == Number(0.) && test_new_max == Number(0.))) {
 #ifdef DEBUG_OUTPUT
@@ -143,9 +143,9 @@ namespace ryujin
       const auto &gamma = std::get<3>(bounds) /* = gamma_min*/;
       const Number gm1 = gamma - Number(1.);
 
-      const auto b = Number(view.eos_covolume_constant());
-      const auto pinf = Number(view.eos_interpolation_pinfty());
-      const auto q = Number(view.eos_interpolation_q());
+      const auto b = Number(view_.eos_covolume_constant());
+      const auto pinf = Number(view_.eos_interpolation_pinfty());
+      const auto q = Number(view_.eos_interpolation_q());
 
       {
         /*
@@ -173,14 +173,14 @@ namespace ryujin
         std::cout << "t_r: (start) " << t_r << std::endl;
 #endif
 
-        for (unsigned int n = 0; n < limiter.newton_max_iterations(); ++n) {
+        for (unsigned int n = 0; n < limiter_.newton_max_iterations(); ++n) {
 
           const auto U_r = U + t_r * P;
-          const auto rho_r = view.density(U_r);
+          const auto rho_r = view_.density(U_r);
           const auto rho_r_gamma = ryujin::pow(rho_r, gamma);
           const auto covolume_r = Number(1.) - b * rho_r;
 
-          const auto rho_e_r = view.internal_energy(U_r);
+          const auto rho_e_r = view_.internal_energy(U_r);
           const auto shift_r = rho_e_r - rho_r * q - pinf * covolume_r;
 
           auto psi_r =
@@ -224,10 +224,10 @@ namespace ryujin
 #endif
 
           const auto U_l = U + t_l * P;
-          const auto rho_l = view.density(U_l);
+          const auto rho_l = view_.density(U_l);
           const auto rho_l_gamma = ryujin::pow(rho_l, gamma);
           const auto covolume_l = Number(1.) - b * rho_l;
-          const auto rho_e_l = view.internal_energy(U_l);
+          const auto rho_e_l = view_.internal_energy(U_l);
           const auto shift_l = rho_e_l - rho_l * q - pinf * covolume_l;
 
           auto psi_l =
@@ -265,7 +265,7 @@ namespace ryujin
            * Break if the window between t_l and t_r is within the prescribed
            * tolerance:
            */
-          const Number tolerance(limiter.newton_tolerance());
+          const Number tolerance(limiter_.newton_tolerance());
           if (std::max(Number(0.), t_r - t_l - tolerance) == Number(0.)) {
 #ifdef DEBUG_OUTPUT_LIMITER
             std::cout << "break: t_l and t_r within tolerance" << std::endl;
@@ -279,9 +279,9 @@ namespace ryujin
 
           /* We got unlucky and have to perform a Newton step: */
 
-          const auto drho = view.density(P);
-          const auto drho_e_l = view.internal_energy_derivative(U_l) * P;
-          const auto drho_e_r = view.internal_energy_derivative(U_r) * P;
+          const auto drho = view_.density(P);
+          const auto drho_e_l = view_.internal_energy_derivative(U_l) * P;
+          const auto drho_e_r = view_.internal_energy_derivative(U_r) * P;
 
           const auto q_pinf_term_l =
               ScalarNumber(2.) * rho_l * q +
@@ -322,11 +322,11 @@ namespace ryujin
         {
           const auto U_new = U + t_l * P;
 
-          const auto rho_new = view.density(U_new);
+          const auto rho_new = view_.density(U_new);
           const auto covolume_new = Number(1.) - b * rho_new;
 
           const auto rho_new_gamma = ryujin::pow(rho_new, gamma);
-          const auto rho_e_new = view.internal_energy(U_new);
+          const auto rho_e_new = view_.internal_energy(U_new);
 
           const auto shift_new = rho_e_new - rho_new * q - pinf * covolume_new;
 

--- a/source/euler_aeos/limiter.template.h
+++ b/source/euler_aeos/limiter.template.h
@@ -173,7 +173,7 @@ namespace ryujin
         std::cout << "t_r: (start) " << t_r << std::endl;
 #endif
 
-        for (unsigned int n = 0; n < parameters.newton_max_iterations(); ++n) {
+        for (unsigned int n = 0; n < limiter.newton_max_iterations(); ++n) {
 
           const auto U_r = U + t_r * P;
           const auto rho_r = view.density(U_r);
@@ -265,7 +265,7 @@ namespace ryujin
            * Break if the window between t_l and t_r is within the prescribed
            * tolerance:
            */
-          const Number tolerance(parameters.newton_tolerance());
+          const Number tolerance(limiter.newton_tolerance());
           if (std::max(Number(0.), t_r - t_l - tolerance) == Number(0.)) {
 #ifdef DEBUG_OUTPUT_LIMITER
             std::cout << "break: t_l and t_r within tolerance" << std::endl;

--- a/source/euler_aeos/wave_speed_estimator.h
+++ b/source/euler_aeos/wave_speed_estimator.h
@@ -112,8 +112,8 @@ namespace ryujin
       WaveSpeedEstimatorView(
           const View &view,
           const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
-          : view(view)
-          , wave_speed_estimator(wave_speed_estimator)
+          : view_(view)
+          , wave_speed_estimator_(wave_speed_estimator)
       {
       }
 
@@ -279,8 +279,8 @@ namespace ryujin
                               const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      const View view;
-      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
+      const View view_;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator_;
       //@}
     };
   } // namespace EulerAEOS

--- a/source/euler_aeos/wave_speed_estimator.h
+++ b/source/euler_aeos/wave_speed_estimator.h
@@ -9,6 +9,7 @@
 
 #include "hyperbolic_system.h"
 
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/point.h>
@@ -18,14 +19,34 @@ namespace ryujin
 {
   namespace EulerAEOS
   {
+    template <int dim, typename Number = double>
+    class WaveSpeedEstimatorView;
+
     template <typename ScalarNumber = double>
     class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
+                         const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
       }
+
+      /**
+       * Return a view on the WaveSpeedEstimator for a given dimension @p dim
+       * and choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return WaveSpeedEstimatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
+    private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
     };
 
 
@@ -38,7 +59,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class WaveSpeedEstimatorView
     {
     public:
@@ -80,11 +101,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -251,7 +272,7 @@ namespace ryujin
                               const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
       //@}
     };

--- a/source/euler_aeos/wave_speed_estimator.h
+++ b/source/euler_aeos/wave_speed_estimator.h
@@ -34,6 +34,13 @@ namespace ryujin
       }
 
       /**
+       * Alias for the view on the wave speed estimator for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = WaveSpeedEstimatorView<dim, Number>;
+
+      /**
        * Return a view on the WaveSpeedEstimator for a given dimension @p dim
        * and choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -41,7 +48,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return WaveSpeedEstimatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -92,8 +99,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = WaveSpeedEstimator<ScalarNumber>;
-
       //@}
       /**
        * @name Compute wavespeed estimates
@@ -101,10 +106,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+      WaveSpeedEstimatorView(const View &view,
+                             const WaveSpeedEstimator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -273,7 +279,7 @@ namespace ryujin
 
     private:
       const View view;
-      const Parameters &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &parameters;
       //@}
     };
   } // namespace EulerAEOS

--- a/source/euler_aeos/wave_speed_estimator.h
+++ b/source/euler_aeos/wave_speed_estimator.h
@@ -69,7 +69,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
@@ -83,11 +83,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters,
-                             const PrecomputedVector &precomputed_values)
+                             const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -104,7 +102,8 @@ namespace ryujin
        * compute an estimate for an upper bound of the maximum wavespeed
        * lambda.
        */
-      Number compute(const state_type &U_i,
+      Number compute(const PrecomputedVectorView &pv,
+                     const state_type &U_i,
                      const state_type &U_j,
                      const unsigned int i,
                      const unsigned int *js,
@@ -254,7 +253,6 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace EulerAEOS

--- a/source/euler_aeos/wave_speed_estimator.h
+++ b/source/euler_aeos/wave_speed_estimator.h
@@ -106,13 +106,14 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a WaveSpeedEstimator
        * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view,
-                             const WaveSpeedEstimator<ScalarNumber> &parameters)
+      WaveSpeedEstimatorView(
+          const View &view,
+          const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
           : view(view)
-          , parameters(parameters)
+          , wave_speed_estimator(wave_speed_estimator)
       {
       }
 
@@ -279,7 +280,7 @@ namespace ryujin
 
     private:
       const View view;
-      const WaveSpeedEstimator<ScalarNumber> &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
       //@}
     };
   } // namespace EulerAEOS

--- a/source/euler_aeos/wave_speed_estimator.template.h
+++ b/source/euler_aeos/wave_speed_estimator.template.h
@@ -86,7 +86,7 @@ namespace ryujin
                                                const Number &gamma,
                                                const Number &a) const
     {
-      const auto covolume_b = view.eos_covolume_constant();
+      const auto covolume_b = view_.eos_covolume_constant();
 
       const Number numerator =
           ScalarNumber(2.) * a * (Number(1.) - covolume_b * rho);
@@ -103,7 +103,7 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, gamma_j, a_j] = riemann_data_j;
@@ -218,7 +218,7 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, gamma_j, a_j] = riemann_data_j;
@@ -271,8 +271,8 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto covolume_b = view.eos_covolume_constant();
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto covolume_b = view_.eos_covolume_constant();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, gamma_j, a_j] = riemann_data_j;
@@ -326,7 +326,7 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, gamma_j, a_j] = riemann_data_j;
@@ -414,8 +414,8 @@ namespace ryujin
     {
       constexpr ScalarNumber min = std::numeric_limits<ScalarNumber>::min();
 
-      const auto covolume_b = view.eos_covolume_constant();
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto covolume_b = view_.eos_covolume_constant();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho, u, p, gamma, a] = riemann_data;
 
@@ -467,8 +467,8 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto covolume_b = view.eos_covolume_constant();
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto covolume_b = view_.eos_covolume_constant();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, gamma_j, a_j] = riemann_data_j;
@@ -502,7 +502,7 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::lambda1_minus(
         const primitive_type &riemann_data, const Number p_star) const
     {
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho, u, p, gamma, a] = riemann_data;
 
@@ -520,7 +520,7 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::lambda3_plus(
         const primitive_type &riemann_data, const Number p_star) const
     {
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho, u, p, gamma, a] = riemann_data;
 
@@ -554,16 +554,16 @@ namespace ryujin
         const Number &p,
         const dealii::Tensor<1, dim, Number> &n_ij) const -> primitive_type
     {
-      const auto rho = view.density(U);
+      const auto rho = view_.density(U);
       const auto rho_inverse = ScalarNumber(1.0) / rho;
 
-      const auto m = view.momentum(U);
+      const auto m = view_.momentum(U);
       const auto proj_m = n_ij * m;
 
-      const auto gamma = view.surrogate_gamma(U, p);
+      const auto gamma = view_.surrogate_gamma(U, p);
 
-      const auto covolume_b = view.eos_covolume_constant();
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto covolume_b = view_.eos_covolume_constant();
+      const auto pinf = view_.eos_interpolation_pinfty();
       const auto x = Number(1.) - covolume_b * rho;
       const auto a = std::sqrt(gamma * (p + pinf) / (rho * x));
 
@@ -593,7 +593,7 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto pinf = view.eos_interpolation_pinfty();
+      const auto pinf = view_.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
       const auto &[rho_j, u_j, p_j, gamma_j, a_j] = riemann_data_j;
@@ -614,7 +614,7 @@ namespace ryujin
       const Number p_max = std::max(p_i, p_j) + pinf;
       const Number phi_p_max = phi_of_p_max(riemann_data_i, riemann_data_j);
 
-      if (!view.compute_strict_bounds()) {
+      if (!view_.compute_strict_bounds()) {
 #ifdef DEBUG_WAVE_SPEED_ESTIMATOR
         const Number p_star_RS = p_star_RS_full(riemann_data_i, riemann_data_j);
         const Number p_star_SS = p_star_SS_full(riemann_data_i, riemann_data_j);

--- a/source/euler_aeos/wave_speed_estimator.template.h
+++ b/source/euler_aeos/wave_speed_estimator.template.h
@@ -688,6 +688,7 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
     WaveSpeedEstimatorView<dim, Number>::compute(
+        const PrecomputedVectorView &pv,
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int i,
@@ -695,10 +696,10 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &n_ij) const
     {
       const auto &[p_i, unused_i, s_i, eta_i] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       const auto &[p_j, unused_j, s_j, eta_j] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(js);
+          pv.template read_tensor<Number, precomputed_type>(js);
 
       const auto riemann_data_i = riemann_data_from_state(U_i, p_i, n_ij);
       const auto riemann_data_j = riemann_data_from_state(U_j, p_j, n_ij);

--- a/source/euler_aeos/wave_speed_estimator.template.h
+++ b/source/euler_aeos/wave_speed_estimator.template.h
@@ -86,7 +86,6 @@ namespace ryujin
                                                const Number &gamma,
                                                const Number &a) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto covolume_b = view.eos_covolume_constant();
 
       const Number numerator =
@@ -104,7 +103,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto pinf = view.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
@@ -220,7 +218,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto pinf = view.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
@@ -274,7 +271,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto covolume_b = view.eos_covolume_constant();
       const auto pinf = view.eos_interpolation_pinfty();
 
@@ -330,7 +326,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto pinf = view.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;
@@ -419,7 +414,6 @@ namespace ryujin
     {
       constexpr ScalarNumber min = std::numeric_limits<ScalarNumber>::min();
 
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto covolume_b = view.eos_covolume_constant();
       const auto pinf = view.eos_interpolation_pinfty();
 
@@ -473,7 +467,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto covolume_b = view.eos_covolume_constant();
       const auto pinf = view.eos_interpolation_pinfty();
 
@@ -509,7 +502,6 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::lambda1_minus(
         const primitive_type &riemann_data, const Number p_star) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto pinf = view.eos_interpolation_pinfty();
 
       const auto &[rho, u, p, gamma, a] = riemann_data;
@@ -528,7 +520,6 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::lambda3_plus(
         const primitive_type &riemann_data, const Number p_star) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto pinf = view.eos_interpolation_pinfty();
 
       const auto &[rho, u, p, gamma, a] = riemann_data;
@@ -563,8 +554,6 @@ namespace ryujin
         const Number &p,
         const dealii::Tensor<1, dim, Number> &n_ij) const -> primitive_type
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto rho = view.density(U);
       const auto rho_inverse = ScalarNumber(1.0) / rho;
 
@@ -604,7 +593,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto pinf = view.eos_interpolation_pinfty();
 
       const auto &[rho_i, u_i, p_i, gamma_i, a_i] = riemann_data_i;

--- a/source/euler_barotropic/description.h
+++ b/source/euler_barotropic/description.h
@@ -36,25 +36,21 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = EulerBarotropic::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView =
-          EulerBarotropic::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = ryujin::StubParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           ryujin::StubParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = EulerBarotropic::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = EulerBarotropic::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = EulerBarotropic::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = EulerBarotropic::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView =
-          EulerBarotropic::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator =
+          EulerBarotropic::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace EulerBarotropic
 } // namespace ryujin

--- a/source/euler_barotropic/hyperbolic_system.h
+++ b/source/euler_barotropic/hyperbolic_system.h
@@ -77,6 +77,13 @@ namespace ryujin
       HyperbolicSystem(const std::string &subsection = "/HyperbolicSystem");
 
       /**
+       * Alias for the view on the hyperbolic system for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = HyperbolicSystemView<dim, Number>;
+
+      /**
        * Return a view on the Hyperbolic System for a given dimension @p
        * dim and choice of number type @p Number (which can be a scalar
        * float, or double, as well as a VectorizedArray holding packed
@@ -85,7 +92,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return HyperbolicSystemView<dim, Number>{*this};
+        return View<dim, Number>{*this};
       }
 
       /**

--- a/source/euler_barotropic/hyperbolic_system.h
+++ b/source/euler_barotropic/hyperbolic_system.h
@@ -395,12 +395,27 @@ namespace ryujin
           Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * states:
+       */
+      using PrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber, n_precomputed_values>;
+
+      /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
           Vectors::MultiComponentVector<ScalarNumber,
                                         n_initial_precomputed_values>;
+
+      /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * initial states:
+       */
+      using InitialPrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber,
+                                            n_initial_precomputed_values>;
 
       //@}
       /**
@@ -536,14 +551,14 @@ namespace ryujin
        * For the Euler equations we simply compute <code>f(U_i)</code>.
        */
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector &piv,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView &piv,
                         const unsigned int i,
                         const state_type &U_i) const;
 
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector &piv,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView &piv,
                         const unsigned int *js,
                         const state_type &U_j) const;
 
@@ -574,12 +589,12 @@ namespace ryujin
       /** We do not have source terms */
       static constexpr bool have_source_terms = false;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int i,
                               const state_type &U_i,
                               const ScalarNumber tau) const = delete;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int *js,
                               const state_type &U_j,
                               const ScalarNumber tau) const = delete;
@@ -973,8 +988,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector &pv,
-        const InitialPrecomputedVector & /*piv*/,
+        const PrecomputedVectorView &pv,
+        const InitialPrecomputedVectorView & /*piv*/,
         const unsigned int i,
         const state_type &U_i) const -> flux_contribution_type
     {
@@ -987,8 +1002,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector &pv,
-        const InitialPrecomputedVector & /*piv*/,
+        const PrecomputedVectorView &pv,
+        const InitialPrecomputedVectorView & /*piv*/,
         const unsigned int *js,
         const state_type &U_j) const -> flux_contribution_type
     {

--- a/source/euler_barotropic/indicator.h
+++ b/source/euler_barotropic/indicator.h
@@ -67,7 +67,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Indicator<ScalarNumber>;
 
@@ -80,10 +80,10 @@ namespace ryujin
        * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator_view.reset(i, U_i);
+       *   indicator_view.reset(pv, i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator_view.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(pv, js, U_j, c_ij);
        *   }
        *   indicator_view.alpha(hd_i);
        * }
@@ -95,11 +95,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters,
-                    const PrecomputedVector &precomputed_values)
+                    const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -107,13 +105,16 @@ namespace ryujin
        * Reset temporary storage and initialize for a new row corresponding
        * to state vector U_i.
        */
-      void reset(const unsigned int i, const state_type &U_i);
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
+                 const state_type &U_i);
 
       /**
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const dealii::Tensor<1, dim, Number> &c_ij);
 
@@ -132,7 +133,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       Number eta_i = 0.;
       state_type d_eta_i;
@@ -153,7 +153,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    IndicatorView<dim, Number>::reset(const unsigned int i,
+    IndicatorView<dim, Number>::reset(const PrecomputedVectorView &pv,
+                                      const unsigned int i,
                                       const state_type &U_i)
     {
       /* Entropy viscosity commutator: */
@@ -161,7 +162,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[e_i, p_i, a_i] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       eta_i = view.total_energy(U_i, e_i);
       d_eta_i = view.total_energy_derivative(U_i, e_i, p_i);
@@ -176,6 +177,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
+        const PrecomputedVectorView &pv,
         const unsigned int *js,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -185,7 +187,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[e_j, p_j, a_j] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(js);
+          pv.template read_tensor<Number, precomputed_type>(js);
 
       const auto rho_j = view.density(U_j);
       const auto rho_j_inverse = Number(1.) / rho_j;

--- a/source/euler_barotropic/indicator.h
+++ b/source/euler_barotropic/indicator.h
@@ -10,6 +10,7 @@
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -20,12 +21,17 @@ namespace ryujin
 {
   namespace EulerBarotropic
   {
+    template <int dim, typename Number = double>
+    class IndicatorView;
+
     template <typename ScalarNumber = double>
     class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      Indicator(const std::string &subsection = "/Indicator")
+      Indicator(const HyperbolicSystem &hyperbolic_system,
+                const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
@@ -35,7 +41,20 @@ namespace ryujin
 
       ACCESSOR_READ_ONLY(evc_factor);
 
+      /**
+       * Return a view on the Indicator for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return IndicatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       ScalarNumber evc_factor_;
     };
 
@@ -46,7 +65,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class IndicatorView
     {
     public:
@@ -92,11 +111,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      IndicatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -131,7 +150,7 @@ namespace ryujin
        */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       Number eta_i = 0.;
@@ -159,8 +178,6 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto &[e_i, p_i, a_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
@@ -183,8 +200,6 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
       /* Entropy viscosity commutator: */
-
-      const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[e_j, p_j, a_j] =
           pv.template read_tensor<Number, precomputed_type>(js);

--- a/source/euler_barotropic/indicator.h
+++ b/source/euler_barotropic/indicator.h
@@ -120,8 +120,8 @@ namespace ryujin
        * object as arguments
        */
       IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
-          : view(view)
-          , indicator(indicator)
+          : view_(view)
+          , indicator_(indicator)
       {
       }
 
@@ -155,14 +155,14 @@ namespace ryujin
        */
       //@{
 
-      const View view;
-      const Indicator<ScalarNumber> &indicator;
+      const View view_;
+      const Indicator<ScalarNumber> &indicator_;
 
-      Number eta_i = 0.;
-      state_type d_eta_i;
+      Number eta_i_ = 0.;
+      state_type d_eta_i_;
 
-      Number left = 0.;
-      state_type right;
+      Number left_ = 0.;
+      state_type right_;
 
       //@}
     };
@@ -186,14 +186,14 @@ namespace ryujin
       const auto &[e_i, p_i, a_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
-      eta_i = view.total_energy(U_i, e_i);
-      d_eta_i = view.total_energy_derivative(U_i, e_i, p_i);
+      eta_i_ = view_.total_energy(U_i, e_i);
+      d_eta_i_ = view_.total_energy_derivative(U_i, e_i, p_i);
 
-      // left = sum_j F(U_j) * c_ij, where F is the mathematical entropy flux
-      left = 0.;
+      // left_ = sum_j F(U_j) * c_ij, where F is the mathematical entropy flux
+      left_ = 0.;
 
-      // right = sum_j f(U_j) * c_ij, where f is the flux of the system
-      right = 0.;
+      // right_ = sum_j f(U_j) * c_ij, where f is the flux of the system
+      right_ = 0.;
     }
 
 
@@ -209,19 +209,19 @@ namespace ryujin
       const auto &[e_j, p_j, a_j] =
           pv.template read_tensor<Number, precomputed_type>(js);
 
-      const auto rho_j = view.density(U_j);
+      const auto rho_j = view_.density(U_j);
       const auto rho_j_inverse = Number(1.) / rho_j;
-      const auto eta_j = view.total_energy(U_j, e_j);
+      const auto eta_j = view_.total_energy(U_j, e_j);
 
-      const auto m_j = view.momentum(U_j);
+      const auto m_j = view_.momentum(U_j);
 
-      const auto f_j = view.f(U_j, p_j);
+      const auto f_j = view_.f(U_j, p_j);
 
       const auto entropy_flux = (eta_j + p_j) * rho_j_inverse * (m_j * c_ij);
 
-      left += entropy_flux;
+      left_ += entropy_flux;
       for (unsigned int k = 0; k < problem_dimension; ++k) {
-        right[k] += f_j[k] * c_ij;
+        right_[k] += f_j[k] * c_ij;
       }
     }
 
@@ -232,17 +232,17 @@ namespace ryujin
     {
       /* Entropy viscosity commutator: */
 
-      Number numerator = left;
-      Number denominator = std::abs(left);
+      Number numerator = left_;
+      Number denominator = std::abs(left_);
       for (unsigned int k = 0; k < problem_dimension; ++k) {
-        numerator -= d_eta_i[k] * right[k];
-        denominator += std::abs(d_eta_i[k] * right[k]);
+        numerator -= d_eta_i_[k] * right_[k];
+        denominator += std::abs(d_eta_i_[k] * right_[k]);
       }
 
-      const auto quotient = safe_division(std::abs(numerator),
-                                          denominator + hd_i * std::abs(eta_i));
+      const auto quotient = safe_division(
+          std::abs(numerator), denominator + hd_i * std::abs(eta_i_));
 
-      return std::min(Number(1.), indicator.evc_factor() * quotient);
+      return std::min(Number(1.), indicator_.evc_factor() * quotient);
     }
   } // namespace EulerBarotropic
 } // namespace ryujin

--- a/source/euler_barotropic/indicator.h
+++ b/source/euler_barotropic/indicator.h
@@ -116,12 +116,12 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and an Indicator
        * object as arguments
        */
-      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
           : view(view)
-          , parameters(parameters)
+          , indicator(indicator)
       {
       }
 
@@ -156,7 +156,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Indicator<ScalarNumber> &parameters;
+      const Indicator<ScalarNumber> &indicator;
 
       Number eta_i = 0.;
       state_type d_eta_i;
@@ -242,7 +242,7 @@ namespace ryujin
       const auto quotient = safe_division(std::abs(numerator),
                                           denominator + hd_i * std::abs(eta_i));
 
-      return std::min(Number(1.), parameters.evc_factor() * quotient);
+      return std::min(Number(1.), indicator.evc_factor() * quotient);
     }
   } // namespace EulerBarotropic
 } // namespace ryujin

--- a/source/euler_barotropic/indicator.h
+++ b/source/euler_barotropic/indicator.h
@@ -42,6 +42,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(evc_factor);
 
       /**
+       * Alias for the view on the indicator for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = IndicatorView<dim, Number>;
+
+      /**
        * Return a view on the Indicator for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -49,7 +56,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return IndicatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -88,8 +95,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Indicator<ScalarNumber>;
-
       //@}
       /**
        * @name Stencil-based computation of indicators
@@ -111,10 +116,10 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      IndicatorView(const View &view, const Parameters &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -151,7 +156,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Indicator<ScalarNumber> &parameters;
 
       Number eta_i = 0.;
       state_type d_eta_i;

--- a/source/euler_barotropic/initial_state_library.template.h
+++ b/source/euler_barotropic/initial_state_library.template.h
@@ -21,8 +21,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/euler_barotropic/limiter.h
+++ b/source/euler_barotropic/limiter.h
@@ -115,12 +115,12 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a Limiter
        * object as arguments
        */
-      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
           : view(view)
-          , parameters(parameters)
+          , limiter(limiter)
       {
       }
 
@@ -226,7 +226,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Limiter<ScalarNumber> &parameters;
+      const Limiter<ScalarNumber> &limiter;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -286,7 +286,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= parameters.relaxation_factor();
+      r *= limiter.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       rho_min_relaxed *= std::max(Number(1.) - r, Number(eps));
@@ -378,7 +378,7 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const auto rho_relaxation =
-          ScalarNumber(2. * parameters.relaxation_factor()) *
+          ScalarNumber(2. * limiter.relaxation_factor()) *
           std::abs(rho_relaxation_numerator) /
           (std::abs(rho_relaxation_denominator) + Number(eps));
 

--- a/source/euler_barotropic/limiter.h
+++ b/source/euler_barotropic/limiter.h
@@ -119,8 +119,8 @@ namespace ryujin
        * object as arguments
        */
       LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
-          : view(view)
-          , limiter(limiter)
+          : view_(view)
+          , limiter_(limiter)
       {
       }
 
@@ -225,16 +225,16 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const View view;
-      const Limiter<ScalarNumber> &limiter;
+      const View view_;
+      const Limiter<ScalarNumber> &limiter_;
 
-      state_type U_i;
-      flux_contribution_type flux_i;
+      state_type U_i_;
+      flux_contribution_type flux_i_;
 
       Bounds bounds_;
 
-      Number rho_relaxation_numerator;
-      Number rho_relaxation_denominator;
+      Number rho_relaxation_numerator_;
+      Number rho_relaxation_denominator_;
 
       //@}
     };
@@ -254,7 +254,7 @@ namespace ryujin
         const unsigned int /*i*/,
         const state_type &U_i) const -> Bounds
     {
-      const auto rho_i = view.density(U_i);
+      const auto rho_i = view_.density(U_i);
       return {/*rho_min*/ rho_i, /*rho_max*/ rho_i};
     }
 
@@ -286,7 +286,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= limiter.relaxation_factor();
+      r *= limiter_.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       rho_min_relaxed *= std::max(Number(1.) - r, Number(eps));
@@ -303,8 +303,8 @@ namespace ryujin
                                     const state_type &new_U_i,
                                     const flux_contribution_type &new_flux_i)
     {
-      U_i = new_U_i;
-      flux_i = new_flux_i;
+      U_i_ = new_U_i;
+      flux_i_ = new_flux_i;
 
       /* Bounds: */
 
@@ -315,8 +315,8 @@ namespace ryujin
 
       /* Relaxation: */
 
-      rho_relaxation_numerator = Number(0.);
-      rho_relaxation_denominator = Number(0.);
+      rho_relaxation_numerator_ = Number(0.);
+      rho_relaxation_denominator_ = Number(0.);
     }
 
 
@@ -339,16 +339,16 @@ namespace ryujin
       /* Bounds: */
       auto &[rho_min, rho_max] = bounds_;
 
-      const auto rho_i = view.density(U_i);
-      const auto rho_j = view.density(U_j);
+      const auto rho_i = view_.density(U_i_);
+      const auto rho_j = view_.density(U_j);
 
       /* bar state shifted by an affine shift: */
       const auto U_ij_bar =
-          ScalarNumber(0.5) * (U_i + U_j) -
-          ScalarNumber(0.5) * contract(add(flux_j, -flux_i), scaled_c_ij) +
+          ScalarNumber(0.5) * (U_i_ + U_j) -
+          ScalarNumber(0.5) * contract(add(flux_j, -flux_i_), scaled_c_ij) +
           affine_shift;
 
-      const auto rho_ij_bar = view.density(U_ij_bar);
+      const auto rho_ij_bar = view_.density(U_ij_bar);
 
       /* Density bounds: */
 
@@ -359,8 +359,8 @@ namespace ryujin
 
       /* Use a uniform weight. */
       const auto beta_ij = Number(1.);
-      rho_relaxation_numerator += beta_ij * (rho_i + rho_j);
-      rho_relaxation_denominator += std::abs(beta_ij);
+      rho_relaxation_numerator_ += beta_ij * (rho_i + rho_j);
+      rho_relaxation_denominator_ += std::abs(beta_ij);
     }
 
 
@@ -378,9 +378,9 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const auto rho_relaxation =
-          ScalarNumber(2. * limiter.relaxation_factor()) *
-          std::abs(rho_relaxation_numerator) /
-          (std::abs(rho_relaxation_denominator) + Number(eps));
+          ScalarNumber(2. * limiter_.relaxation_factor()) *
+          std::abs(rho_relaxation_numerator_) /
+          (std::abs(rho_relaxation_denominator_) + Number(eps));
 
       rho_min_relaxed = std::max(rho_min_relaxed, rho_min - rho_relaxation);
       rho_max_relaxed = std::min(rho_max_relaxed, rho_max + rho_relaxation);

--- a/source/euler_barotropic/limiter.h
+++ b/source/euler_barotropic/limiter.h
@@ -45,6 +45,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(relaxation_factor);
 
       /**
+       * Alias for the view on the limiter for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = LimiterView<dim, Number>;
+
+      /**
        * Return a view on the Limiter for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -52,7 +59,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return LimiterView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -91,8 +98,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Limiter<ScalarNumber>;
-
       //@}
       /**
        * @name Computation and manipulation of bounds
@@ -110,10 +115,10 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      LimiterView(const View &view, const Parameters &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -221,7 +226,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Limiter<ScalarNumber> &parameters;
 
       state_type U_i;
       flux_contribution_type flux_i;

--- a/source/euler_barotropic/limiter.h
+++ b/source/euler_barotropic/limiter.h
@@ -70,7 +70,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Limiter<ScalarNumber>;
 
@@ -94,11 +94,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters,
-                  const PrecomputedVector &precomputed_values)
+                  const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -106,7 +104,8 @@ namespace ryujin
        * Given a state @p U_i and an index @p i return "strict" bounds,
        * i.e., a minimal convex set containing the state.
        */
-      Bounds projection_bounds_from_state(const unsigned int i,
+      Bounds projection_bounds_from_state(const PrecomputedVectorView &pv,
+                                          const unsigned int i,
                                           const state_type &U_i) const;
 
       /**
@@ -136,10 +135,10 @@ namespace ryujin
        * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter_view.reset(i, U_i, flux_i);
+       *   limiter_view.reset(pv, i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       *     limiter_view.accumulate(pv, js, U_j, flux_j, scaled_c_ij,
        * affine_shift);
        *   }
        *   limiter_view.bounds(hd_i);
@@ -151,7 +150,8 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int i,
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
                  const state_type &U_i,
                  const flux_contribution_type &flux_i);
 
@@ -159,7 +159,8 @@ namespace ryujin
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
@@ -202,7 +203,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -226,7 +226,9 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     LimiterView<dim, Number>::projection_bounds_from_state(
-        const unsigned int /*i*/, const state_type &U_i) const -> Bounds
+        const PrecomputedVectorView & /*pv*/,
+        const unsigned int /*i*/,
+        const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
       const auto rho_i = view.density(U_i);
@@ -273,7 +275,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    LimiterView<dim, Number>::reset(const unsigned int /*i*/,
+    LimiterView<dim, Number>::reset(const PrecomputedVectorView & /*pv*/,
+                                    const unsigned int /*i*/,
                                     const state_type &new_U_i,
                                     const flux_contribution_type &new_flux_i)
     {
@@ -296,6 +299,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
+        const PrecomputedVectorView & /*pv*/,
         const unsigned int * /*js*/,
         const state_type &U_j,
         const flux_contribution_type &flux_j,

--- a/source/euler_barotropic/limiter.h
+++ b/source/euler_barotropic/limiter.h
@@ -11,18 +11,24 @@
 
 #include <multicomponent_vector.h>
 #include <newton.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 namespace ryujin
 {
   namespace EulerBarotropic
   {
+    template <int dim, typename Number = double>
+    class LimiterView;
+
     template <typename ScalarNumber = double>
     class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      Limiter(const std::string &subsection = "/Limiter")
+      Limiter(const HyperbolicSystem &hyperbolic_system,
+              const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         iterations_ = 2;
         add_parameter(
@@ -38,7 +44,20 @@ namespace ryujin
       ACCESSOR_READ_ONLY(iterations);
       ACCESSOR_READ_ONLY(relaxation_factor);
 
+      /**
+       * Return a view on the Limiter for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return LimiterView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       unsigned int iterations_;
       ScalarNumber relaxation_factor_;
     };
@@ -49,7 +68,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class LimiterView
     {
     public:
@@ -91,11 +110,11 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      LimiterView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -201,7 +220,7 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       state_type U_i;
@@ -230,7 +249,6 @@ namespace ryujin
         const unsigned int /*i*/,
         const state_type &U_i) const -> Bounds
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto rho_i = view.density(U_i);
       return {/*rho_min*/ rho_i, /*rho_max*/ rho_i};
     }
@@ -312,8 +330,6 @@ namespace ryujin
       // equations verify that this does the right thing.
       Assert(std::max(affine_shift.norm(), Number(0.)) == Number(0.),
              dealii::ExcNotImplemented());
-
-      const auto view = hyperbolic_system.view<dim, Number>();
 
       /* Bounds: */
       auto &[rho_min, rho_max] = bounds_;

--- a/source/euler_barotropic/limiter.h
+++ b/source/euler_barotropic/limiter.h
@@ -300,11 +300,11 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline void
     LimiterView<dim, Number>::reset(const PrecomputedVectorView & /*pv*/,
                                     const unsigned int /*i*/,
-                                    const state_type &new_U_i,
-                                    const flux_contribution_type &new_flux_i)
+                                    const state_type &U_i,
+                                    const flux_contribution_type &flux_i)
     {
-      U_i_ = new_U_i;
-      flux_i_ = new_flux_i;
+      U_i_ = U_i;
+      flux_i_ = flux_i;
 
       /* Bounds: */
 

--- a/source/euler_barotropic/limiter.template.h
+++ b/source/euler_barotropic/limiter.template.h
@@ -20,8 +20,6 @@ namespace ryujin
                                     const Number t_min /* = Number(0.) */,
                                     const Number t_max /* = Number(1.) */) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       bool success = true;
       Number t_r = t_max;
 

--- a/source/euler_barotropic/limiter.template.h
+++ b/source/euler_barotropic/limiter.template.h
@@ -24,7 +24,7 @@ namespace ryujin
       Number t_r = t_max;
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
-      const auto large = view.vacuum_state_relaxation_large();
+      const auto large = view_.vacuum_state_relaxation_large();
       const ScalarNumber relax = ScalarNumber(1. + large * eps);
 
       /*
@@ -32,8 +32,8 @@ namespace ryujin
        */
 
       {
-        const auto &rho_U = view.density(U);
-        const auto &rho_P = view.density(P);
+        const auto &rho_U = view_.density(U);
+        const auto &rho_P = view_.density(P);
 
         const auto &rho_min = std::get<0>(bounds);
         const auto &rho_max = std::get<1>(bounds);
@@ -42,9 +42,9 @@ namespace ryujin
          * Verify that rho_U is within bounds. This property might be
          * violated for relative CFL numbers larger than 1.
          */
-        const auto test_min = view.filter_vacuum_density(
+        const auto test_min = view_.filter_vacuum_density(
             std::max(Number(0.), rho_U - relax * rho_max));
-        const auto test_max = view.filter_vacuum_density(
+        const auto test_max = view_.filter_vacuum_density(
             std::max(Number(0.), rho_min - relax * rho_U));
         if (!(test_min == Number(0.) && test_max == Number(0.))) {
 #ifdef DEBUG_OUTPUT
@@ -103,10 +103,10 @@ namespace ryujin
         /*
          * Verify that the new state is within bounds:
          */
-        const auto rho_new = view.density(U + t_r * P);
-        const auto test_new_min = view.filter_vacuum_density(
+        const auto rho_new = view_.density(U + t_r * P);
+        const auto test_new_min = view_.filter_vacuum_density(
             std::max(Number(0.), rho_new - relax * rho_max));
-        const auto test_new_max = view.filter_vacuum_density(
+        const auto test_new_max = view_.filter_vacuum_density(
             std::max(Number(0.), rho_min - relax * rho_new));
         if (!(test_new_min == Number(0.) && test_new_max == Number(0.))) {
 #ifdef DEBUG_OUTPUT

--- a/source/euler_barotropic/wave_speed_estimator.h
+++ b/source/euler_barotropic/wave_speed_estimator.h
@@ -104,13 +104,14 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a WaveSpeedEstimator
        * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view,
-                             const WaveSpeedEstimator<ScalarNumber> &parameters)
+      WaveSpeedEstimatorView(
+          const View &view,
+          const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
           : view(view)
-          , parameters(parameters)
+          , wave_speed_estimator(wave_speed_estimator)
       {
       }
 
@@ -141,7 +142,7 @@ namespace ryujin
 
     private:
       const View view;
-      const WaveSpeedEstimator<ScalarNumber> &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
       //@}
     };
   } // namespace EulerBarotropic

--- a/source/euler_barotropic/wave_speed_estimator.h
+++ b/source/euler_barotropic/wave_speed_estimator.h
@@ -110,8 +110,8 @@ namespace ryujin
       WaveSpeedEstimatorView(
           const View &view,
           const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
-          : view(view)
-          , wave_speed_estimator(wave_speed_estimator)
+          : view_(view)
+          , wave_speed_estimator_(wave_speed_estimator)
       {
       }
 
@@ -141,8 +141,8 @@ namespace ryujin
       //@{
 
     private:
-      const View view;
-      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
+      const View view_;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator_;
       //@}
     };
   } // namespace EulerBarotropic

--- a/source/euler_barotropic/wave_speed_estimator.h
+++ b/source/euler_barotropic/wave_speed_estimator.h
@@ -9,6 +9,7 @@
 
 #include "hyperbolic_system.h"
 
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/point.h>
@@ -18,14 +19,34 @@ namespace ryujin
 {
   namespace EulerBarotropic
   {
+    template <int dim, typename Number = double>
+    class WaveSpeedEstimatorView;
+
     template <typename ScalarNumber = double>
     class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
+                         const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
       }
+
+      /**
+       * Return a view on the WaveSpeedEstimator for a given dimension @p dim
+       * and choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return WaveSpeedEstimatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
+    private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
     };
 
 
@@ -37,7 +58,7 @@ namespace ryujin
      *
      * @ingroup EulerEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class WaveSpeedEstimatorView
     {
     public:
@@ -78,11 +99,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -113,7 +134,7 @@ namespace ryujin
       //@{
 
     private:
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
       //@}
     };

--- a/source/euler_barotropic/wave_speed_estimator.h
+++ b/source/euler_barotropic/wave_speed_estimator.h
@@ -34,6 +34,13 @@ namespace ryujin
       }
 
       /**
+       * Alias for the view on the wave speed estimator for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = WaveSpeedEstimatorView<dim, Number>;
+
+      /**
        * Return a view on the WaveSpeedEstimator for a given dimension @p dim
        * and choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -41,7 +48,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return WaveSpeedEstimatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -90,8 +97,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = WaveSpeedEstimator<ScalarNumber>;
-
       //@}
       /**
        * @name Compute wavespeed estimates
@@ -99,10 +104,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+      WaveSpeedEstimatorView(const View &view,
+                             const WaveSpeedEstimator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -135,7 +141,7 @@ namespace ryujin
 
     private:
       const View view;
-      const Parameters &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &parameters;
       //@}
     };
   } // namespace EulerBarotropic

--- a/source/euler_barotropic/wave_speed_estimator.h
+++ b/source/euler_barotropic/wave_speed_estimator.h
@@ -67,7 +67,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
@@ -81,11 +81,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters,
-                             const PrecomputedVector &precomputed_values)
+                             const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -102,7 +100,8 @@ namespace ryujin
        * compute an estimate for an upper bound of the maximum wavespeed
        * lambda.
        */
-      Number compute(const state_type &U_i,
+      Number compute(const PrecomputedVectorView &pv,
+                     const state_type &U_i,
                      const state_type &U_j,
                      const unsigned int i,
                      const unsigned int *js,
@@ -116,7 +115,6 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace EulerBarotropic

--- a/source/euler_barotropic/wave_speed_estimator.template.h
+++ b/source/euler_barotropic/wave_speed_estimator.template.h
@@ -40,6 +40,7 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
     WaveSpeedEstimatorView<dim, Number>::compute(
+        const PrecomputedVectorView &pv,
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int i,
@@ -49,10 +50,10 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[e_i, p_i, a_i] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       const auto &[e_j, p_j, a_j] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(js);
+          pv.template read_tensor<Number, precomputed_type>(js);
 
       const auto rho_i = view.density(U_i);
       const auto rho_i_inverse = Number(1.0) / rho_i;

--- a/source/euler_barotropic/wave_speed_estimator.template.h
+++ b/source/euler_barotropic/wave_speed_estimator.template.h
@@ -53,14 +53,14 @@ namespace ryujin
       const auto &[e_j, p_j, a_j] =
           pv.template read_tensor<Number, precomputed_type>(js);
 
-      const auto rho_i = view.density(U_i);
+      const auto rho_i = view_.density(U_i);
       const auto rho_i_inverse = Number(1.0) / rho_i;
-      const auto m_i = view.momentum(U_i);
+      const auto m_i = view_.momentum(U_i);
       const auto u_i = rho_i_inverse * n_ij * m_i;
 
-      const auto rho_j = view.density(U_j);
+      const auto rho_j = view_.density(U_j);
       const auto rho_j_inverse = Number(1.0) / rho_j;
-      const auto m_j = view.momentum(U_j);
+      const auto m_j = view_.momentum(U_j);
       const auto u_j = rho_j_inverse * n_ij * m_j;
 
       return compute(primitive_type{u_i, a_i}, primitive_type{u_j, a_j});

--- a/source/euler_barotropic/wave_speed_estimator.template.h
+++ b/source/euler_barotropic/wave_speed_estimator.template.h
@@ -47,8 +47,6 @@ namespace ryujin
         const unsigned int *js,
         const dealii::Tensor<1, dim, Number> &n_ij) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto &[e_i, p_i, a_i] =
           pv.template read_tensor<Number, precomputed_type>(i);
 

--- a/source/euler_poisson/description.h
+++ b/source/euler_poisson/description.h
@@ -19,23 +19,20 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = Euler::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView = Euler::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = EulerPoisson::ParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = Euler::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = Euler::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = Euler::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = Euler::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView = Euler::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator = Euler::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace EulerPoisson
 } // namespace ryujin

--- a/source/euler_poisson/initial_state_library.template.h
+++ b/source/euler_poisson/initial_state_library.template.h
@@ -21,8 +21,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/euler_poisson/parabolic_module.h
+++ b/source/euler_poisson/parabolic_module.h
@@ -139,8 +139,7 @@ namespace ryujin
 
       using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
 
       using ParabolicSystem = typename Description::ParabolicSystem;
 

--- a/source/euler_poisson_aeos/description.h
+++ b/source/euler_poisson_aeos/description.h
@@ -19,24 +19,20 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = EulerAEOS::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView = EulerAEOS::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = EulerPoisson::ParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = EulerAEOS::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = EulerAEOS::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = EulerAEOS::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = EulerAEOS::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView =
-          EulerAEOS::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator = EulerAEOS::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace EulerPoissonAEOS
 } // namespace ryujin

--- a/source/euler_poisson_aeos/initial_state_library.template.h
+++ b/source/euler_poisson_aeos/initial_state_library.template.h
@@ -21,8 +21,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/euler_poisson_barotropic/description.h
+++ b/source/euler_poisson_barotropic/description.h
@@ -19,25 +19,21 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = EulerBarotropic::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView =
-          EulerBarotropic::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = EulerPoisson::ParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           EulerPoisson::ParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = EulerBarotropic::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = EulerBarotropic::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = EulerBarotropic::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = EulerBarotropic::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView =
-          EulerBarotropic::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator =
+          EulerBarotropic::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace EulerPoissonBarotropic
 } // namespace ryujin

--- a/source/euler_poisson_barotropic/initial_state_library.template.h
+++ b/source/euler_poisson_barotropic/initial_state_library.template.h
@@ -21,8 +21,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/hyperbolic_module.h
+++ b/source/hyperbolic_module.h
@@ -120,8 +120,14 @@ namespace ryujin
 
     using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
+
+    using Indicator = typename Description::template Indicator<Number>;
+
+    using Limiter = typename Description::template Limiter<Number>;
+
+    using WaveSpeedEstimator =
+        typename Description::template WaveSpeedEstimator<Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 
@@ -360,15 +366,11 @@ namespace ryujin
      * @name Run time options
      */
     //@{
-    typename Description::template IndicatorView<dim, Number>::Parameters
-        indicator_;
+    Indicator indicator_;
 
-    typename Description::template LimiterView<dim, Number>::Parameters
-        limiter_;
+    Limiter limiter_;
 
-    typename Description::template WaveSpeedEstimatorView<dim,
-                                                          Number>::Parameters
-        wave_speed_estimator_;
+    WaveSpeedEstimator wave_speed_estimator_;
 
     //@}
     /**
@@ -399,7 +401,7 @@ namespace ryujin
     mutable ScalarVector alpha_;
 
     static constexpr auto n_bounds =
-        Description::template LimiterView<dim, Number>::n_bounds;
+        Limiter::template View<dim, Number>::n_bounds;
     mutable Vectors::MultiComponentVector<Number, n_bounds> bounds_;
 
     using HyperbolicVector =

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -31,9 +31,10 @@ namespace ryujin
       const InitialValues<Description, dim, Number> &initial_values,
       const std::string &subsection /*= "HyperbolicModule"*/)
       : ParameterAcceptor(subsection)
-      , indicator_(subsection + "/indicator")
-      , limiter_(subsection + "/limiter")
-      , wave_speed_estimator_(subsection + "/wave speed estimator")
+      , indicator_(hyperbolic_system, subsection + "/indicator")
+      , limiter_(hyperbolic_system, subsection + "/limiter")
+      , wave_speed_estimator_(hyperbolic_system,
+                              subsection + "/wave speed estimator")
       , mpi_ensemble_(mpi_ensemble)
       , computing_timer_(computing_timer)
       , offline_data_(&offline_data)
@@ -345,14 +346,10 @@ namespace ryujin
         using T = decltype(sentinel);
         constexpr unsigned int stride_size = get_stride_size<T>;
 
-        using WaveSpeedEstimatorView =
-            typename Description::template WaveSpeedEstimatorView<dim, T>;
-        WaveSpeedEstimatorView wave_speed_estimator_view(*hyperbolic_system_,
-                                                         wave_speed_estimator_);
+        const auto wave_speed_estimator_view =
+            wave_speed_estimator_.template view<dim, T>();
 
-        using IndicatorView =
-            typename Description::template IndicatorView<dim, T>;
-        IndicatorView indicator_view(*hyperbolic_system_, indicator_);
+        auto indicator_view = indicator_.template view<dim, T>();
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -427,10 +424,8 @@ namespace ryujin
       const auto body_boundary = [&](const auto &, const unsigned int k) {
         const auto &[i, col_idx, j] = coupling_boundary_pairs[k];
 
-        using WaveSpeedEstimatorView =
-            typename Description::template WaveSpeedEstimatorView<dim, Number>;
-        WaveSpeedEstimatorView wave_speed_estimator_view(*hyperbolic_system_,
-                                                         wave_speed_estimator_);
+        const auto wave_speed_estimator_view =
+            wave_speed_estimator_.template view<dim, Number>();
 
         /*
          * Only work on index pairs "i < j" that point to the upper
@@ -472,10 +467,8 @@ namespace ryujin
       const auto body = [&](auto, unsigned int i) {
 
 #ifdef DEBUG_SYMMETRY_CHECK
-        using WaveSpeedEstimatorView =
-            typename Description::template WaveSpeedEstimatorView<dim, Number>;
-        WaveSpeedEstimatorView wave_speed_estimator_view(*hyperbolic_system_,
-                                                         wave_speed_estimator_);
+        const auto wave_speed_estimator_view =
+            wave_speed_estimator_.template view<dim, Number>();
 #endif
 
         /* Skip constrained degrees of freedom: */
@@ -611,7 +604,6 @@ namespace ryujin
         using T = decltype(sentinel);
         using View =
             typename Description::template HyperbolicSystemView<dim, T>;
-        using LimiterView = typename Description::template LimiterView<dim, T>;
         using flux_contribution_type = typename View::flux_contribution_type;
         using state_type = typename View::state_type;
 
@@ -619,7 +611,7 @@ namespace ryujin
 
         const auto view = hyperbolic_system_->template view<dim, T>();
 
-        LimiterView limiter_view(*hyperbolic_system_, limiter_);
+        auto limiter_view = limiter_.template view<dim, T>();
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -885,11 +877,10 @@ namespace ryujin
         using T = decltype(sentinel);
         using View =
             typename Description::template HyperbolicSystemView<dim, T>;
-        using LimiterView = typename Description::template LimiterView<dim, T>;
 
         constexpr unsigned int stride_size = get_stride_size<T>;
 
-        LimiterView limiter_view(*hyperbolic_system_, limiter_);
+        auto limiter_view = limiter_.template view<dim, T>();
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -1035,9 +1026,8 @@ namespace ryujin
         using T = decltype(sentinel);
         using View =
             typename Description::template HyperbolicSystemView<dim, T>;
-        using LimiterView = typename Description::template LimiterView<dim, T>;
 
-        LimiterView limiter_view(*hyperbolic_system_, limiter_);
+        auto limiter_view = limiter_.template view<dim, T>();
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -602,8 +602,7 @@ namespace ryujin
                       auto have_discontinuous_ansatz,
                       const unsigned int i) {
         using T = decltype(sentinel);
-        using View =
-            typename Description::template HyperbolicSystemView<dim, T>;
+        using View = typename HyperbolicSystem::template View<dim, T>;
         using flux_contribution_type = typename View::flux_contribution_type;
         using state_type = typename View::state_type;
 
@@ -875,8 +874,7 @@ namespace ryujin
                       auto have_discontinuous_ansatz,
                       const unsigned int i) {
         using T = decltype(sentinel);
-        using View =
-            typename Description::template HyperbolicSystemView<dim, T>;
+        using View = typename HyperbolicSystem::template View<dim, T>;
 
         constexpr unsigned int stride_size = get_stride_size<T>;
 
@@ -1024,8 +1022,7 @@ namespace ryujin
 
       auto body = [&](auto sentinel, const unsigned int i) {
         using T = decltype(sentinel);
-        using View =
-            typename Description::template HyperbolicSystemView<dim, T>;
+        using View = typename HyperbolicSystem::template View<dim, T>;
 
         auto limiter_view = limiter_.template view<dim, T>();
 

--- a/source/hyperbolic_module.template.h
+++ b/source/hyperbolic_module.template.h
@@ -347,13 +347,12 @@ namespace ryujin
 
         using WaveSpeedEstimatorView =
             typename Description::template WaveSpeedEstimatorView<dim, T>;
-        WaveSpeedEstimatorView wave_speed_estimator_view(
-            *hyperbolic_system_, wave_speed_estimator_, old_precomputed);
+        WaveSpeedEstimatorView wave_speed_estimator_view(*hyperbolic_system_,
+                                                         wave_speed_estimator_);
 
         using IndicatorView =
             typename Description::template IndicatorView<dim, T>;
-        IndicatorView indicator_view(
-            *hyperbolic_system_, indicator_, old_precomputed);
+        IndicatorView indicator_view(*hyperbolic_system_, indicator_);
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -362,7 +361,7 @@ namespace ryujin
 
         const auto U_i = old_U.template read_tensor<T>(i);
 
-        indicator_view.reset(i, U_i);
+        indicator_view.reset(old_precomputed, i, U_i);
 
         const unsigned int *js = sparsity_simd.columns(i);
         for (unsigned int col_idx = 0; col_idx < row_length;
@@ -372,7 +371,7 @@ namespace ryujin
 
           const auto c_ij = cij_matrix.template read_tensor<T>(i, col_idx);
 
-          indicator_view.accumulate(js, U_j, c_ij);
+          indicator_view.accumulate(old_precomputed, js, U_j, c_ij);
 
           /* Skip diagonal. */
           if (col_idx == 0)
@@ -384,8 +383,8 @@ namespace ryujin
 
           const auto norm = c_ij.norm();
           const auto n_ij = c_ij / norm;
-          const auto lambda_max =
-              wave_speed_estimator_view.compute(U_i, U_j, i, js, n_ij);
+          const auto lambda_max = wave_speed_estimator_view.compute(
+              old_precomputed, U_i, U_j, i, js, n_ij);
           const auto d_ij = norm * lambda_max;
 
           dij_matrix_.write_entry(d_ij, i, col_idx, true);
@@ -430,8 +429,8 @@ namespace ryujin
 
         using WaveSpeedEstimatorView =
             typename Description::template WaveSpeedEstimatorView<dim, Number>;
-        WaveSpeedEstimatorView wave_speed_estimator_view(
-            *hyperbolic_system_, wave_speed_estimator_, old_precomputed);
+        WaveSpeedEstimatorView wave_speed_estimator_view(*hyperbolic_system_,
+                                                         wave_speed_estimator_);
 
         /*
          * Only work on index pairs "i < j" that point to the upper
@@ -454,8 +453,8 @@ namespace ryujin
 
         const auto d_ij = dij_matrix_.read_entry(i, col_idx);
 
-        const auto lambda_max =
-            wave_speed_estimator_view.compute(U_j, U_i, j, &i, n_ji);
+        const auto lambda_max = wave_speed_estimator_view.compute(
+            old_precomputed, U_j, U_i, j, &i, n_ji);
         const auto d_ji = norm_ji * lambda_max;
 
         dij_matrix_.write_entry(std::max(d_ij, d_ji), i, col_idx);
@@ -475,8 +474,8 @@ namespace ryujin
 #ifdef DEBUG_SYMMETRY_CHECK
         using WaveSpeedEstimatorView =
             typename Description::template WaveSpeedEstimatorView<dim, Number>;
-        WaveSpeedEstimatorView wave_speed_estimator_view(
-            *hyperbolic_system_, wave_speed_estimator_, old_precomputed);
+        WaveSpeedEstimatorView wave_speed_estimator_view(*hyperbolic_system_,
+                                                         wave_speed_estimator_);
 #endif
 
         /* Skip constrained degrees of freedom: */
@@ -507,8 +506,8 @@ namespace ryujin
             const auto norm_ij = c_ij.norm();
             const auto n_ij = c_ij / norm_ij;
 
-            const auto lambda_max =
-                wave_speed_estimator_view.compute(U_i, U_j, i, &j, n_ij);
+            const auto lambda_max = wave_speed_estimator_view.compute(
+                old_precomputed, U_i, U_j, i, &j, n_ij);
             const auto d_ij = norm_ij * lambda_max;
 
             Assert(d_ij <= d_ji + 1.0e-12,
@@ -620,8 +619,7 @@ namespace ryujin
 
         const auto view = hyperbolic_system_->template view<dim, T>();
 
-        LimiterView limiter_view(
-            *hyperbolic_system_, limiter_, old_precomputed);
+        LimiterView limiter_view(*hyperbolic_system_, limiter_);
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -664,7 +662,7 @@ namespace ryujin
           F_iH += m_i * S_iH;
         }
 
-        limiter_view.reset(i, U_i, flux_i);
+        limiter_view.reset(old_precomputed, i, U_i, flux_i);
 
         [[maybe_unused]] state_type affine_shift;
 
@@ -762,8 +760,12 @@ namespace ryujin
             F_iH += d_ijH * (U_star_ji - U_star_ij);
             P_ij += (d_ijH - d_ij) * (U_star_ji - U_star_ij);
 
-            limiter_view.accumulate(
-                U_j, U_star_ij, U_star_ji, scaled_c_ij, affine_shift);
+            limiter_view.accumulate(old_precomputed,
+                                    U_j,
+                                    U_star_ij,
+                                    U_star_ji,
+                                    scaled_c_ij,
+                                    affine_shift);
 
           } else {
 
@@ -771,7 +773,8 @@ namespace ryujin
             F_iH += d_ijH * (U_j - U_i);
             P_ij += (d_ijH - d_ij) * (U_j - U_i);
 
-            limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij, affine_shift);
+            limiter_view.accumulate(
+                old_precomputed, js, U_j, flux_j, scaled_c_ij, affine_shift);
           }
 
           if constexpr (View::have_source_terms) {
@@ -886,8 +889,7 @@ namespace ryujin
 
         constexpr unsigned int stride_size = get_stride_size<T>;
 
-        LimiterView limiter_view(
-            *hyperbolic_system_, limiter_, old_precomputed);
+        LimiterView limiter_view(*hyperbolic_system_, limiter_);
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);
@@ -1035,8 +1037,7 @@ namespace ryujin
             typename Description::template HyperbolicSystemView<dim, T>;
         using LimiterView = typename Description::template LimiterView<dim, T>;
 
-        LimiterView limiter_view(
-            *hyperbolic_system_, limiter_, old_precomputed);
+        LimiterView limiter_view(*hyperbolic_system_, limiter_);
 
         /* Skip constrained degrees of freedom: */
         const unsigned int row_length = sparsity_simd.row_length(i);

--- a/source/initial_state_library.h
+++ b/source/initial_state_library.h
@@ -34,7 +34,7 @@ namespace ryujin
   {
   public:
     using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+        typename Description::HyperbolicSystem::template View<dim, Number>;
 
     using state_type = typename View::state_type;
 

--- a/source/initial_values.h
+++ b/source/initial_values.h
@@ -47,8 +47,7 @@ namespace ryujin
 
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 

--- a/source/mesh_adaptor.h
+++ b/source/mesh_adaptor.h
@@ -114,8 +114,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 

--- a/source/navier_stokes/description.h
+++ b/source/navier_stokes/description.h
@@ -32,22 +32,19 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = Euler::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView = Euler::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = NavierStokes::ParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule = NavierStokes::ParabolicModule<dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = Euler::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = Euler::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = Euler::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = Euler::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView = Euler::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator = Euler::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace NavierStokes
 } // namespace ryujin

--- a/source/navier_stokes/initial_state_library.template.h
+++ b/source/navier_stokes/initial_state_library.template.h
@@ -21,8 +21,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/postprocessor.h
+++ b/source/postprocessor.h
@@ -49,8 +49,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 

--- a/source/quantities.h
+++ b/source/quantities.h
@@ -38,8 +38,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using state_type = typename View::state_type;
 

--- a/source/scalar_conservation/description.h
+++ b/source/scalar_conservation/description.h
@@ -37,25 +37,21 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = ScalarConservation::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView =
-          ScalarConservation::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = ryujin::StubParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           ryujin::StubParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = ScalarConservation::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = ScalarConservation::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = ScalarConservation::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = ScalarConservation::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView =
-          ScalarConservation::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator =
+          ScalarConservation::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace ScalarConservation
 } // namespace ryujin

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -270,12 +270,27 @@ namespace ryujin
           Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * states:
+       */
+      using PrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber, n_precomputed_values>;
+
+      /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
           Vectors::MultiComponentVector<ScalarNumber,
                                         n_initial_precomputed_values>;
+
+      /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * initial states:
+       */
+      using InitialPrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber,
+                                            n_initial_precomputed_values>;
 
       //@}
       /**
@@ -392,14 +407,14 @@ namespace ryujin
        * For the Euler equations we simply compute <code>f(U_i)</code>.
        */
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector & /*piv*/,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView & /*piv*/,
                         const unsigned int i,
                         const state_type & /*U_i*/) const;
 
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector & /*piv*/,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView & /*piv*/,
                         const unsigned int *js,
                         const state_type & /*U_j*/) const;
 
@@ -429,12 +444,12 @@ namespace ryujin
       /** We do not have source terms */
       static constexpr bool have_source_terms = false;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int i,
                               const state_type &U_i,
                               const ScalarNumber tau) const = delete;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int *js,
                               const state_type &U_j,
                               const ScalarNumber tau) const = delete;
@@ -790,8 +805,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector &pv,
-        const InitialPrecomputedVector & /*piv*/,
+        const PrecomputedVectorView &pv,
+        const InitialPrecomputedVectorView & /*piv*/,
         const unsigned int i,
         const state_type & /*U_i*/) const -> flux_contribution_type
     {
@@ -806,8 +821,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector &pv,
-        const InitialPrecomputedVector & /*piv*/,
+        const PrecomputedVectorView &pv,
+        const InitialPrecomputedVectorView & /*piv*/,
         const unsigned int *js,
         const state_type & /*U_j*/) const -> flux_contribution_type
     {

--- a/source/scalar_conservation/hyperbolic_system.h
+++ b/source/scalar_conservation/hyperbolic_system.h
@@ -49,6 +49,13 @@ namespace ryujin
       HyperbolicSystem(const std::string &subsection = "/HyperbolicSystem");
 
       /**
+       * Alias for the view on the hyperbolic system for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = HyperbolicSystemView<dim, Number>;
+
+      /**
        * Return a view on the Hyperbolic System for a given dimension @p
        * dim and choice of number type @p Number (which can be a scalar
        * float, or double, as well as a VectorizedArray holding packed
@@ -57,7 +64,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return HyperbolicSystemView<dim, Number>{*this};
+        return View<dim, Number>{*this};
       }
 
       /**

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -116,12 +116,12 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and an Indicator
        * object as arguments
        */
-      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
           : view(view)
-          , parameters(parameters)
+          , indicator(indicator)
       {
       }
 
@@ -156,7 +156,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Indicator<ScalarNumber> &parameters;
+      const Indicator<ScalarNumber> &indicator;
 
       Number u_i;
       Number u_abs_max;
@@ -227,7 +227,7 @@ namespace ryujin
           std::abs(numerator) /
           (denominator + std::max(hd_i * std::abs(u_abs_max), regularization));
 
-      return std::min(Number(1.), parameters.evc_factor() * quotient);
+      return std::min(Number(1.), indicator.evc_factor() * quotient);
     }
 
   } // namespace ScalarConservation

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -42,6 +42,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(evc_factor);
 
       /**
+       * Alias for the view on the indicator for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = IndicatorView<dim, Number>;
+
+      /**
        * Return a view on the Indicator for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -49,7 +56,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return IndicatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -88,8 +95,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Indicator<ScalarNumber>;
-
       //@}
       /**
        * @name Stencil-based computation of indicators
@@ -111,10 +116,10 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      IndicatorView(const View &view, const Parameters &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -151,7 +156,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Indicator<ScalarNumber> &parameters;
 
       Number u_i;
       Number u_abs_max;

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -67,7 +67,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Indicator<ScalarNumber>;
 
@@ -80,10 +80,10 @@ namespace ryujin
        * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator_view.reset(i, U_i);
+       *   indicator_view.reset(pv, i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator_view.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(pv, js, U_j, c_ij);
        *   }
        *   indicator_view.alpha(hd_i);
        * }
@@ -95,11 +95,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters,
-                    const PrecomputedVector &precomputed_values)
+                    const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -107,13 +105,16 @@ namespace ryujin
        * Reset temporary storage and initialize for a new row corresponding
        * to state vector U_i.
        */
-      void reset(const unsigned int i, const state_type &U_i);
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
+                 const state_type &U_i);
 
       /**
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const dealii::Tensor<1, dim, Number> &c_ij);
 
@@ -132,7 +133,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       Number u_i;
       Number u_abs_max;
@@ -152,15 +152,15 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    IndicatorView<dim, Number>::reset(const unsigned int i,
+    IndicatorView<dim, Number>::reset(const PrecomputedVectorView &pv,
+                                      const unsigned int i,
                                       const state_type &U_i)
     {
       /* entropy viscosity commutator: */
 
       const auto view = hyperbolic_system.view<dim, Number>();
 
-      const auto prec_i =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+      const auto prec_i = pv.template read_tensor<Number, precomputed_type>(i);
 
       u_i = view.state(U_i);
       u_abs_max = std::abs(u_i);
@@ -172,6 +172,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
+        const PrecomputedVectorView &pv,
         const unsigned int *js,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -180,8 +181,7 @@ namespace ryujin
 
       const auto view = hyperbolic_system.view<dim, Number>();
 
-      const auto prec_j =
-          precomputed_values.template read_tensor<Number, precomputed_type>(js);
+      const auto prec_j = pv.template read_tensor<Number, precomputed_type>(js);
 
       const auto u_j = view.state(U_j);
       u_abs_max = std::max(u_abs_max, std::abs(u_j));

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -120,8 +120,8 @@ namespace ryujin
        * object as arguments
        */
       IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
-          : view(view)
-          , indicator(indicator)
+          : view_(view)
+          , indicator_(indicator)
       {
       }
 
@@ -155,14 +155,14 @@ namespace ryujin
        */
       //@{
 
-      const View view;
-      const Indicator<ScalarNumber> &indicator;
+      const View view_;
+      const Indicator<ScalarNumber> &indicator_;
 
-      Number u_i;
-      Number u_abs_max;
-      dealii::Tensor<1, dim, Number> f_i;
-      Number left;
-      Number right;
+      Number u_i_;
+      Number u_abs_max_;
+      dealii::Tensor<1, dim, Number> f_i_;
+      Number left_;
+      Number right_;
       //@}
     };
 
@@ -184,11 +184,11 @@ namespace ryujin
 
       const auto prec_i = pv.template read_tensor<Number, precomputed_type>(i);
 
-      u_i = view.state(U_i);
-      u_abs_max = std::abs(u_i);
-      f_i = view.construct_flux_tensor(prec_i);
-      left = 0.;
-      right = 0.;
+      u_i_ = view_.state(U_i);
+      u_abs_max_ = std::abs(u_i_);
+      f_i_ = view_.construct_flux_tensor(prec_i);
+      left_ = 0.;
+      right_ = 0.;
     }
 
 
@@ -203,13 +203,13 @@ namespace ryujin
 
       const auto prec_j = pv.template read_tensor<Number, precomputed_type>(js);
 
-      const auto u_j = view.state(U_j);
-      u_abs_max = std::max(u_abs_max, std::abs(u_j));
-      const auto d_eta_j = view.kruzkov_entropy_derivative(u_i, u_j);
-      const auto f_j = view.construct_flux_tensor(prec_j);
+      const auto u_j = view_.state(U_j);
+      u_abs_max_ = std::max(u_abs_max_, std::abs(u_j));
+      const auto d_eta_j = view_.kruzkov_entropy_derivative(u_i_, u_j);
+      const auto f_j = view_.construct_flux_tensor(prec_j);
 
-      left += d_eta_j * (f_j * c_ij);
-      right += d_eta_j * (f_i * c_ij);
+      left_ += d_eta_j * (f_j * c_ij);
+      right_ += d_eta_j * (f_i_ * c_ij);
     }
 
 
@@ -217,17 +217,17 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline Number
     IndicatorView<dim, Number>::alpha(const Number hd_i) const
     {
-      Number numerator = left - right;
-      Number denominator = std::abs(left) + std::abs(right);
+      Number numerator = left_ - right_;
+      Number denominator = std::abs(left_) + std::abs(right_);
 
       const auto regularization =
           Number(100. * std::numeric_limits<ScalarNumber>::min());
 
       const auto quotient =
           std::abs(numerator) /
-          (denominator + std::max(hd_i * std::abs(u_abs_max), regularization));
+          (denominator + std::max(hd_i * std::abs(u_abs_max_), regularization));
 
-      return std::min(Number(1.), indicator.evc_factor() * quotient);
+      return std::min(Number(1.), indicator_.evc_factor() * quotient);
     }
 
   } // namespace ScalarConservation

--- a/source/scalar_conservation/indicator.h
+++ b/source/scalar_conservation/indicator.h
@@ -10,6 +10,7 @@
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -20,12 +21,17 @@ namespace ryujin
 {
   namespace ScalarConservation
   {
+    template <int dim, typename Number = double>
+    class IndicatorView;
+
     template <typename ScalarNumber = double>
     class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      Indicator(const std::string &subsection = "/Indicator")
+      Indicator(const HyperbolicSystem &hyperbolic_system,
+                const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
@@ -35,7 +41,20 @@ namespace ryujin
 
       ACCESSOR_READ_ONLY(evc_factor);
 
+      /**
+       * Return a view on the Indicator for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return IndicatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       ScalarNumber evc_factor_;
     };
 
@@ -46,7 +65,7 @@ namespace ryujin
      *
      * @ingroup ScalarConservationEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class IndicatorView
     {
     public:
@@ -92,11 +111,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      IndicatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -131,7 +150,7 @@ namespace ryujin
        */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       Number u_i;
@@ -158,8 +177,6 @@ namespace ryujin
     {
       /* entropy viscosity commutator: */
 
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto prec_i = pv.template read_tensor<Number, precomputed_type>(i);
 
       u_i = view.state(U_i);
@@ -178,8 +195,6 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
       /* entropy viscosity commutator: */
-
-      const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto prec_j = pv.template read_tensor<Number, precomputed_type>(js);
 

--- a/source/scalar_conservation/initial_state_library.template.h
+++ b/source/scalar_conservation/initial_state_library.template.h
@@ -22,8 +22,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -69,7 +69,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Limiter<ScalarNumber>;
 
@@ -94,11 +94,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters,
-                  const PrecomputedVector &precomputed_values)
+                  const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -106,7 +104,8 @@ namespace ryujin
        * Given a state @p U_i and an index @p i return "strict" bounds,
        * i.e., a minimal convex set containing the state.
        */
-      Bounds projection_bounds_from_state(const unsigned int i,
+      Bounds projection_bounds_from_state(const PrecomputedVectorView &pv,
+                                          const unsigned int i,
                                           const state_type &U_i) const;
 
       /**
@@ -133,10 +132,10 @@ namespace ryujin
        * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter_view.reset(i, U_i, flux_i);
+       *   limiter_view.reset(pv, i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       *     limiter_view.accumulate(pv, js, U_j, flux_j, scaled_c_ij,
        * affine_shift);
        *   }
        *   limiter_view.bounds(hd_i);
@@ -148,7 +147,8 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int i,
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
                  const state_type &U_i,
                  const flux_contribution_type &flux_i);
 
@@ -156,7 +156,8 @@ namespace ryujin
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const flux_contribution_type &flux_j,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
@@ -190,7 +191,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -213,7 +213,9 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     LimiterView<dim, Number>::projection_bounds_from_state(
-        const unsigned int /*i*/, const state_type &U_i) const -> Bounds
+        const PrecomputedVectorView & /*pv*/,
+        const unsigned int /*i*/,
+        const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
       const auto u_i = view.state(U_i);
@@ -259,7 +261,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    LimiterView<dim, Number>::reset(const unsigned int /*i*/,
+    LimiterView<dim, Number>::reset(const PrecomputedVectorView & /*pv*/,
+                                    const unsigned int /*i*/,
                                     const state_type &new_U_i,
                                     const flux_contribution_type &new_flux_i)
     {
@@ -282,6 +285,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
+        const PrecomputedVectorView & /*pv*/,
         const unsigned int * /*js*/,
         const state_type &U_j,
         const flux_contribution_type &flux_j,

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -44,6 +44,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(relaxation_factor);
 
       /**
+       * Alias for the view on the limiter for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = LimiterView<dim, Number>;
+
+      /**
        * Return a view on the Limiter for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -51,7 +58,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return LimiterView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -90,8 +97,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Limiter<ScalarNumber>;
-
       //@}
       /**
        * @name Computation and manipulation of bounds
@@ -110,10 +115,10 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      LimiterView(const View &view, const Parameters &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -209,7 +214,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Limiter<ScalarNumber> &parameters;
 
       state_type U_i;
       flux_contribution_type flux_i;

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -119,8 +119,8 @@ namespace ryujin
        * object as arguments
        */
       LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
-          : view(view)
-          , limiter(limiter)
+          : view_(view)
+          , limiter_(limiter)
       {
       }
 
@@ -213,16 +213,16 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const View view;
-      const Limiter<ScalarNumber> &limiter;
+      const View view_;
+      const Limiter<ScalarNumber> &limiter_;
 
-      state_type U_i;
-      flux_contribution_type flux_i;
+      state_type U_i_;
+      flux_contribution_type flux_i_;
 
       Bounds bounds_;
 
-      Number u_relaxation_numerator;
-      Number u_relaxation_denominator;
+      Number u_relaxation_numerator_;
+      Number u_relaxation_denominator_;
       //@}
     };
 
@@ -241,7 +241,7 @@ namespace ryujin
         const unsigned int /*i*/,
         const state_type &U_i) const -> Bounds
     {
-      const auto u_i = view.state(U_i);
+      const auto u_i = view_.state(U_i);
       return {/*u_min*/ u_i, /*u_max*/ u_i};
     }
 
@@ -273,7 +273,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= limiter.relaxation_factor();
+      r *= limiter_.relaxation_factor();
 
       u_min = std::min((Number(1.) - r) * u_min, (Number(1.) + r) * u_min);
       u_max = std::max((Number(1.) + r) * u_max, (Number(1.) - r) * u_max);
@@ -289,8 +289,8 @@ namespace ryujin
                                     const state_type &new_U_i,
                                     const flux_contribution_type &new_flux_i)
     {
-      U_i = new_U_i;
-      flux_i = new_flux_i;
+      U_i_ = new_U_i;
+      flux_i_ = new_flux_i;
 
       /* Bounds: */
 
@@ -301,8 +301,8 @@ namespace ryujin
 
       /* Relaxation: */
 
-      u_relaxation_numerator = Number(0.);
-      u_relaxation_denominator = Number(0.);
+      u_relaxation_numerator_ = Number(0.);
+      u_relaxation_denominator_ = Number(0.);
     }
 
 
@@ -318,15 +318,15 @@ namespace ryujin
       /* Bounds: */
       auto &[u_min, u_max] = bounds_;
 
-      const auto u_i = view.state(U_i);
-      const auto u_j = view.state(U_j);
+      const auto u_i = view_.state(U_i_);
+      const auto u_j = view_.state(U_j);
 
       const auto U_ij_bar =
-          ScalarNumber(0.5) * (U_i + U_j) -
-          ScalarNumber(0.5) * contract(add(flux_j, -flux_i), scaled_c_ij) +
+          ScalarNumber(0.5) * (U_i_ + U_j) -
+          ScalarNumber(0.5) * contract(add(flux_j, -flux_i_), scaled_c_ij) +
           affine_shift;
 
-      const auto u_ij_bar = view.state(U_ij_bar);
+      const auto u_ij_bar = view_.state(U_ij_bar);
 
       /* Bounds: */
 
@@ -337,8 +337,8 @@ namespace ryujin
 
       /* Use a uniform weight. */
       const auto beta_ij = Number(1.);
-      u_relaxation_numerator += beta_ij * (u_i + u_j);
-      u_relaxation_denominator += std::abs(beta_ij);
+      u_relaxation_numerator_ += beta_ij * (u_i + u_j);
+      u_relaxation_denominator_ += std::abs(beta_ij);
     }
 
 
@@ -356,9 +356,9 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const Number u_relaxation =
-          ScalarNumber(2. * limiter.relaxation_factor()) *
-          std::abs(u_relaxation_numerator) /
-          (std::abs(u_relaxation_denominator) + Number(eps));
+          ScalarNumber(2. * limiter_.relaxation_factor()) *
+          std::abs(u_relaxation_numerator_) /
+          (std::abs(u_relaxation_denominator_) + Number(eps));
 
       u_min_relaxed = std::max(u_min_relaxed, u_min - u_relaxation);
       u_max_relaxed = std::min(u_max_relaxed, u_max + u_relaxation);

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -115,12 +115,12 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a Limiter
        * object as arguments
        */
-      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
           : view(view)
-          , parameters(parameters)
+          , limiter(limiter)
       {
       }
 
@@ -214,7 +214,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Limiter<ScalarNumber> &parameters;
+      const Limiter<ScalarNumber> &limiter;
 
       state_type U_i;
       flux_contribution_type flux_i;
@@ -273,7 +273,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= parameters.relaxation_factor();
+      r *= limiter.relaxation_factor();
 
       u_min = std::min((Number(1.) - r) * u_min, (Number(1.) + r) * u_min);
       u_max = std::max((Number(1.) + r) * u_max, (Number(1.) - r) * u_max);
@@ -356,7 +356,7 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
       const Number u_relaxation =
-          ScalarNumber(2. * parameters.relaxation_factor()) *
+          ScalarNumber(2. * limiter.relaxation_factor()) *
           std::abs(u_relaxation_numerator) /
           (std::abs(u_relaxation_denominator) + Number(eps));
 

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -10,18 +10,24 @@
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 namespace ryujin
 {
   namespace ScalarConservation
   {
+    template <int dim, typename Number = double>
+    class LimiterView;
+
     template <typename ScalarNumber = double>
     class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      Limiter(const std::string &subsection = "/Limiter")
+      Limiter(const HyperbolicSystem &hyperbolic_system,
+              const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         iterations_ = 2;
         add_parameter(
@@ -37,7 +43,20 @@ namespace ryujin
       ACCESSOR_READ_ONLY(iterations);
       ACCESSOR_READ_ONLY(relaxation_factor);
 
+      /**
+       * Return a view on the Limiter for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return LimiterView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       unsigned int iterations_;
       ScalarNumber relaxation_factor_;
     };
@@ -48,7 +67,7 @@ namespace ryujin
      *
      * @ingroup ScalarConservationEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class LimiterView
     {
     public:
@@ -91,11 +110,11 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      LimiterView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -189,7 +208,7 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       state_type U_i;
@@ -217,7 +236,6 @@ namespace ryujin
         const unsigned int /*i*/,
         const state_type &U_i) const -> Bounds
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto u_i = view.state(U_i);
       return {/*u_min*/ u_i, /*u_max*/ u_i};
     }
@@ -292,8 +310,6 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
         const state_type &affine_shift)
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       /* Bounds: */
       auto &[u_min, u_max] = bounds_;
 

--- a/source/scalar_conservation/limiter.h
+++ b/source/scalar_conservation/limiter.h
@@ -286,11 +286,11 @@ namespace ryujin
     DEAL_II_ALWAYS_INLINE inline void
     LimiterView<dim, Number>::reset(const PrecomputedVectorView & /*pv*/,
                                     const unsigned int /*i*/,
-                                    const state_type &new_U_i,
-                                    const flux_contribution_type &new_flux_i)
+                                    const state_type &U_i,
+                                    const flux_contribution_type &flux_i)
     {
-      U_i_ = new_U_i;
-      flux_i_ = new_flux_i;
+      U_i_ = U_i;
+      flux_i_ = flux_i;
 
       /* Bounds: */
 

--- a/source/scalar_conservation/limiter.template.h
+++ b/source/scalar_conservation/limiter.template.h
@@ -19,8 +19,6 @@ namespace ryujin
                                     const Number t_min /* = Number(0.) */,
                                     const Number t_max /* = Number(1.) */) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       bool success = true;
       Number t_r = t_max;
 

--- a/source/scalar_conservation/limiter.template.h
+++ b/source/scalar_conservation/limiter.template.h
@@ -25,8 +25,8 @@ namespace ryujin
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       const ScalarNumber relax = ScalarNumber(1. + 10000. * eps);
 
-      const auto &u_U = view.state(U);
-      const auto &u_P = view.state(P);
+      const auto &u_U = view_.state(U);
+      const auto &u_P = view_.state(P);
 
       const auto &u_min = std::get<0>(bounds);
       const auto &u_max = std::get<1>(bounds);
@@ -102,7 +102,7 @@ namespace ryujin
        *
        * u_min, u_U, u_max might be negative, thus relax in both directions.
        */
-      const auto u_new = view.state(U + t_r * P);
+      const auto u_new = view_.state(U + t_r * P);
       const auto test_new_max = std::max(
           Number(0.), std::min(u_new - relax * u_max, relax * u_new - u_max));
       const auto test_new_min = std::max(

--- a/source/scalar_conservation/wave_speed_estimator.h
+++ b/source/scalar_conservation/wave_speed_estimator.h
@@ -92,7 +92,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
@@ -107,11 +107,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters,
-                             const PrecomputedVector &precomputed_values)
+                             const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -130,7 +128,8 @@ namespace ryujin
        * For two given states U_i a U_j and a (normalized) "direction" n_ij
        * compute an estimate for an upper bound of lambda.
        */
-      Number compute(const state_type &U_i,
+      Number compute(const PrecomputedVectorView &pv,
+                     const state_type &U_i,
                      const state_type &U_j,
                      const unsigned int i,
                      const unsigned int *js,
@@ -139,7 +138,6 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace ScalarConservation

--- a/source/scalar_conservation/wave_speed_estimator.h
+++ b/source/scalar_conservation/wave_speed_estimator.h
@@ -128,13 +128,14 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a WaveSpeedEstimator
        * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view,
-                             const WaveSpeedEstimator<ScalarNumber> &parameters)
+      WaveSpeedEstimatorView(
+          const View &view,
+          const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
           : view(view)
-          , parameters(parameters)
+          , wave_speed_estimator(wave_speed_estimator)
       {
       }
 
@@ -162,7 +163,7 @@ namespace ryujin
 
     private:
       const View view;
-      const WaveSpeedEstimator<ScalarNumber> &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
       //@}
     };
   } // namespace ScalarConservation

--- a/source/scalar_conservation/wave_speed_estimator.h
+++ b/source/scalar_conservation/wave_speed_estimator.h
@@ -9,6 +9,7 @@
 
 #include "hyperbolic_system.h"
 
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/point.h>
@@ -18,12 +19,17 @@ namespace ryujin
 {
   namespace ScalarConservation
   {
+    template <int dim, typename Number = double>
+    class WaveSpeedEstimatorView;
+
     template <typename ScalarNumber = double>
     class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
+                         const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         use_greedy_wavespeed_ = false;
         add_parameter("use greedy wavespeed",
@@ -56,7 +62,20 @@ namespace ryujin
       ACCESSOR_READ_ONLY(use_averaged_entropy);
       ACCESSOR_READ_ONLY(random_entropies);
 
+      /**
+       * Return a view on the WaveSpeedEstimator for a given dimension @p dim
+       * and choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return WaveSpeedEstimatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       bool use_greedy_wavespeed_;
       bool use_averaged_entropy_;
       unsigned int random_entropies_;
@@ -73,7 +92,7 @@ namespace ryujin
      *
      * @ingroup ScalarConservationEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class WaveSpeedEstimatorView
     {
     public:
@@ -104,11 +123,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -136,7 +155,7 @@ namespace ryujin
                      const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
       //@}
     };

--- a/source/scalar_conservation/wave_speed_estimator.h
+++ b/source/scalar_conservation/wave_speed_estimator.h
@@ -134,8 +134,8 @@ namespace ryujin
       WaveSpeedEstimatorView(
           const View &view,
           const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
-          : view(view)
-          , wave_speed_estimator(wave_speed_estimator)
+          : view_(view)
+          , wave_speed_estimator_(wave_speed_estimator)
       {
       }
 
@@ -162,8 +162,8 @@ namespace ryujin
                      const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      const View view;
-      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
+      const View view_;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator_;
       //@}
     };
   } // namespace ScalarConservation

--- a/source/scalar_conservation/wave_speed_estimator.h
+++ b/source/scalar_conservation/wave_speed_estimator.h
@@ -63,6 +63,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(random_entropies);
 
       /**
+       * Alias for the view on the wave speed estimator for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = WaveSpeedEstimatorView<dim, Number>;
+
+      /**
        * Return a view on the WaveSpeedEstimator for a given dimension @p dim
        * and choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -70,7 +77,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return WaveSpeedEstimatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -113,8 +120,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = WaveSpeedEstimator<ScalarNumber>;
-
       //@}
 
       /**
@@ -123,10 +128,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+      WaveSpeedEstimatorView(const View &view,
+                             const WaveSpeedEstimator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -156,7 +162,7 @@ namespace ryujin
 
     private:
       const View view;
-      const Parameters &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &parameters;
       //@}
     };
   } // namespace ScalarConservation

--- a/source/scalar_conservation/wave_speed_estimator.template.h
+++ b/source/scalar_conservation/wave_speed_estimator.template.h
@@ -27,8 +27,6 @@ namespace ryujin
         const precomputed_type &prec_j,
         const dealii::Tensor<1, dim, Number> &n_ij) const
     {
-      const auto &view = hyperbolic_system.view<dim, Number>();
-
       /* Project all fluxes to 1D: */
       const Number f_i = view.construct_flux_tensor(prec_i) * n_ij;
       const Number f_j = view.construct_flux_tensor(prec_j) * n_ij;
@@ -202,8 +200,6 @@ namespace ryujin
         const unsigned int *js,
         const dealii::Tensor<1, dim, Number> &n_ij) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       using pst = typename View::precomputed_type;
 
       const auto u_i = view.state(U_i);

--- a/source/scalar_conservation/wave_speed_estimator.template.h
+++ b/source/scalar_conservation/wave_speed_estimator.template.h
@@ -66,7 +66,7 @@ namespace ryujin
 
       constexpr auto gte = dealii::SIMDComparison::greater_than_or_equal;
 
-      if (parameters.use_greedy_wavespeed()) {
+      if (wave_speed_estimator.use_greedy_wavespeed()) {
         /*
          * In case of a greedy estimate we make sure that we always use the
          * Roe average and only fall back to the derivative approximation
@@ -171,12 +171,12 @@ namespace ryujin
       };
 
 
-      if (parameters.use_averaged_entropy()) {
+      if (wave_speed_estimator.use_averaged_entropy()) {
         const Number k = ScalarNumber(0.5) * (u_i + u_j);
         enforce_entropy(k);
       }
 
-      const unsigned int n_entropies = parameters.random_entropies();
+      const unsigned int n_entropies = wave_speed_estimator.random_entropies();
       for (unsigned int i = 0; i < n_entropies; ++i) {
         const Number factor = draw();
         const Number k = factor * u_i + (Number(1.) - factor) * u_j;

--- a/source/scalar_conservation/wave_speed_estimator.template.h
+++ b/source/scalar_conservation/wave_speed_estimator.template.h
@@ -195,6 +195,7 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline Number
     WaveSpeedEstimatorView<dim, Number>::compute(
+        const PrecomputedVectorView &pv,
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int i,
@@ -208,7 +209,6 @@ namespace ryujin
       const auto u_i = view.state(U_i);
       const auto u_j = view.state(U_j);
 
-      const auto &pv = precomputed_values;
       const auto prec_i = pv.template read_tensor<Number, pst>(i);
       const auto prec_j = pv.template read_tensor<Number, pst>(js);
 

--- a/source/scalar_conservation/wave_speed_estimator.template.h
+++ b/source/scalar_conservation/wave_speed_estimator.template.h
@@ -28,12 +28,12 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &n_ij) const
     {
       /* Project all fluxes to 1D: */
-      const Number f_i = view.construct_flux_tensor(prec_i) * n_ij;
-      const Number f_j = view.construct_flux_tensor(prec_j) * n_ij;
-      const Number df_i = view.construct_flux_gradient_tensor(prec_i) * n_ij;
-      const Number df_j = view.construct_flux_gradient_tensor(prec_j) * n_ij;
+      const Number f_i = view_.construct_flux_tensor(prec_i) * n_ij;
+      const Number f_j = view_.construct_flux_tensor(prec_j) * n_ij;
+      const Number df_i = view_.construct_flux_gradient_tensor(prec_i) * n_ij;
+      const Number df_j = view_.construct_flux_gradient_tensor(prec_j) * n_ij;
 
-      const auto h2 = Number(2. * view.derivative_approximation_delta());
+      const auto h2 = Number(2. * view_.derivative_approximation_delta());
 
 #ifdef DEBUG_WAVE_SPEED_ESTIMATOR
       std::cout << "\nu_i  = " << u_i << std::endl;
@@ -66,7 +66,7 @@ namespace ryujin
 
       constexpr auto gte = dealii::SIMDComparison::greater_than_or_equal;
 
-      if (wave_speed_estimator.use_greedy_wavespeed()) {
+      if (wave_speed_estimator_.use_greedy_wavespeed()) {
         /*
          * In case of a greedy estimate we make sure that we always use the
          * Roe average and only fall back to the derivative approximation
@@ -130,20 +130,20 @@ namespace ryujin
        */
 
       const auto enforce_entropy = [&](const Number &k) {
-        const Number f_k = view.flux_function(k) * n_ij;
+        const Number f_k = view_.flux_function(k) * n_ij;
 
 #ifdef DEBUG_WAVE_SPEED_ESTIMATOR
         std::cout << "k    = " << k << std::endl;
         std::cout << "f_k  = " << f_k << std::endl;
 #endif
 
-        const Number eta_i = view.kruzkov_entropy(k, u_i);
+        const Number eta_i = view_.kruzkov_entropy(k, u_i);
         const Number q_i =
-            view.kruzkov_entropy_derivative(k, u_i) * (f_i - f_k);
+            view_.kruzkov_entropy_derivative(k, u_i) * (f_i - f_k);
 
-        const Number eta_j = view.kruzkov_entropy(k, u_j);
+        const Number eta_j = view_.kruzkov_entropy(k, u_j);
         const Number q_j =
-            view.kruzkov_entropy_derivative(k, u_j) * (f_j - f_k);
+            view_.kruzkov_entropy_derivative(k, u_j) * (f_j - f_k);
 
         const Number a = u_i + u_j - ScalarNumber(2.) * k;
         const Number b = f_j - f_i;
@@ -171,12 +171,12 @@ namespace ryujin
       };
 
 
-      if (wave_speed_estimator.use_averaged_entropy()) {
+      if (wave_speed_estimator_.use_averaged_entropy()) {
         const Number k = ScalarNumber(0.5) * (u_i + u_j);
         enforce_entropy(k);
       }
 
-      const unsigned int n_entropies = wave_speed_estimator.random_entropies();
+      const unsigned int n_entropies = wave_speed_estimator_.random_entropies();
       for (unsigned int i = 0; i < n_entropies; ++i) {
         const Number factor = draw();
         const Number k = factor * u_i + (Number(1.) - factor) * u_j;
@@ -202,8 +202,8 @@ namespace ryujin
     {
       using pst = typename View::precomputed_type;
 
-      const auto u_i = view.state(U_i);
-      const auto u_j = view.state(U_j);
+      const auto u_i = view_.state(U_i);
+      const auto u_j = view_.state(U_j);
 
       const auto prec_i = pv.template read_tensor<Number, pst>(i);
       const auto prec_j = pv.template read_tensor<Number, pst>(js);

--- a/source/selected_components_extractor.h
+++ b/source/selected_components_extractor.h
@@ -16,8 +16,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using StateVector = typename View::StateVector;
     using InitialPrecomputedVector = typename View::InitialPrecomputedVector;

--- a/source/shallow_water/description.h
+++ b/source/shallow_water/description.h
@@ -34,25 +34,20 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = ShallowWater::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView =
-          ShallowWater::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = ryujin::StubParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           ryujin::StubParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = ShallowWater::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = ShallowWater::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = ShallowWater::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = ShallowWater::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView =
-          ShallowWater::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator = ShallowWater::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace ShallowWater
 } // namespace ryujin

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -291,12 +291,27 @@ namespace ryujin
           Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * states:
+       */
+      using PrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber, n_precomputed_values>;
+
+      /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
           Vectors::MultiComponentVector<ScalarNumber,
                                         n_initial_precomputed_values>;
+
+      /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * initial states:
+       */
+      using InitialPrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber,
+                                            n_initial_precomputed_values>;
 
       //@}
       /**
@@ -488,14 +503,14 @@ namespace ryujin
        * bathymetry and return, both, state and bathymetry.
        */
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector &piv,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView &piv,
                         const unsigned int i,
                         const state_type &U_i) const;
 
       flux_contribution_type
-      flux_contribution(const PrecomputedVector &pv,
-                        const InitialPrecomputedVector &piv,
+      flux_contribution(const PrecomputedVectorView &pv,
+                        const InitialPrecomputedVectorView &piv,
                         const unsigned int *js,
                         const state_type &U_j) const;
 
@@ -552,12 +567,12 @@ namespace ryujin
                                   const Number &h_star,
                                   const ScalarNumber tau) const;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int i,
                               const state_type &U_i,
                               const ScalarNumber tau) const;
 
-      state_type nodal_source(const PrecomputedVector &pv,
+      state_type nodal_source(const PrecomputedVectorView &pv,
                               const unsigned int *js,
                               const state_type &U_j,
                               const ScalarNumber tau) const;
@@ -1075,8 +1090,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector & /*pv*/,
-        const InitialPrecomputedVector &piv,
+        const PrecomputedVectorView & /*pv*/,
+        const InitialPrecomputedVectorView &piv,
         const unsigned int i,
         const state_type &U_i) const -> flux_contribution_type
     {
@@ -1088,8 +1103,8 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::flux_contribution(
-        const PrecomputedVector & /*pv*/,
-        const InitialPrecomputedVector &piv,
+        const PrecomputedVectorView & /*pv*/,
+        const InitialPrecomputedVectorView &piv,
         const unsigned int *js,
         const state_type &U_j) const -> flux_contribution_type
     {
@@ -1207,7 +1222,7 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::nodal_source(
-        const PrecomputedVector &pv,
+        const PrecomputedVectorView &pv,
         const unsigned int i,
         const state_type &U_i,
         const ScalarNumber tau) const -> state_type
@@ -1222,7 +1237,7 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     HyperbolicSystemView<dim, Number>::nodal_source(
-        const PrecomputedVector &pv,
+        const PrecomputedVectorView &pv,
         const unsigned int *js,
         const state_type &U_j,
         const ScalarNumber tau) const -> state_type

--- a/source/shallow_water/hyperbolic_system.h
+++ b/source/shallow_water/hyperbolic_system.h
@@ -52,6 +52,13 @@ namespace ryujin
       HyperbolicSystem(const std::string &subsection = "/HyperbolicSystem");
 
       /**
+       * Alias for the view on the hyperbolic system for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = HyperbolicSystemView<dim, Number>;
+
+      /**
        * Return a view on the Hyperbolic System for a given dimension @p
        * dim and choice of number type @p Number (which can be a scalar
        * float, or double, as well as a VectorizedArray holding packed
@@ -60,7 +67,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return HyperbolicSystemView<dim, Number>{*this};
+        return View<dim, Number>{*this};
       }
 
       /**

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -121,8 +121,8 @@ namespace ryujin
        * object as arguments
        */
       IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
-          : view(view)
-          , indicator(indicator)
+          : view_(view)
+          , indicator_(indicator)
       {
       }
 
@@ -156,17 +156,17 @@ namespace ryujin
        */
       //@{
 
-      const View view;
-      const Indicator<ScalarNumber> &indicator;
+      const View view_;
+      const Indicator<ScalarNumber> &indicator_;
 
-      Number h_i = 0.;
-      Number eta_i = 0.;
-      flux_type f_i;
-      state_type d_eta_i;
-      Number pressure_i = 0.;
+      Number h_i_ = 0.;
+      Number eta_i_ = 0.;
+      flux_type f_i_;
+      state_type d_eta_i_;
+      Number pressure_i_ = 0.;
 
-      Number left = 0.;
-      state_type right;
+      Number left_ = 0.;
+      state_type right_;
       //@}
     };
 
@@ -189,14 +189,14 @@ namespace ryujin
       const auto &[eta_m, h_star] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
-      h_i = view.water_depth(U_i);
-      eta_i = eta_m;
-      d_eta_i = view.mathematical_entropy_derivative(U_i);
-      f_i = view.f(U_i);
-      pressure_i = view.pressure(U_i);
+      h_i_ = view_.water_depth(U_i);
+      eta_i_ = eta_m;
+      d_eta_i_ = view_.mathematical_entropy_derivative(U_i);
+      f_i_ = view_.f(U_i);
+      pressure_i_ = view_.pressure(U_i);
 
-      left = 0.;
-      right = 0.;
+      left_ = 0.;
+      right_ = 0.;
     }
 
 
@@ -213,14 +213,14 @@ namespace ryujin
           pv.template read_tensor<Number, precomputed_type>(js);
 
       const auto velocity_j =
-          view.momentum(U_j) * view.inverse_water_depth_sharp(U_j);
-      const auto f_j = view.f(U_j);
-      const auto pressure_j = view.pressure(U_j);
+          view_.momentum(U_j) * view_.inverse_water_depth_sharp(U_j);
+      const auto f_j = view_.f(U_j);
+      const auto pressure_j = view_.pressure(U_j);
 
-      left += (eta_j + pressure_j) * (velocity_j * c_ij);
+      left_ += (eta_j + pressure_j) * (velocity_j * c_ij);
 
       for (unsigned int k = 0; k < problem_dimension; ++k)
-        right[k] += (f_j[k] - f_i[k]) * c_ij;
+        right_[k] += (f_j[k] - f_i_[k]) * c_ij;
     }
 
 
@@ -230,20 +230,20 @@ namespace ryujin
     {
       Number my_sum = 0.;
       for (unsigned int k = 0; k < problem_dimension; ++k) {
-        my_sum += d_eta_i[k] * right[k];
+        my_sum += d_eta_i_[k] * right_[k];
       }
 
-      Number numerator = std::abs(left - my_sum);
-      Number denominator = std::abs(left) + std::abs(my_sum);
+      Number numerator = std::abs(left_ - my_sum);
+      Number denominator = std::abs(left_) + std::abs(my_sum);
 
       const auto regularization =
           Number(100. * std::numeric_limits<ScalarNumber>::min());
 
       const auto quotient =
           std::abs(numerator) /
-          (denominator + std::max(hd_i * std::abs(eta_i), regularization));
+          (denominator + std::max(hd_i * std::abs(eta_i_), regularization));
 
-      return std::min(Number(1.), indicator.evc_factor() * quotient);
+      return std::min(Number(1.), indicator_.evc_factor() * quotient);
     }
 
 

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -12,6 +12,7 @@
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>
+#include <observer_pointer.h>
 
 #include <deal.II/base/parameter_acceptor.h>
 #include <deal.II/base/vectorization.h>
@@ -21,12 +22,17 @@ namespace ryujin
 {
   namespace ShallowWater
   {
+    template <int dim, typename Number = double>
+    class IndicatorView;
+
     template <typename ScalarNumber = double>
     class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      Indicator(const std::string &subsection = "/Indicator")
+      Indicator(const HyperbolicSystem &hyperbolic_system,
+                const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         evc_factor_ = ScalarNumber(1.);
         add_parameter("evc factor",
@@ -36,7 +42,20 @@ namespace ryujin
 
       ACCESSOR_READ_ONLY(evc_factor);
 
+      /**
+       * Return a view on the Indicator for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return IndicatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       ScalarNumber evc_factor_;
     };
 
@@ -47,7 +66,7 @@ namespace ryujin
      *
      * @ingroup ShallowWaterEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class IndicatorView
     {
     public:
@@ -93,11 +112,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      IndicatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -132,7 +151,7 @@ namespace ryujin
        */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       Number h_i = 0.;
@@ -162,8 +181,6 @@ namespace ryujin
     {
       /* entropy viscosity commutator: */
 
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const auto &[eta_m, h_star] =
           pv.template read_tensor<Number, precomputed_type>(i);
 
@@ -186,8 +203,6 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &c_ij)
     {
       /* entropy viscosity commutator: */
-
-      const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[eta_j, h_star_j] =
           pv.template read_tensor<Number, precomputed_type>(js);

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -68,7 +68,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Indicator<ScalarNumber>;
 
@@ -81,10 +81,10 @@ namespace ryujin
        * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator_view.reset(i, U_i);
+       *   indicator_view.reset(pv, i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator_view.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(pv, js, U_j, c_ij);
        *   }
        *   indicator_view.alpha(hd_i);
        * }
@@ -96,11 +96,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters,
-                    const PrecomputedVector &precomputed_values)
+                    const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -108,13 +106,16 @@ namespace ryujin
        * Reset temporary storage and initialize for a new row corresponding
        * to state vector U_i.
        */
-      void reset(const unsigned int /*i*/, const state_type &U_i);
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int /*i*/,
+                 const state_type &U_i);
 
       /**
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int *js,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const unsigned int *js,
                       const state_type &U_j,
                       const dealii::Tensor<1, dim, Number> &c_ij);
 
@@ -133,7 +134,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       Number h_i = 0.;
       Number eta_i = 0.;
@@ -156,7 +156,8 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void
-    IndicatorView<dim, Number>::reset(const unsigned int i,
+    IndicatorView<dim, Number>::reset(const PrecomputedVectorView &pv,
+                                      const unsigned int i,
                                       const state_type &U_i)
     {
       /* entropy viscosity commutator: */
@@ -164,7 +165,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[eta_m, h_star] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(i);
+          pv.template read_tensor<Number, precomputed_type>(i);
 
       h_i = view.water_depth(U_i);
       eta_i = eta_m;
@@ -179,6 +180,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void IndicatorView<dim, Number>::accumulate(
+        const PrecomputedVectorView &pv,
         const unsigned int *js,
         const state_type &U_j,
         const dealii::Tensor<1, dim, Number> &c_ij)
@@ -188,7 +190,7 @@ namespace ryujin
       const auto view = hyperbolic_system.view<dim, Number>();
 
       const auto &[eta_j, h_star_j] =
-          precomputed_values.template read_tensor<Number, precomputed_type>(js);
+          pv.template read_tensor<Number, precomputed_type>(js);
 
       const auto velocity_j =
           view.momentum(U_j) * view.inverse_water_depth_sharp(U_j);

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -117,12 +117,12 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and an Indicator
        * object as arguments
        */
-      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
           : view(view)
-          , parameters(parameters)
+          , indicator(indicator)
       {
       }
 
@@ -157,7 +157,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Indicator<ScalarNumber> &parameters;
+      const Indicator<ScalarNumber> &indicator;
 
       Number h_i = 0.;
       Number eta_i = 0.;
@@ -243,7 +243,7 @@ namespace ryujin
           std::abs(numerator) /
           (denominator + std::max(hd_i * std::abs(eta_i), regularization));
 
-      return std::min(Number(1.), parameters.evc_factor() * quotient);
+      return std::min(Number(1.), indicator.evc_factor() * quotient);
     }
 
 

--- a/source/shallow_water/indicator.h
+++ b/source/shallow_water/indicator.h
@@ -43,6 +43,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(evc_factor);
 
       /**
+       * Alias for the view on the indicator for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = IndicatorView<dim, Number>;
+
+      /**
        * Return a view on the Indicator for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -50,7 +57,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return IndicatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -89,8 +96,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Indicator<ScalarNumber>;
-
       //@}
       /**
        * @name Stencil-based computation of indicators
@@ -112,10 +117,10 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      IndicatorView(const View &view, const Parameters &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -152,7 +157,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Indicator<ScalarNumber> &parameters;
 
       Number h_i = 0.;
       Number eta_i = 0.;

--- a/source/shallow_water/initial_state_contrast.h
+++ b/source/shallow_water/initial_state_contrast.h
@@ -26,8 +26,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       Contrast(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_flow_over_bump.h
+++ b/source/shallow_water/initial_state_flow_over_bump.h
@@ -28,8 +28,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       FlowOverBump(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_function.h
+++ b/source/shallow_water/initial_state_function.h
@@ -28,8 +28,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       Function(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_geotiff.h
+++ b/source/shallow_water/initial_state_geotiff.h
@@ -29,8 +29,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
 

--- a/source/shallow_water/initial_state_hou_test.h
+++ b/source/shallow_water/initial_state_hou_test.h
@@ -27,8 +27,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       HouTest(const HyperbolicSystem &hyperbolic_system, const std::string s)

--- a/source/shallow_water/initial_state_library.template.h
+++ b/source/shallow_water/initial_state_library.template.h
@@ -23,8 +23,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/shallow_water/initial_state_paraboloid.h
+++ b/source/shallow_water/initial_state_paraboloid.h
@@ -32,8 +32,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       Paraboloid(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_ritter_dam_break.h
+++ b/source/shallow_water/initial_state_ritter_dam_break.h
@@ -26,8 +26,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       RitterDamBreak(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_sloping_friction.h
+++ b/source/shallow_water/initial_state_sloping_friction.h
@@ -29,8 +29,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       SlopingFriction(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_smooth_vortex.h
+++ b/source/shallow_water/initial_state_smooth_vortex.h
@@ -28,8 +28,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       SmoothVortex(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_soliton.h
+++ b/source/shallow_water/initial_state_soliton.h
@@ -25,8 +25,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       Soliton(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_three_bumps_dam_break.h
+++ b/source/shallow_water/initial_state_three_bumps_dam_break.h
@@ -26,8 +26,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       ThreeBumpsDamBreak(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_transient.h
+++ b/source/shallow_water/initial_state_transient.h
@@ -25,8 +25,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       TankExperiments(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/initial_state_uniform.h
+++ b/source/shallow_water/initial_state_uniform.h
@@ -29,8 +29,7 @@ namespace ryujin
     {
     public:
       using HyperbolicSystem = typename Description::HyperbolicSystem;
-      using View =
-          typename Description::template HyperbolicSystemView<dim, Number>;
+      using View = typename HyperbolicSystem::template View<dim, Number>;
       using state_type = typename View::state_type;
 
       Uniform(const HyperbolicSystem &hyperbolic_system,

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -314,13 +314,13 @@ namespace ryujin
 
 
     template <int dim, typename Number>
-    DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::reset(
-        const PrecomputedVectorView & /*pv*/,
-        unsigned int /*i*/,
-        const state_type &new_U_i,
-        const flux_contribution_type & /*new_flux_i*/)
+    DEAL_II_ALWAYS_INLINE inline void
+    LimiterView<dim, Number>::reset(const PrecomputedVectorView & /*pv*/,
+                                    unsigned int /*i*/,
+                                    const state_type &U_i,
+                                    const flux_contribution_type & /*flux_i*/)
     {
-      U_i_ = new_U_i;
+      U_i_ = U_i;
 
       auto &[h_min, h_max, v2_max] = bounds_;
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -62,6 +62,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(relaxation_factor);
 
       /**
+       * Alias for the view on the limiter for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = LimiterView<dim, Number>;
+
+      /**
        * Return a view on the Limiter for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -69,7 +76,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return LimiterView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -110,8 +117,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Limiter<ScalarNumber>;
-
       //@}
       /**
        * @name Computation and manipulation of bounds
@@ -128,10 +133,10 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      LimiterView(const View &view, const Parameters &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -229,7 +234,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Limiter<ScalarNumber> &parameters;
 
       state_type U_i;
 

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -13,17 +13,23 @@
 
 #include <multicomponent_vector.h>
 #include <newton.h>
+#include <observer_pointer.h>
 
 namespace ryujin
 {
   namespace ShallowWater
   {
+    template <int dim, typename Number = double>
+    class LimiterView;
+
     template <typename ScalarNumber = double>
     class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      Limiter(const std::string &subsection = "/Limiter")
+      Limiter(const HyperbolicSystem &hyperbolic_system,
+              const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         iterations_ = 2;
         add_parameter(
@@ -55,7 +61,20 @@ namespace ryujin
       ACCESSOR_READ_ONLY(newton_max_iterations);
       ACCESSOR_READ_ONLY(relaxation_factor);
 
+      /**
+       * Return a view on the Limiter for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return LimiterView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       unsigned int iterations_;
       ScalarNumber newton_tolerance_;
       unsigned int newton_max_iterations_;
@@ -68,7 +87,7 @@ namespace ryujin
      *
      * @ingroup ShallowWaterEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class LimiterView
     {
     public:
@@ -109,11 +128,11 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      LimiterView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -209,7 +228,7 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       state_type U_i;
@@ -240,7 +259,6 @@ namespace ryujin
         const unsigned int /*i*/,
         const state_type &U_i) const -> Bounds
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const auto h_i = view.water_depth(U_i);
       const auto v_i =
           view.momentum(U_i) * view.inverse_water_depth_mollified(U_i);
@@ -320,8 +338,6 @@ namespace ryujin
         const dealii::Tensor<1, dim, Number> &scaled_c_ij,
         const state_type &affine_shift)
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       /* The bar states: */
 
       const auto f_star_ij = view.f(U_star_ij);

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -137,8 +137,8 @@ namespace ryujin
        * object as arguments
        */
       LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
-          : view(view)
-          , limiter(limiter)
+          : view_(view)
+          , limiter_(limiter)
       {
       }
 
@@ -233,18 +233,18 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const View view;
-      const Limiter<ScalarNumber> &limiter;
+      const View view_;
+      const Limiter<ScalarNumber> &limiter_;
 
-      state_type U_i;
+      state_type U_i_;
 
       Bounds bounds_;
 
       /* for relaxation */
 
-      Number h_relaxation_numerator;
-      Number v2_relaxation_numerator;
-      Number relaxation_denominator;
+      Number h_relaxation_numerator_;
+      Number v2_relaxation_numerator_;
+      Number relaxation_denominator_;
 
       //@}
     };
@@ -264,9 +264,9 @@ namespace ryujin
         const unsigned int /*i*/,
         const state_type &U_i) const -> Bounds
     {
-      const auto h_i = view.water_depth(U_i);
+      const auto h_i = view_.water_depth(U_i);
       const auto v_i =
-          view.momentum(U_i) * view.inverse_water_depth_mollified(U_i);
+          view_.momentum(U_i) * view_.inverse_water_depth_mollified(U_i);
       const auto v2_i = v_i.norm_square();
 
       return {/*h_min*/ h_i, /*h_max*/ h_i, /*v2_max*/ v2_i};
@@ -302,7 +302,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= limiter.relaxation_factor();
+      r *= limiter_.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       h_min *= std::max((Number(1.) - r), Number(eps));
@@ -320,7 +320,7 @@ namespace ryujin
         const state_type &new_U_i,
         const flux_contribution_type & /*new_flux_i*/)
     {
-      U_i = new_U_i;
+      U_i_ = new_U_i;
 
       auto &[h_min, h_max, v2_max] = bounds_;
 
@@ -328,9 +328,9 @@ namespace ryujin
       h_max = Number(0.);
       v2_max = Number(0.);
 
-      h_relaxation_numerator = Number(0.);
-      v2_relaxation_numerator = Number(0.);
-      relaxation_denominator = Number(0.);
+      h_relaxation_numerator_ = Number(0.);
+      v2_relaxation_numerator_ = Number(0.);
+      relaxation_denominator_ = Number(0.);
     }
 
 
@@ -345,8 +345,8 @@ namespace ryujin
     {
       /* The bar states: */
 
-      const auto f_star_ij = view.f(U_star_ij);
-      const auto f_star_ji = view.f(U_star_ji);
+      const auto f_star_ij = view_.f(U_star_ij);
+      const auto f_star_ji = view_.f(U_star_ji);
 
       /* bar state shifted by an affine shift: */
       const auto U_ij_bar =
@@ -359,12 +359,12 @@ namespace ryujin
 
       auto &[h_min, h_max, v2_max] = bounds_;
 
-      const auto h_bar_ij = view.water_depth(U_ij_bar);
+      const auto h_bar_ij = view_.water_depth(U_ij_bar);
       h_min = std::min(h_min, h_bar_ij);
       h_max = std::max(h_max, h_bar_ij);
 
-      const auto v_bar_ij = view.momentum(U_ij_bar) *
-                            view.inverse_water_depth_mollified(U_ij_bar);
+      const auto v_bar_ij = view_.momentum(U_ij_bar) *
+                            view_.inverse_water_depth_mollified(U_ij_bar);
       const auto v2_bar_ij = v_bar_ij.norm_square();
       v2_max = std::max(v2_max, v2_bar_ij);
 
@@ -373,17 +373,17 @@ namespace ryujin
       /* Use a uniform weight. */
       const auto beta_ij = Number(1.);
 
-      relaxation_denominator += std::abs(beta_ij);
+      relaxation_denominator_ += std::abs(beta_ij);
 
-      const auto h_i = view.water_depth(U_i);
-      const auto h_j = view.water_depth(U_j);
-      h_relaxation_numerator += beta_ij * (h_i + h_j);
+      const auto h_i = view_.water_depth(U_i_);
+      const auto h_j = view_.water_depth(U_j);
+      h_relaxation_numerator_ += beta_ij * (h_i + h_j);
 
       const auto vel_i =
-          view.momentum(U_i) * view.inverse_water_depth_mollified(U_i);
+          view_.momentum(U_i_) * view_.inverse_water_depth_mollified(U_i_);
       const auto vel_j =
-          view.momentum(U_j) * view.inverse_water_depth_mollified(U_j);
-      v2_relaxation_numerator +=
+          view_.momentum(U_j) * view_.inverse_water_depth_mollified(U_j);
+      v2_relaxation_numerator_ +=
           beta_ij * (-vel_i.norm_square() + vel_j.norm_square());
     }
 
@@ -401,13 +401,14 @@ namespace ryujin
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
-      const Number h_relaxed = ScalarNumber(2. * limiter.relaxation_factor()) *
-                               std::abs(h_relaxation_numerator) /
-                               (relaxation_denominator + Number(eps));
+      const Number h_relaxed = ScalarNumber(2. * limiter_.relaxation_factor()) *
+                               std::abs(h_relaxation_numerator_) /
+                               (relaxation_denominator_ + Number(eps));
 
-      const Number v2_relaxed = ScalarNumber(2. * limiter.relaxation_factor()) *
-                                std::abs(v2_relaxation_numerator) /
-                                (relaxation_denominator + Number(eps));
+      const Number v2_relaxed =
+          ScalarNumber(2. * limiter_.relaxation_factor()) *
+          std::abs(v2_relaxation_numerator_) /
+          (relaxation_denominator_ + Number(eps));
 
       h_min_relaxed = std::max(h_min_relaxed, h_min - h_relaxed);
       h_max_relaxed = std::min(h_max_relaxed, h_max + h_relaxed);

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -133,12 +133,12 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a Limiter
        * object as arguments
        */
-      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
           : view(view)
-          , parameters(parameters)
+          , limiter(limiter)
       {
       }
 
@@ -234,7 +234,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Limiter<ScalarNumber> &parameters;
+      const Limiter<ScalarNumber> &limiter;
 
       state_type U_i;
 
@@ -302,7 +302,7 @@ namespace ryujin
         r = dealii::Utilities::fixed_power<3>(std::sqrt(r)); // in 2D: ^ 3/4
       else if constexpr (dim == 1)                           //
         r = dealii::Utilities::fixed_power<3>(r);            // in 1D: ^ 3/2
-      r *= parameters.relaxation_factor();
+      r *= limiter.relaxation_factor();
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
       h_min *= std::max((Number(1.) - r), Number(eps));
@@ -401,15 +401,13 @@ namespace ryujin
 
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
 
-      const Number h_relaxed =
-          ScalarNumber(2. * parameters.relaxation_factor()) *
-          std::abs(h_relaxation_numerator) /
-          (relaxation_denominator + Number(eps));
+      const Number h_relaxed = ScalarNumber(2. * limiter.relaxation_factor()) *
+                               std::abs(h_relaxation_numerator) /
+                               (relaxation_denominator + Number(eps));
 
-      const Number v2_relaxed =
-          ScalarNumber(2. * parameters.relaxation_factor()) *
-          std::abs(v2_relaxation_numerator) /
-          (relaxation_denominator + Number(eps));
+      const Number v2_relaxed = ScalarNumber(2. * limiter.relaxation_factor()) *
+                                std::abs(v2_relaxation_numerator) /
+                                (relaxation_denominator + Number(eps));
 
       h_min_relaxed = std::max(h_min_relaxed, h_min - h_relaxed);
       h_max_relaxed = std::min(h_max_relaxed, h_max + h_relaxed);

--- a/source/shallow_water/limiter.h
+++ b/source/shallow_water/limiter.h
@@ -89,7 +89,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Limiter<ScalarNumber>;
 
@@ -112,11 +112,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters,
-                  const PrecomputedVector &precomputed_values)
+                  const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -124,7 +122,8 @@ namespace ryujin
        * Given a state @p U_i and an index @p i return "strict" bounds,
        * i.e., a minimal convex set containing the state.
        */
-      Bounds projection_bounds_from_state(const unsigned int i,
+      Bounds projection_bounds_from_state(const PrecomputedVectorView &pv,
+                                          const unsigned int i,
                                           const state_type &U_i) const;
 
       /**
@@ -153,10 +152,10 @@ namespace ryujin
        * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter_view.reset(i, U_i, flux_i);
+       *   limiter_view.reset(pv, i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       *     limiter_view.accumulate(pv, js, U_j, flux_j, scaled_c_ij,
        * affine_shift);
        *   }
        *   limiter_view.bounds(hd_i);
@@ -168,7 +167,8 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int i,
+      void reset(const PrecomputedVectorView &pv,
+                 const unsigned int i,
                  const state_type &U_i,
                  const flux_contribution_type &flux_i);
 
@@ -176,7 +176,8 @@ namespace ryujin
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const state_type &U_j,
+      void accumulate(const PrecomputedVectorView &pv,
+                      const state_type &U_j,
                       const state_type &U_star_ij,
                       const state_type &U_star_ji,
                       const dealii::Tensor<1, dim, Number> &scaled_c_ij,
@@ -210,7 +211,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       state_type U_i;
 
@@ -236,7 +236,9 @@ namespace ryujin
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline auto
     LimiterView<dim, Number>::projection_bounds_from_state(
-        const unsigned int /*i*/, const state_type &U_i) const -> Bounds
+        const PrecomputedVectorView & /*pv*/,
+        const unsigned int /*i*/,
+        const state_type &U_i) const -> Bounds
     {
       const auto view = hyperbolic_system.view<dim, Number>();
       const auto h_i = view.water_depth(U_i);
@@ -290,6 +292,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::reset(
+        const PrecomputedVectorView & /*pv*/,
         unsigned int /*i*/,
         const state_type &new_U_i,
         const flux_contribution_type & /*new_flux_i*/)
@@ -310,6 +313,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     DEAL_II_ALWAYS_INLINE inline void LimiterView<dim, Number>::accumulate(
+        const PrecomputedVectorView & /*pv*/,
         const state_type &U_j,
         const state_type &U_star_ij,
         const state_type &U_star_ji,

--- a/source/shallow_water/limiter.template.h
+++ b/source/shallow_water/limiter.template.h
@@ -201,7 +201,7 @@ namespace ryujin
          * Skip the quadratic Newton step if the window between t_l and t_r
          * is within the prescribed tolerance:
          */
-        const Number tolerance(parameters.newton_tolerance());
+        const Number tolerance(limiter.newton_tolerance());
         if (!(std::max(Number(0.), t_r - t_l - tolerance) == Number(0.))) {
           /*
            * If the bound is not satisfied, we need to find the root of a

--- a/source/shallow_water/limiter.template.h
+++ b/source/shallow_water/limiter.template.h
@@ -21,8 +21,6 @@ namespace ryujin
                                     const Number t_min /* = Number(0.) */,
                                     const Number t_max /* = Number(1.) */) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       bool success = true;
       Number t_l = t_min;
       Number t_r = t_max;

--- a/source/shallow_water/limiter.template.h
+++ b/source/shallow_water/limiter.template.h
@@ -29,8 +29,8 @@ namespace ryujin
 
       constexpr ScalarNumber min = std::numeric_limits<ScalarNumber>::min();
       constexpr ScalarNumber eps = std::numeric_limits<ScalarNumber>::epsilon();
-      const auto small = view.dry_state_relaxation_small();
-      const auto large = view.dry_state_relaxation_large();
+      const auto small = view_.dry_state_relaxation_small();
+      const auto large = view_.dry_state_relaxation_large();
       const auto relax_small = ScalarNumber(1. + small * eps);
       const auto relax = ScalarNumber(1. + large * eps);
 
@@ -41,12 +41,12 @@ namespace ryujin
        */
 
       {
-        auto h_U = view.water_depth(U);
-        const auto &h_P = view.water_depth(P);
+        auto h_U = view_.water_depth(U);
+        const auto &h_P = view_.water_depth(P);
 
-        const auto test_min = view.filter_dry_water_depth(
+        const auto test_min = view_.filter_dry_water_depth(
             std::max(Number(0.), h_U - relax * h_max));
-        const auto test_max = view.filter_dry_water_depth(
+        const auto test_max = view_.filter_dry_water_depth(
             std::max(Number(0.), h_min - relax * h_U));
 
         if (!(test_min == Number(0.) && test_max == Number(0.))) {
@@ -107,10 +107,10 @@ namespace ryujin
         /*
          * Verify that the new state is within bounds:
          */
-        const auto h_new = view.water_depth(U + t_r * P);
-        const auto test_new_min = view.filter_dry_water_depth(
+        const auto h_new = view_.water_depth(U + t_r * P);
+        const auto test_new_min = view_.filter_dry_water_depth(
             std::max(Number(0.), h_new - relax * h_max));
-        const auto test_new_max = view.filter_dry_water_depth(
+        const auto test_new_max = view_.filter_dry_water_depth(
             std::max(Number(0.), h_min - relax * h_new));
 
         if (!(test_new_min == Number(0.) && test_new_max == Number(0.))) {
@@ -144,8 +144,8 @@ namespace ryujin
         /* We first check if t_r is a good state */
 
         const auto U_r = U + t_r * P;
-        const auto h_r = view.water_depth(U_r);
-        const auto q_r = view.momentum(U_r);
+        const auto h_r = view_.water_depth(U_r);
+        const auto q_r = view_.momentum(U_r);
 
         const auto psi_r = relax_small * h_r * h_r * v2_max - q_r.norm_square();
 
@@ -170,8 +170,8 @@ namespace ryujin
 #endif
 
         const auto U_l = U + t_l * P;
-        const auto h_l = view.water_depth(U_l);
-        const auto q_l = view.momentum(U_l);
+        const auto h_l = view_.water_depth(U_l);
+        const auto q_l = view_.momentum(U_l);
 
         const auto psi_l = relax_small * h_l * h_l * v2_max - q_l.norm_square();
 
@@ -183,7 +183,7 @@ namespace ryujin
          * negative so that we do not accidentally trigger in "perfect" dry
          * states with h_l equal to zero.
          */
-        const auto filtered_h_l = view.filter_dry_water_depth(h_l);
+        const auto filtered_h_l = view_.filter_dry_water_depth(h_l);
         const auto lower_bound =
             (ScalarNumber(1.) - relax) * filtered_h_l * filtered_h_l * v2_max -
             ScalarNumber(100.) * eps;
@@ -201,7 +201,7 @@ namespace ryujin
          * Skip the quadratic Newton step if the window between t_l and t_r
          * is within the prescribed tolerance:
          */
-        const Number tolerance(limiter.newton_tolerance());
+        const Number tolerance(limiter_.newton_tolerance());
         if (!(std::max(Number(0.), t_r - t_l - tolerance) == Number(0.))) {
           /*
            * If the bound is not satisfied, we need to find the root of a
@@ -220,10 +220,10 @@ namespace ryujin
            * case of a quadratic function psi(t) both polynomials will coincide
            * so that (up to round-off error) t_l = t_r.
            */
-          const auto &h_U = view.water_depth(U);
-          const auto &h_P = view.water_depth(P);
-          const auto &q_U = view.momentum(U);
-          const auto &q_P = view.momentum(P);
+          const auto &h_U = view_.water_depth(U);
+          const auto &h_P = view_.water_depth(P);
+          const auto &q_U = view_.momentum(U);
+          const auto &q_P = view_.momentum(P);
 
           const auto dpsi_l =
               (h_U + t_l * h_P) * h_P * v2_max -
@@ -253,8 +253,8 @@ namespace ryujin
          */
         {
           const auto U_new = U + t_l * P;
-          const auto h_new = view.water_depth(U_new);
-          const auto q_new = view.momentum(U_new);
+          const auto h_new = view_.water_depth(U_new);
+          const auto q_new = view_.momentum(U_new);
 
           const auto psi_new =
               relax_small * h_new * h_new * v2_max - q_new.norm_square();

--- a/source/shallow_water/wave_speed_estimator.h
+++ b/source/shallow_water/wave_speed_estimator.h
@@ -107,13 +107,14 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a WaveSpeedEstimator
        * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view,
-                             const WaveSpeedEstimator<ScalarNumber> &parameters)
+      WaveSpeedEstimatorView(
+          const View &view,
+          const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
           : view(view)
-          , parameters(parameters)
+          , wave_speed_estimator(wave_speed_estimator)
       {
       }
 
@@ -171,7 +172,7 @@ namespace ryujin
 
     private:
       const View view;
-      const WaveSpeedEstimator<ScalarNumber> &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
       //@}
     };
   } // namespace ShallowWater

--- a/source/shallow_water/wave_speed_estimator.h
+++ b/source/shallow_water/wave_speed_estimator.h
@@ -11,6 +11,7 @@
 
 #include "hyperbolic_system.h"
 
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/point.h>
@@ -20,14 +21,34 @@ namespace ryujin
 {
   namespace ShallowWater
   {
+    template <int dim, typename Number = double>
+    class WaveSpeedEstimatorView;
+
     template <typename ScalarNumber = double>
     class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
+                         const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
       }
+
+      /**
+       * Return a view on the WaveSpeedEstimator for a given dimension @p dim
+       * and choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return WaveSpeedEstimatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
+    private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
     };
 
 
@@ -39,7 +60,7 @@ namespace ryujin
      *
      * @ingroup ShallowWaterEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class WaveSpeedEstimatorView
     {
     public:
@@ -81,11 +102,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -143,7 +164,7 @@ namespace ryujin
                               const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
       //@}
     };

--- a/source/shallow_water/wave_speed_estimator.h
+++ b/source/shallow_water/wave_speed_estimator.h
@@ -113,8 +113,8 @@ namespace ryujin
       WaveSpeedEstimatorView(
           const View &view,
           const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
-          : view(view)
-          , wave_speed_estimator(wave_speed_estimator)
+          : view_(view)
+          , wave_speed_estimator_(wave_speed_estimator)
       {
       }
 
@@ -171,8 +171,8 @@ namespace ryujin
                               const dealii::Tensor<1, dim, Number> &n_ij) const;
 
     private:
-      const View view;
-      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
+      const View view_;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator_;
       //@}
     };
   } // namespace ShallowWater

--- a/source/shallow_water/wave_speed_estimator.h
+++ b/source/shallow_water/wave_speed_estimator.h
@@ -36,6 +36,13 @@ namespace ryujin
       }
 
       /**
+       * Alias for the view on the wave speed estimator for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = WaveSpeedEstimatorView<dim, Number>;
+
+      /**
        * Return a view on the WaveSpeedEstimator for a given dimension @p dim
        * and choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -43,7 +50,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return WaveSpeedEstimatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -93,8 +100,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = WaveSpeedEstimator<ScalarNumber>;
-
       //@}
       /**
        * @name Compute wavespeed estimates
@@ -102,10 +107,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+      WaveSpeedEstimatorView(const View &view,
+                             const WaveSpeedEstimator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -165,7 +171,7 @@ namespace ryujin
 
     private:
       const View view;
-      const Parameters &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &parameters;
       //@}
     };
   } // namespace ShallowWater

--- a/source/shallow_water/wave_speed_estimator.h
+++ b/source/shallow_water/wave_speed_estimator.h
@@ -70,7 +70,7 @@ namespace ryujin
 
       using precomputed_type = typename View::precomputed_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
@@ -84,11 +84,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters,
-                             const PrecomputedVector &precomputed_values)
+                             const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -104,7 +102,8 @@ namespace ryujin
        * For two given states U_i a U_j and a (normalized) "direction" n_ij
        * compute an estimation of an upper bound for lambda.
        */
-      Number compute(const state_type &U_i,
+      Number compute(const PrecomputedVectorView &pv,
+                     const state_type &U_i,
                      const state_type &U_j,
                      const unsigned int i,
                      const unsigned int *js,
@@ -146,7 +145,6 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace ShallowWater

--- a/source/shallow_water/wave_speed_estimator.template.h
+++ b/source/shallow_water/wave_speed_estimator.template.h
@@ -240,6 +240,7 @@ namespace ryujin
 
     template <int dim, typename Number>
     Number WaveSpeedEstimatorView<dim, Number>::compute(
+        const PrecomputedVectorView & /*pv*/,
         const state_type &U_i,
         const state_type &U_j,
         const unsigned int /*i*/,

--- a/source/shallow_water/wave_speed_estimator.template.h
+++ b/source/shallow_water/wave_speed_estimator.template.h
@@ -27,7 +27,6 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::f(const primitive_type &riemann_data_Z,
                                            const Number &h) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const ScalarNumber gravity = view.gravity();
 
       const auto &[h_Z, u_Z, a_Z] = riemann_data_Z;
@@ -112,7 +111,6 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
       const ScalarNumber gravity = view.gravity();
       const auto gravity_inverse = ScalarNumber(1.) / gravity;
 
@@ -211,8 +209,6 @@ namespace ryujin
         const state_type &U, const dealii::Tensor<1, dim, Number> &n_ij) const
         -> primitive_type
     {
-      const auto view = hyperbolic_system.view<dim, Number>();
-
       const Number h = view.water_depth_sharp(U);
       const Number gravity = view.gravity();
 

--- a/source/shallow_water/wave_speed_estimator.template.h
+++ b/source/shallow_water/wave_speed_estimator.template.h
@@ -27,7 +27,7 @@ namespace ryujin
     WaveSpeedEstimatorView<dim, Number>::f(const primitive_type &riemann_data_Z,
                                            const Number &h) const
     {
-      const ScalarNumber gravity = view.gravity();
+      const ScalarNumber gravity = view_.gravity();
 
       const auto &[h_Z, u_Z, a_Z] = riemann_data_Z;
 
@@ -111,7 +111,7 @@ namespace ryujin
         const primitive_type &riemann_data_i,
         const primitive_type &riemann_data_j) const
     {
-      const ScalarNumber gravity = view.gravity();
+      const ScalarNumber gravity = view_.gravity();
       const auto gravity_inverse = ScalarNumber(1.) / gravity;
 
       const auto &[h_i, u_i, a_i] = riemann_data_i;
@@ -209,10 +209,10 @@ namespace ryujin
         const state_type &U, const dealii::Tensor<1, dim, Number> &n_ij) const
         -> primitive_type
     {
-      const Number h = view.water_depth_sharp(U);
-      const Number gravity = view.gravity();
+      const Number h = view_.water_depth_sharp(U);
+      const Number gravity = view_.gravity();
 
-      const auto velocity = view.momentum(U) / h;
+      const auto velocity = view_.momentum(U) / h;
       const auto projected_velocity = n_ij * velocity;
       const auto a = std::sqrt(h * gravity);
 

--- a/source/skeleton/description.h
+++ b/source/skeleton/description.h
@@ -32,24 +32,20 @@ namespace ryujin
     struct Description {
       using HyperbolicSystem = Skeleton::HyperbolicSystem;
 
-      template <int dim, typename Number = double>
-      using HyperbolicSystemView = Skeleton::HyperbolicSystemView<dim, Number>;
-
       using ParabolicSystem = ryujin::StubParabolicSystem;
 
       template <int dim, typename Number = double>
       using ParabolicModule =
           ryujin::StubParabolicModule<Description, dim, Number>;
 
-      template <int dim, typename Number = double>
-      using IndicatorView = Skeleton::IndicatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Indicator = Skeleton::Indicator<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using LimiterView = Skeleton::LimiterView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using Limiter = Skeleton::Limiter<ScalarNumber>;
 
-      template <int dim, typename Number = double>
-      using WaveSpeedEstimatorView =
-          Skeleton::WaveSpeedEstimatorView<dim, Number>;
+      template <typename ScalarNumber = double>
+      using WaveSpeedEstimator = Skeleton::WaveSpeedEstimator<ScalarNumber>;
     };
   } // namespace Skeleton
 } // namespace ryujin

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -50,6 +50,13 @@ namespace ryujin
       }
 
       /**
+       * Alias for the view on the hyperbolic system for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = HyperbolicSystemView<dim, Number>;
+
+      /**
        * Return a view on the Hyperbolic System for a given dimension @p
        * dim and choice of number type @p Number (which can be a scalar
        * float, or double, as well as a VectorizedArray holding packed
@@ -58,7 +65,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return HyperbolicSystemView<dim, Number>{*this};
+        return View<dim, Number>{*this};
       }
 
       /**

--- a/source/skeleton/hyperbolic_system.h
+++ b/source/skeleton/hyperbolic_system.h
@@ -230,12 +230,27 @@ namespace ryujin
           Vectors::MultiComponentVector<ScalarNumber, n_precomputed_values>;
 
       /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * states:
+       */
+      using PrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber, n_precomputed_values>;
+
+      /**
        * MulticomponentVector for storing a vector of precomputed initial
        * states:
        */
       using InitialPrecomputedVector =
           Vectors::MultiComponentVector<ScalarNumber,
                                         n_initial_precomputed_values>;
+
+      /**
+       * MulticomponentVectorView for accessing a vector of precomputed
+       * initial states:
+       */
+      using InitialPrecomputedVectorView =
+          Vectors::MultiComponentVectorView<ScalarNumber,
+                                            n_initial_precomputed_values>;
 
       //@}
       /**
@@ -298,8 +313,8 @@ namespace ryujin
        * For the Euler equations we simply compute <code>f(U_i)</code>.
        */
       flux_contribution_type
-      flux_contribution(const PrecomputedVector & /*pv*/,
-                        const InitialPrecomputedVector & /*piv*/,
+      flux_contribution(const PrecomputedVectorView & /*pv*/,
+                        const InitialPrecomputedVectorView & /*piv*/,
                         const unsigned int /*i*/,
                         const state_type & /*U_i*/) const
       {
@@ -307,8 +322,8 @@ namespace ryujin
       }
 
       flux_contribution_type
-      flux_contribution(const PrecomputedVector & /*pv*/,
-                        const InitialPrecomputedVector & /*piv*/,
+      flux_contribution(const PrecomputedVectorView & /*pv*/,
+                        const InitialPrecomputedVectorView & /*piv*/,
                         const unsigned int * /*js*/,
                         const state_type & /*U_j*/) const
       {
@@ -346,12 +361,12 @@ namespace ryujin
       /** We do not have source terms */
       static constexpr bool have_source_terms = false;
 
-      state_type nodal_source(const PrecomputedVector & /*pv*/,
+      state_type nodal_source(const PrecomputedVectorView & /*pv*/,
                               const unsigned int /*i*/,
                               const state_type & /*U_i*/,
                               const ScalarNumber /*tau*/) const = delete;
 
-      state_type nodal_source(const PrecomputedVector & /*pv*/,
+      state_type nodal_source(const PrecomputedVectorView & /*pv*/,
                               const unsigned int * /*js*/,
                               const state_type & /*U_j*/,
                               const ScalarNumber /*tau*/) const = delete;

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -36,6 +36,13 @@ namespace ryujin
       }
 
       /**
+       * Alias for the view on the indicator for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = IndicatorView<dim, Number>;
+
+      /**
        * Return a view on the Indicator for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -43,7 +50,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return IndicatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -75,8 +82,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Indicator<ScalarNumber>;
-
       //@}
       /**
        * @name Stencil-based computation of indicators
@@ -98,10 +103,10 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      IndicatorView(const View &view, const Parameters &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -147,7 +152,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Indicator<ScalarNumber> &parameters;
 
       //@}
     };

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -103,12 +103,12 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and an Indicator
        * object as arguments
        */
-      IndicatorView(const View &view, const Indicator<ScalarNumber> &parameters)
+      IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
           : view(view)
-          , parameters(parameters)
+          , indicator(indicator)
       {
       }
 
@@ -152,7 +152,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Indicator<ScalarNumber> &parameters;
+      const Indicator<ScalarNumber> &indicator;
 
       //@}
     };

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -107,8 +107,8 @@ namespace ryujin
        * object as arguments
        */
       IndicatorView(const View &view, const Indicator<ScalarNumber> &indicator)
-          : view(view)
-          , indicator(indicator)
+          : view_(view)
+          , indicator_(indicator)
       {
       }
 
@@ -151,8 +151,8 @@ namespace ryujin
        */
       //@{
 
-      const View view;
-      const Indicator<ScalarNumber> &indicator;
+      const View view_;
+      const Indicator<ScalarNumber> &indicator_;
 
       //@}
     };

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -52,7 +52,7 @@ namespace ryujin
 
       using state_type = typename View::state_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Indicator<ScalarNumber>;
 
@@ -65,10 +65,10 @@ namespace ryujin
        * IndicatorView<dim, Number> indicator_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   indicator_view.reset(i, U_i);
+       *   indicator_view.reset(pv, i, U_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     indicator_view.accumulate(js, U_j, c_ij);
+       *     indicator_view.accumulate(pv, js, U_j, c_ij);
        *   }
        *   indicator_view.alpha(hd_i);
        * }
@@ -80,11 +80,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters,
-                    const PrecomputedVector &precomputed_values)
+                    const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -92,7 +90,9 @@ namespace ryujin
        * Reset temporary storage and initialize for a new row corresponding
        * to state vector U_i.
        */
-      void reset(const unsigned int /*i*/, const state_type & /*U_i*/)
+      void reset(const PrecomputedVectorView & /*pv*/,
+                 const unsigned int /*i*/,
+                 const state_type & /*U_i*/)
       {
         // empty
       }
@@ -101,7 +101,8 @@ namespace ryujin
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int * /*js*/,
+      void accumulate(const PrecomputedVectorView & /*pv*/,
+                      const unsigned int * /*js*/,
                       const state_type & /*U_j*/,
                       const dealii::Tensor<1, dim, Number> & /*c_ij*/)
       {
@@ -126,7 +127,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       //@}
     };

--- a/source/skeleton/indicator.h
+++ b/source/skeleton/indicator.h
@@ -10,6 +10,7 @@
 #include "hyperbolic_system.h"
 
 #include <multicomponent_vector.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/parameter_acceptor.h>
@@ -20,14 +21,34 @@ namespace ryujin
 {
   namespace Skeleton
   {
+    template <int dim, typename Number = double>
+    class IndicatorView;
+
     template <typename ScalarNumber = double>
     class Indicator : public dealii::ParameterAcceptor
     {
     public:
-      Indicator(const std::string &subsection = "/Indicator")
+      Indicator(const HyperbolicSystem &hyperbolic_system,
+                const std::string &subsection = "/Indicator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
       }
+
+      /**
+       * Return a view on the Indicator for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return IndicatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
+    private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
     };
 
 
@@ -37,7 +58,7 @@ namespace ryujin
      *
      * @ingroup SkeletonEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class IndicatorView
     {
     public:
@@ -77,11 +98,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      IndicatorView(const HyperbolicSystem &hyperbolic_system,
-                    const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      IndicatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -125,7 +146,7 @@ namespace ryujin
        */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       //@}

--- a/source/skeleton/initial_state_library.template.h
+++ b/source/skeleton/initial_state_library.template.h
@@ -21,8 +21,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using initial_state_list_type =
         std::set<std::unique_ptr<InitialState<Description, dim, Number>>>;

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -12,18 +12,24 @@
 #include <compile_time_options.h>
 #include <multicomponent_vector.h>
 #include <newton.h>
+#include <observer_pointer.h>
 #include <simd.h>
 
 namespace ryujin
 {
   namespace Skeleton
   {
+    template <int dim, typename Number = double>
+    class LimiterView;
+
     template <typename ScalarNumber = double>
     class Limiter : public dealii::ParameterAcceptor
     {
     public:
-      Limiter(const std::string &subsection = "/Limiter")
+      Limiter(const HyperbolicSystem &hyperbolic_system,
+              const std::string &subsection = "/Limiter")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
         iterations_ = 2;
         add_parameter(
@@ -32,7 +38,20 @@ namespace ryujin
 
       ACCESSOR_READ_ONLY(iterations);
 
+      /**
+       * Return a view on the Limiter for a given dimension @p dim and
+       * choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return LimiterView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
     private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
       unsigned int iterations_;
     };
 
@@ -42,7 +61,7 @@ namespace ryujin
      *
      * @ingroup SkeletonEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class LimiterView
     {
     public:
@@ -79,11 +98,11 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      LimiterView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -201,7 +220,7 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
 
       Bounds bounds_;

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -171,8 +171,8 @@ namespace ryujin
        */
       void reset(const PrecomputedVectorView & /*pv*/,
                  const unsigned int /*i*/,
-                 const state_type & /*new_U_i*/,
-                 const flux_contribution_type & /*new_flux_i*/)
+                 const state_type & /*U_i*/,
+                 const flux_contribution_type & /*flux_i*/)
       {
         // empty
       }

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -39,6 +39,13 @@ namespace ryujin
       ACCESSOR_READ_ONLY(iterations);
 
       /**
+       * Alias for the view on the limiter for a given dimension @p dim
+       * and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = LimiterView<dim, Number>;
+
+      /**
        * Return a view on the Limiter for a given dimension @p dim and
        * choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -46,7 +53,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return LimiterView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -80,8 +87,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = Limiter<ScalarNumber>;
-
       //@}
       /**
        * @name Computation and manipulation of bounds
@@ -98,10 +103,10 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      LimiterView(const View &view, const Parameters &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -221,7 +226,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Parameters &parameters;
+      const Limiter<ScalarNumber> &parameters;
 
       Bounds bounds_;
       //@}

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -59,7 +59,7 @@ namespace ryujin
 
       using flux_contribution_type = typename View::flux_contribution_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = Limiter<ScalarNumber>;
 
@@ -82,11 +82,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       LimiterView(const HyperbolicSystem &hyperbolic_system,
-                  const Parameters &parameters,
-                  const PrecomputedVector &precomputed_values)
+                  const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -94,7 +92,8 @@ namespace ryujin
        * Given a state @p U_i and an index @p i return "strict" bounds,
        * i.e., a minimal convex set containing the state.
        */
-      Bounds projection_bounds_from_state(const unsigned int /*i*/,
+      Bounds projection_bounds_from_state(const PrecomputedVectorView & /*pv*/,
+                                          const unsigned int /*i*/,
                                           const state_type & /*U_i*/) const
       {
         return Bounds{};
@@ -131,10 +130,10 @@ namespace ryujin
        * LimiterView<dim, Number> limiter_view;
        * for (unsigned int i = n_internal; i < n_owned; ++i) {
        *   // ...
-       *   limiter_view.reset(i, U_i, flux_i);
+       *   limiter_view.reset(pv, i, U_i, flux_i);
        *   for (unsigned int col_idx = 1; col_idx < row_length; ++col_idx) {
        *     // ...
-       *     limiter_view.accumulate(js, U_j, flux_j, scaled_c_ij,
+       *     limiter_view.accumulate(pv, js, U_j, flux_j, scaled_c_ij,
        * affine_shift);
        *   }
        *   limiter_view.bounds(hd_i);
@@ -146,7 +145,8 @@ namespace ryujin
       /**
        * Reset temporary storage
        */
-      void reset(const unsigned int /*i*/,
+      void reset(const PrecomputedVectorView & /*pv*/,
+                 const unsigned int /*i*/,
                  const state_type & /*new_U_i*/,
                  const flux_contribution_type & /*new_flux_i*/)
       {
@@ -157,7 +157,8 @@ namespace ryujin
        * When looping over the sparsity row, add the contribution associated
        * with the neighboring state U_j.
        */
-      void accumulate(const unsigned int * /*js*/,
+      void accumulate(const PrecomputedVectorView & /*pv*/,
+                      const unsigned int * /*js*/,
                       const state_type & /*U_j*/,
                       const flux_contribution_type & /*flux_j*/,
                       const dealii::Tensor<1, dim, Number> & /*scaled_c_ij*/,
@@ -202,7 +203,6 @@ namespace ryujin
 
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
 
       Bounds bounds_;
       //@}

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -103,12 +103,12 @@ namespace ryujin
       using Bounds = std::array<Number, n_bounds>;
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a Limiter
        * object as arguments
        */
-      LimiterView(const View &view, const Limiter<ScalarNumber> &parameters)
+      LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
           : view(view)
-          , parameters(parameters)
+          , limiter(limiter)
       {
       }
 
@@ -226,7 +226,7 @@ namespace ryujin
       //@{
 
       const View view;
-      const Limiter<ScalarNumber> &parameters;
+      const Limiter<ScalarNumber> &limiter;
 
       Bounds bounds_;
       //@}

--- a/source/skeleton/limiter.h
+++ b/source/skeleton/limiter.h
@@ -107,8 +107,8 @@ namespace ryujin
        * object as arguments
        */
       LimiterView(const View &view, const Limiter<ScalarNumber> &limiter)
-          : view(view)
-          , limiter(limiter)
+          : view_(view)
+          , limiter_(limiter)
       {
       }
 
@@ -225,8 +225,8 @@ namespace ryujin
       /** @name Arguments and internal fields */
       //@{
 
-      const View view;
-      const Limiter<ScalarNumber> &limiter;
+      const View view_;
+      const Limiter<ScalarNumber> &limiter_;
 
       Bounds bounds_;
       //@}

--- a/source/skeleton/wave_speed_estimator.h
+++ b/source/skeleton/wave_speed_estimator.h
@@ -34,6 +34,13 @@ namespace ryujin
       }
 
       /**
+       * Alias for the view on the wave speed estimator for a given dimension @p
+       * dim and choice of number type @p Number.
+       */
+      template <int dim, typename Number = double>
+      using View = WaveSpeedEstimatorView<dim, Number>;
+
+      /**
        * Return a view on the WaveSpeedEstimator for a given dimension @p dim
        * and choice of number type @p Number (which can be a scalar float, or
        * double, as well as a VectorizedArray holding packed scalars).
@@ -41,7 +48,7 @@ namespace ryujin
       template <int dim, typename Number>
       auto view() const
       {
-        return WaveSpeedEstimatorView<dim, Number>{
+        return View<dim, Number>{
             hyperbolic_system_->template view<dim, Number>(), *this};
       }
 
@@ -75,8 +82,6 @@ namespace ryujin
 
       using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
-      using Parameters = WaveSpeedEstimator<ScalarNumber>;
-
       //@}
       /**
        * @name Compute wavespeed estimates
@@ -84,10 +89,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a
-       * Parameters object as arguments
+       * Constructor taking a HyperbolicSystemView and a parameters
+       * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+      WaveSpeedEstimatorView(const View &view,
+                             const WaveSpeedEstimator<ScalarNumber> &parameters)
           : view(view)
           , parameters(parameters)
       {
@@ -109,7 +115,7 @@ namespace ryujin
 
     private:
       const View view;
-      const Parameters &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &parameters;
       //@}
     };
   } // namespace Skeleton

--- a/source/skeleton/wave_speed_estimator.h
+++ b/source/skeleton/wave_speed_estimator.h
@@ -52,7 +52,7 @@ namespace ryujin
 
       using state_type = typename View::state_type;
 
-      using PrecomputedVector = typename View::PrecomputedVector;
+      using PrecomputedVectorView = typename View::PrecomputedVectorView;
 
       using Parameters = WaveSpeedEstimator<ScalarNumber>;
 
@@ -66,11 +66,9 @@ namespace ryujin
        * Constructor taking a HyperbolicSystem instance as argument
        */
       WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters,
-                             const PrecomputedVector &precomputed_values)
+                             const Parameters &parameters)
           : hyperbolic_system(hyperbolic_system)
           , parameters(parameters)
-          , precomputed_values(precomputed_values)
       {
       }
 
@@ -78,7 +76,8 @@ namespace ryujin
        * For two given states U_i a U_j and a (normalized) "direction" n_ij
        * compute an estimation of an upper bound for lambda.
        */
-      Number compute(const state_type & /*U_i*/,
+      Number compute(const PrecomputedVectorView & /*pv*/,
+                     const state_type & /*U_i*/,
                      const state_type & /*U_j*/,
                      const unsigned int /*i*/,
                      const unsigned int * /*js*/,
@@ -90,7 +89,6 @@ namespace ryujin
     private:
       const HyperbolicSystem &hyperbolic_system;
       const Parameters &parameters;
-      const PrecomputedVector &precomputed_values;
       //@}
     };
   } // namespace Skeleton

--- a/source/skeleton/wave_speed_estimator.h
+++ b/source/skeleton/wave_speed_estimator.h
@@ -9,6 +9,7 @@
 
 #include "hyperbolic_system.h"
 
+#include <observer_pointer.h>
 #include <simd.h>
 
 #include <deal.II/base/point.h>
@@ -18,14 +19,34 @@ namespace ryujin
 {
   namespace Skeleton
   {
+    template <int dim, typename Number = double>
+    class WaveSpeedEstimatorView;
+
     template <typename ScalarNumber = double>
     class WaveSpeedEstimator : public dealii::ParameterAcceptor
     {
     public:
-      WaveSpeedEstimator(const std::string &subsection = "/WaveSpeedEstimator")
+      WaveSpeedEstimator(const HyperbolicSystem &hyperbolic_system,
+                         const std::string &subsection = "/WaveSpeedEstimator")
           : ParameterAcceptor(subsection)
+          , hyperbolic_system_(&hyperbolic_system)
       {
       }
+
+      /**
+       * Return a view on the WaveSpeedEstimator for a given dimension @p dim
+       * and choice of number type @p Number (which can be a scalar float, or
+       * double, as well as a VectorizedArray holding packed scalars).
+       */
+      template <int dim, typename Number>
+      auto view() const
+      {
+        return WaveSpeedEstimatorView<dim, Number>{
+            hyperbolic_system_->template view<dim, Number>(), *this};
+      }
+
+    private:
+      dealii::ObserverPointer<const HyperbolicSystem> hyperbolic_system_;
     };
 
 
@@ -37,7 +58,7 @@ namespace ryujin
      *
      * @ingroup SkeletonEquations
      */
-    template <int dim, typename Number = double>
+    template <int dim, typename Number>
     class WaveSpeedEstimatorView
     {
     public:
@@ -63,11 +84,11 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystem instance as argument
+       * Constructor taking a HyperbolicSystemView and a
+       * Parameters object as arguments
        */
-      WaveSpeedEstimatorView(const HyperbolicSystem &hyperbolic_system,
-                             const Parameters &parameters)
-          : hyperbolic_system(hyperbolic_system)
+      WaveSpeedEstimatorView(const View &view, const Parameters &parameters)
+          : view(view)
           , parameters(parameters)
       {
       }
@@ -87,7 +108,7 @@ namespace ryujin
       }
 
     private:
-      const HyperbolicSystem &hyperbolic_system;
+      const View view;
       const Parameters &parameters;
       //@}
     };

--- a/source/skeleton/wave_speed_estimator.h
+++ b/source/skeleton/wave_speed_estimator.h
@@ -89,13 +89,14 @@ namespace ryujin
       //@{
 
       /**
-       * Constructor taking a HyperbolicSystemView and a parameters
+       * Constructor taking a HyperbolicSystemView and a WaveSpeedEstimator
        * object as arguments
        */
-      WaveSpeedEstimatorView(const View &view,
-                             const WaveSpeedEstimator<ScalarNumber> &parameters)
+      WaveSpeedEstimatorView(
+          const View &view,
+          const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
           : view(view)
-          , parameters(parameters)
+          , wave_speed_estimator(wave_speed_estimator)
       {
       }
 
@@ -115,7 +116,7 @@ namespace ryujin
 
     private:
       const View view;
-      const WaveSpeedEstimator<ScalarNumber> &parameters;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
       //@}
     };
   } // namespace Skeleton

--- a/source/skeleton/wave_speed_estimator.h
+++ b/source/skeleton/wave_speed_estimator.h
@@ -95,8 +95,8 @@ namespace ryujin
       WaveSpeedEstimatorView(
           const View &view,
           const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator)
-          : view(view)
-          , wave_speed_estimator(wave_speed_estimator)
+          : view_(view)
+          , wave_speed_estimator_(wave_speed_estimator)
       {
       }
 
@@ -115,8 +115,8 @@ namespace ryujin
       }
 
     private:
-      const View view;
-      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator;
+      const View view_;
+      const WaveSpeedEstimator<ScalarNumber> &wave_speed_estimator_;
       //@}
     };
   } // namespace Skeleton

--- a/source/solution_transfer.h
+++ b/source/solution_transfer.h
@@ -38,8 +38,11 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
+
+    using Limiter = typename Description::template Limiter<Number>;
+
+    using LimiterView = typename Limiter::template View<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 
@@ -51,14 +54,12 @@ namespace ryujin
     /**
      * The number of stored entries in the bounds array.
      */
-    static constexpr unsigned int n_bounds =
-        Description::template LimiterView<dim, Number>::n_bounds;
+    static constexpr unsigned int n_bounds = LimiterView::n_bounds;
 
     /**
      * Array type used to store accumulated bounds.
      */
-    using Bounds =
-        typename Description::template LimiterView<dim, Number>::Bounds;
+    using Bounds = typename LimiterView::Bounds;
 
     //@}
     /**
@@ -156,8 +157,7 @@ namespace ryujin
      */
     //@{
 
-    typename Description::template LimiterView<dim, Number>::Parameters
-        limiter_;
+    Limiter limiter_;
 
     //@}
     /**

--- a/source/solution_transfer.template.h
+++ b/source/solution_transfer.template.h
@@ -163,8 +163,7 @@ namespace ryujin
 
           using LimiterView =
               typename Description::template LimiterView<dim, Number>;
-          const LimiterView limiter_view(
-              *hyperbolic_system_, limiter_, precomputed);
+          const LimiterView limiter_view(*hyperbolic_system_, limiter_);
 
           /*
            * Collect state values for packing:
@@ -274,8 +273,8 @@ namespace ryujin
                 const auto U_i = read_tensor(U, global_i);
                 const auto local_i =
                     scalar_partitioner->global_to_local(global_i);
-                bounds =
-                    limiter_view.projection_bounds_from_state(local_i, U_i);
+                bounds = limiter_view.projection_bounds_from_state(
+                    precomputed, local_i, U_i);
               }
 
               for (auto &it : state_values_quad)
@@ -286,8 +285,8 @@ namespace ryujin
                 const auto U_i = read_tensor(U, global_i);
                 const auto local_i =
                     scalar_partitioner->global_to_local(global_i);
-                const auto bounds_i =
-                    limiter_view.projection_bounds_from_state(local_i, U_i);
+                const auto bounds_i = limiter_view.projection_bounds_from_state(
+                    precomputed, local_i, U_i);
                 bounds = limiter_view.combine_bounds(bounds, bounds_i);
 
                 for (unsigned int q = 0; q < quadrature.size(); ++q) {
@@ -739,7 +738,7 @@ namespace ryujin
     update_precomputed_values();
 
     using LimiterView = typename Description::template LimiterView<dim, Number>;
-    const LimiterView limiter_view(*hyperbolic_system_, limiter_, precomputed);
+    const LimiterView limiter_view(*hyperbolic_system_, limiter_);
 
     /*
      * Step 1: compute low-order update P_ij matrix, and bounds:
@@ -765,7 +764,8 @@ namespace ryujin
       const auto U_i_star = projected_state.read_tensor(local_i) / m_i_star;
 
       auto &bounds = bounds_map[local_i]; /* by reference */
-      bounds = limiter_view.projection_bounds_from_state(local_i, U_i_star);
+      bounds = limiter_view.projection_bounds_from_state(
+          precomputed, local_i, U_i_star);
 
       /* The value obtained from the affine constraints object: */
       state_type U_i_interp;
@@ -779,8 +779,8 @@ namespace ryujin
         const auto local_k = scalar_partitioner->global_to_local(global_k);
         const auto U_k = new_U.read_tensor(local_k);
 
-        const auto bounds_k =
-            limiter_view.projection_bounds_from_state(local_k, U_k);
+        const auto bounds_k = limiter_view.projection_bounds_from_state(
+            precomputed, local_k, U_k);
         bounds = limiter_view.combine_bounds(bounds, bounds_k);
 
         projected_state.add_tensor(c_k * m_i_star * U_i_star, local_k);
@@ -835,8 +835,8 @@ namespace ryujin
         for (const auto &[global_k, c_k] : line.entries) {
           const auto local_k = scalar_partitioner->global_to_local(global_k);
           const auto U_k = new_U.read_tensor(local_k);
-          const auto bounds_k =
-              limiter_view.projection_bounds_from_state(local_k, U_k);
+          const auto bounds_k = limiter_view.projection_bounds_from_state(
+              precomputed, local_k, U_k);
           bounds = limiter_view.combine_bounds(bounds, bounds_k);
 
           const auto m_k = projected_mass.local_element(local_k);

--- a/source/solution_transfer.template.h
+++ b/source/solution_transfer.template.h
@@ -35,7 +35,7 @@ namespace ryujin
       const ParabolicSystem &parabolic_system,
       const std::string &subsection /* = "/SolutionTransfer" */)
       : ParameterAcceptor(subsection)
-      , limiter_(subsection + "/mass transfer limiter")
+      , limiter_(hyperbolic_system, subsection + "/mass transfer limiter")
       , mpi_ensemble_(mpi_ensemble)
       , offline_data_(&offline_data)
       , hyperbolic_system_(&hyperbolic_system)
@@ -161,9 +161,7 @@ namespace ryujin
           /* precomputed needs to be valid for bounds computation */
           const auto &precomputed = std::get<1>(old_state_vector);
 
-          using LimiterView =
-              typename Description::template LimiterView<dim, Number>;
-          const LimiterView limiter_view(*hyperbolic_system_, limiter_);
+          const auto limiter_view = limiter_.template view<dim, Number>();
 
           /*
            * Collect state values for packing:
@@ -737,8 +735,7 @@ namespace ryujin
 
     update_precomputed_values();
 
-    using LimiterView = typename Description::template LimiterView<dim, Number>;
-    const LimiterView limiter_view(*hyperbolic_system_, limiter_);
+    const auto limiter_view = limiter_.template view<dim, Number>();
 
     /*
      * Step 1: compute low-order update P_ij matrix, and bounds:

--- a/source/stub_parabolic_module.h
+++ b/source/stub_parabolic_module.h
@@ -33,8 +33,7 @@ namespace ryujin
 
     using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using ParabolicSystem = typename Description::ParabolicSystem;
 

--- a/source/time_integrator.h
+++ b/source/time_integrator.h
@@ -260,8 +260,7 @@ namespace ryujin
 
     using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using ParabolicSystem = typename Description::ParabolicSystem;
 

--- a/source/time_loop.h
+++ b/source/time_loop.h
@@ -44,8 +44,7 @@ namespace ryujin
 
     using HyperbolicSystem = typename Description::HyperbolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     using ParabolicSystem = typename Description::ParabolicSystem;
 

--- a/source/vtu_output.h
+++ b/source/vtu_output.h
@@ -38,8 +38,7 @@ namespace ryujin
     using HyperbolicSystem = typename Description::HyperbolicSystem;
     using ParabolicSystem = typename Description::ParabolicSystem;
 
-    using View =
-        typename Description::template HyperbolicSystemView<dim, Number>;
+    using View = typename HyperbolicSystem::template View<dim, Number>;
 
     static constexpr auto problem_dimension = View::problem_dimension;
 

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -21,13 +21,13 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  LimiterView<dim, double>::Parameters limiter;
+  LimiterView<dim, double>::Parameters limiter(hyperbolic_system);
 
   using state_type = HyperbolicSystemView<dim, double>::state_type;
 
   using bounds_type = LimiterView<dim, double>::Bounds;
 
-  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter);
+  const auto limiter_view = limiter.view<dim, double>();
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -27,14 +27,7 @@ int main()
 
   using bounds_type = LimiterView<dim, double>::Bounds;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter, dummy);
+  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler/limiter.cc
+++ b/tests/euler/limiter.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  LimiterView<dim, double>::Parameters limiter(hyperbolic_system);
+  Limiter<double> limiter(hyperbolic_system);
 
   using state_type = HyperbolicSystemView<dim, double>::state_type;
 

--- a/tests/euler/wave_speed_estimator.cc
+++ b/tests/euler/wave_speed_estimator.cc
@@ -30,14 +30,8 @@ int main()
 
   const auto gamma = hyperbolic_system.view<dim, Number>().gamma();
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, Number>::n_precomputed_values;
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
-      hyperbolic_system, wave_speed_estimator, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
+                                                        wave_speed_estimator);
 
   std::stringstream parameters;
   parameters << "subsection WaveSpeedEstimator\n"

--- a/tests/euler/wave_speed_estimator.cc
+++ b/tests/euler/wave_speed_estimator.cc
@@ -26,12 +26,13 @@ int main()
   using Number = NUMBER;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, Number>::Parameters wave_speed_estimator;
+  WaveSpeedEstimatorView<dim, Number>::Parameters wave_speed_estimator(
+      hyperbolic_system);
 
   const auto gamma = hyperbolic_system.view<dim, Number>().gamma();
 
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
-                                                        wave_speed_estimator);
+  const auto wave_speed_estimator_view =
+      wave_speed_estimator.view<dim, Number>();
 
   std::stringstream parameters;
   parameters << "subsection WaveSpeedEstimator\n"

--- a/tests/euler/wave_speed_estimator.cc
+++ b/tests/euler/wave_speed_estimator.cc
@@ -26,8 +26,7 @@ int main()
   using Number = NUMBER;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, Number>::Parameters wave_speed_estimator(
-      hyperbolic_system);
+  WaveSpeedEstimator<double> wave_speed_estimator(hyperbolic_system);
 
   const auto gamma = hyperbolic_system.view<dim, Number>().gamma();
 

--- a/tests/euler_aeos/limiter-NASG.cc
+++ b/tests/euler_aeos/limiter-NASG.cc
@@ -45,14 +45,7 @@ int main()
 
   using bounds_type = LimiterView<dim, double>::Bounds;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter, dummy);
+  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler_aeos/limiter-NASG.cc
+++ b/tests/euler_aeos/limiter-NASG.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  LimiterView<dim, double>::Parameters limiter(hyperbolic_system);
+  Limiter<double> limiter(hyperbolic_system);
 
   const auto set_covolume = [&](const double covolume) {
     /*

--- a/tests/euler_aeos/limiter-NASG.cc
+++ b/tests/euler_aeos/limiter-NASG.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  LimiterView<dim, double>::Parameters limiter;
+  LimiterView<dim, double>::Parameters limiter(hyperbolic_system);
 
   const auto set_covolume = [&](const double covolume) {
     /*
@@ -45,7 +45,7 @@ int main()
 
   using bounds_type = LimiterView<dim, double>::Bounds;
 
-  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter);
+  const auto limiter_view = limiter.view<dim, double>();
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  LimiterView<dim, double>::Parameters limiter;
+  LimiterView<dim, double>::Parameters limiter(hyperbolic_system);
 
   const auto set_covolume = [&](const double covolume) {
     /*
@@ -43,7 +43,7 @@ int main()
 
   using bounds_type = LimiterView<dim, double>::Bounds;
 
-  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter);
+  const auto limiter_view = limiter.view<dim, double>();
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  LimiterView<dim, double>::Parameters limiter(hyperbolic_system);
+  Limiter<double> limiter(hyperbolic_system);
 
   const auto set_covolume = [&](const double covolume) {
     /*

--- a/tests/euler_aeos/limiter.cc
+++ b/tests/euler_aeos/limiter.cc
@@ -43,14 +43,7 @@ int main()
 
   using bounds_type = LimiterView<dim, double>::Bounds;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter, dummy);
+  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler_aeos/wave_speed_estimator-strict-NASG.cc
+++ b/tests/euler_aeos/wave_speed_estimator-strict-NASG.cc
@@ -22,10 +22,11 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
+      hyperbolic_system);
 
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
-                                                        wave_speed_estimator);
+  const auto wave_speed_estimator_view =
+      wave_speed_estimator.view<dim, double>();
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"

--- a/tests/euler_aeos/wave_speed_estimator-strict-NASG.cc
+++ b/tests/euler_aeos/wave_speed_estimator-strict-NASG.cc
@@ -24,14 +24,8 @@ int main()
   HyperbolicSystem hyperbolic_system;
   WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
-      hyperbolic_system, wave_speed_estimator, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
+                                                        wave_speed_estimator);
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"

--- a/tests/euler_aeos/wave_speed_estimator-strict-NASG.cc
+++ b/tests/euler_aeos/wave_speed_estimator-strict-NASG.cc
@@ -22,8 +22,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
-      hyperbolic_system);
+  WaveSpeedEstimator<double> wave_speed_estimator(hyperbolic_system);
 
   const auto wave_speed_estimator_view =
       wave_speed_estimator.view<dim, double>();

--- a/tests/euler_aeos/wave_speed_estimator-strict.cc
+++ b/tests/euler_aeos/wave_speed_estimator-strict.cc
@@ -17,8 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
-      hyperbolic_system);
+  WaveSpeedEstimator<double> wave_speed_estimator(hyperbolic_system);
 
   const auto wave_speed_estimator_view =
       wave_speed_estimator.view<dim, double>();

--- a/tests/euler_aeos/wave_speed_estimator-strict.cc
+++ b/tests/euler_aeos/wave_speed_estimator-strict.cc
@@ -19,14 +19,8 @@ int main()
   HyperbolicSystem hyperbolic_system;
   WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
-      hyperbolic_system, wave_speed_estimator, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
+                                                        wave_speed_estimator);
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"

--- a/tests/euler_aeos/wave_speed_estimator-strict.cc
+++ b/tests/euler_aeos/wave_speed_estimator-strict.cc
@@ -17,10 +17,11 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
+      hyperbolic_system);
 
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
-                                                        wave_speed_estimator);
+  const auto wave_speed_estimator_view =
+      wave_speed_estimator.view<dim, double>();
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"

--- a/tests/euler_aeos/wave_speed_estimator.cc
+++ b/tests/euler_aeos/wave_speed_estimator.cc
@@ -17,8 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
-      hyperbolic_system);
+  WaveSpeedEstimator<double> wave_speed_estimator(hyperbolic_system);
 
   const auto wave_speed_estimator_view =
       wave_speed_estimator.view<dim, double>();

--- a/tests/euler_aeos/wave_speed_estimator.cc
+++ b/tests/euler_aeos/wave_speed_estimator.cc
@@ -19,14 +19,8 @@ int main()
   HyperbolicSystem hyperbolic_system;
   WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
-      hyperbolic_system, wave_speed_estimator, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
+                                                        wave_speed_estimator);
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"

--- a/tests/euler_aeos/wave_speed_estimator.cc
+++ b/tests/euler_aeos/wave_speed_estimator.cc
@@ -17,10 +17,11 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
+      hyperbolic_system);
 
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
-                                                        wave_speed_estimator);
+  const auto wave_speed_estimator_view =
+      wave_speed_estimator.view<dim, double>();
 
   std::stringstream parameters;
   parameters << "subsection HyperbolicSystem\n"

--- a/tests/euler_barotropic/limiter.cc
+++ b/tests/euler_barotropic/limiter.cc
@@ -21,13 +21,13 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  LimiterView<dim, double>::Parameters limiter;
+  LimiterView<dim, double>::Parameters limiter(hyperbolic_system);
 
   using state_type = HyperbolicSystemView<dim, double>::state_type;
 
   using bounds_type = LimiterView<dim, double>::Bounds;
 
-  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter);
+  const auto limiter_view = limiter.view<dim, double>();
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler_barotropic/limiter.cc
+++ b/tests/euler_barotropic/limiter.cc
@@ -27,14 +27,7 @@ int main()
 
   using bounds_type = LimiterView<dim, double>::Bounds;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter, dummy);
+  LimiterView<dim, double> limiter_view(hyperbolic_system, limiter);
 
   const auto view = hyperbolic_system.template view<dim, double>();
 

--- a/tests/euler_barotropic/limiter.cc
+++ b/tests/euler_barotropic/limiter.cc
@@ -21,7 +21,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  LimiterView<dim, double>::Parameters limiter(hyperbolic_system);
+  Limiter<double> limiter(hyperbolic_system);
 
   using state_type = HyperbolicSystemView<dim, double>::state_type;
 

--- a/tests/euler_barotropic/wave_speed_estimator.cc
+++ b/tests/euler_barotropic/wave_speed_estimator.cc
@@ -17,8 +17,7 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
-      hyperbolic_system);
+  WaveSpeedEstimator<double> wave_speed_estimator(hyperbolic_system);
 
   const auto wave_speed_estimator_view =
       wave_speed_estimator.view<dim, double>();

--- a/tests/euler_barotropic/wave_speed_estimator.cc
+++ b/tests/euler_barotropic/wave_speed_estimator.cc
@@ -19,14 +19,8 @@ int main()
   HyperbolicSystem hyperbolic_system;
   WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
-      hyperbolic_system, wave_speed_estimator, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
+                                                        wave_speed_estimator);
 
   const auto view = hyperbolic_system.view<dim, double>();
 

--- a/tests/euler_barotropic/wave_speed_estimator.cc
+++ b/tests/euler_barotropic/wave_speed_estimator.cc
@@ -17,10 +17,11 @@ int main()
   constexpr int dim = 1;
 
   HyperbolicSystem hyperbolic_system;
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
+      hyperbolic_system);
 
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
-                                                        wave_speed_estimator);
+  const auto wave_speed_estimator_view =
+      wave_speed_estimator.view<dim, double>();
 
   const auto view = hyperbolic_system.view<dim, double>();
 

--- a/tests/scalar_conservation/wave_speed_estimator.cc
+++ b/tests/scalar_conservation/wave_speed_estimator.cc
@@ -22,7 +22,8 @@ void test(const std::string &expression)
   std::cout << std::scientific;
 
   HyperbolicSystem hyperbolic_system;
-  typename WaveSpeedEstimatorView<dim, Number>::Parameters wave_speed_estimator;
+  typename WaveSpeedEstimatorView<dim, Number>::Parameters wave_speed_estimator(
+      hyperbolic_system);
 
   const auto view = hyperbolic_system.view<dim, Number>();
 
@@ -43,8 +44,8 @@ void test(const std::string &expression)
   using state_type = typename View::state_type;
   using precomputed_type = typename View::precomputed_type;
   static constexpr auto n_precomputed_values = View::n_precomputed_values;
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
-                                                        wave_speed_estimator);
+  const auto wave_speed_estimator_view =
+      wave_speed_estimator.template view<dim, Number>();
 
   std::cout << "\n\ndim = " << dim << std::endl;
   std::cout << "f(u)={" + expression + "}" << std::endl;

--- a/tests/scalar_conservation/wave_speed_estimator.cc
+++ b/tests/scalar_conservation/wave_speed_estimator.cc
@@ -22,8 +22,7 @@ void test(const std::string &expression)
   std::cout << std::scientific;
 
   HyperbolicSystem hyperbolic_system;
-  typename WaveSpeedEstimatorView<dim, Number>::Parameters wave_speed_estimator(
-      hyperbolic_system);
+  WaveSpeedEstimator<> wave_speed_estimator(hyperbolic_system);
 
   const auto view = hyperbolic_system.view<dim, Number>();
 

--- a/tests/scalar_conservation/wave_speed_estimator.cc
+++ b/tests/scalar_conservation/wave_speed_estimator.cc
@@ -43,12 +43,8 @@ void test(const std::string &expression)
   using state_type = typename View::state_type;
   using precomputed_type = typename View::precomputed_type;
   static constexpr auto n_precomputed_values = View::n_precomputed_values;
-  using PrecomputedVector = typename View::PrecomputedVector;
-
-  PrecomputedVector dummy;
-
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
-      hyperbolic_system, wave_speed_estimator, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
+                                                        wave_speed_estimator);
 
   std::cout << "\n\ndim = " << dim << std::endl;
   std::cout << "f(u)={" + expression + "}" << std::endl;

--- a/tests/shallow_water/wave_speed_estimator.cc
+++ b/tests/shallow_water/wave_speed_estimator.cc
@@ -19,10 +19,11 @@ int main()
   HyperbolicSystem hyperbolic_system;
   const double gravity = hyperbolic_system.view<dim, double>().gravity();
 
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
+  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
+      hyperbolic_system);
 
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
-                                                        wave_speed_estimator);
+  const auto wave_speed_estimator_view =
+      wave_speed_estimator.view<dim, double>();
 
   const auto riemann_data = [&](const auto &state) {
     const auto h = hyperbolic_system.view<dim, double>().water_depth_sharp(

--- a/tests/shallow_water/wave_speed_estimator.cc
+++ b/tests/shallow_water/wave_speed_estimator.cc
@@ -21,14 +21,8 @@ int main()
 
   WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator;
 
-  static constexpr unsigned int n_precomputed_values =
-      HyperbolicSystemView<dim, double>::n_precomputed_values;
-  using precomputed_type =
-      Vectors::MultiComponentVector<double, n_precomputed_values>;
-  precomputed_type dummy;
-
-  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(
-      hyperbolic_system, wave_speed_estimator, dummy);
+  WaveSpeedEstimatorView<dim> wave_speed_estimator_view(hyperbolic_system,
+                                                        wave_speed_estimator);
 
   const auto riemann_data = [&](const auto &state) {
     const auto h = hyperbolic_system.view<dim, double>().water_depth_sharp(

--- a/tests/shallow_water/wave_speed_estimator.cc
+++ b/tests/shallow_water/wave_speed_estimator.cc
@@ -19,8 +19,7 @@ int main()
   HyperbolicSystem hyperbolic_system;
   const double gravity = hyperbolic_system.view<dim, double>().gravity();
 
-  WaveSpeedEstimatorView<dim, double>::Parameters wave_speed_estimator(
-      hyperbolic_system);
+  WaveSpeedEstimator<double> wave_speed_estimator(hyperbolic_system);
 
   const auto wave_speed_estimator_view =
       wave_speed_estimator.view<dim, double>();


### PR DESCRIPTION
This is a lot of "code churn", but I think the end result is much cleaner.

- Euler: switch flux_contribution() and nodal_source() over to views
- HyperbolicModule: follow the Indicator, Limiter and WaveSpeedEstimator change
- SolutionTransfer: apply the Limiter change
- Euler: switch Indicator, Limiter and WaveSpeedEstimator over to views
- EulerAEOS: apply the precomputed vector view refactoring
- EulerBarotropic: apply the precomputed vector view refactoring
- ScalarConservation: apply the precomputed vector view refactoring
- ShallowWater: apply the precomputed vector view refactoring
- Skeleton: apply the precomputed vector view refactoring
- Tests: apply the Limiter and WaveSpeedEstimator change
- HyperbolicModule, SolutionTransfer: use the new Indicator, Limiter and WaveSpeedEstimator view() accessors
- Euler: add a view() accessor to Indicator, Limiter and WaveSpeedEstimator
- EulerAEOS: add a view() accessor to Indicator, Limiter and WaveSpeedEstimator
- EulerBarotropic: add a view() accessor to Indicator, Limiter and WaveSpeedEstimator
- ScalarConservation: add a view() accessor to Indicator, Limiter and WaveSpeedEstimator
- ShallowWater: add a view() accessor to Indicator, Limiter and WaveSpeedEstimator
- Skeleton: add a view() accessor to Indicator, Limiter and WaveSpeedEstimator
- Modules: name equation classes and views through the base classes
- Euler: export the equation base classes from Description
- EulerAEOS: export the equation base classes from Description
- EulerBarotropic: export the equation base classes from Description
- ScalarConservation: export the equation base classes from Description
- ShallowWater: export the equation base classes from Description
- Skeleton: export the equation base classes from Description
- EulerPoisson, NavierStokes: follow the Description change
- */*: rename the parameters member to the lowercase class name
- */*: append a trailing underscore to all class fields
- */*: drop the now unnecessary new_ prefix of reset() arguments
