### PR TITLE
GPU Support: make simd.h interface usable on device

### DIFF
--- a/source/convenience_macros.h
+++ b/source/convenience_macros.h
@@ -144,7 +144,7 @@ namespace ryujin
             int problem_dim = FT::dimension,
             typename TT = typename FT::value_type,
             typename T = typename TT::value_type>
-  DEAL_II_ALWAYS_INLINE inline dealii::Tensor<1, problem_dim, T>
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE dealii::Tensor<1, problem_dim, T>
   contract(const FT &flux_ij, const TT &c_ij)
   {
     dealii::Tensor<1, problem_dim, T> result;
@@ -158,8 +158,8 @@ namespace ryujin
    * Add two given rank-2 tensors flux_left_ij and flux_right_ij:
    */
   template <typename FT, int problem_dim = FT::dimension>
-  DEAL_II_ALWAYS_INLINE inline FT add(const FT &flux_left_ij,
-                                      const FT &flux_right_ij)
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE FT add(const FT &flux_left_ij,
+                                           const FT &flux_right_ij)
   {
     FT result;
     for (unsigned int k = 0; k < problem_dim; ++k)

--- a/source/newton.h
+++ b/source/newton.h
@@ -35,7 +35,7 @@ namespace ryujin
    * @ingroup Miscellaneous
    */
   template <typename Number>
-  DEAL_II_ALWAYS_INLINE inline void
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE void
   quadratic_newton_step(Number &p_1,
                         Number &p_2,
                         const Number phi_p_1,
@@ -71,14 +71,14 @@ namespace ryujin
     /* Make sure we do not produce NaNs: */
 
     auto t_1 =
-        p_1 - dealii::compare_and_apply_mask<dealii::SIMDComparison::less_than>(
+        p_1 - ryujin::compare_and_apply_mask<dealii::SIMDComparison::less_than>(
                   std::abs(denominator_1),
                   Number(eps),
                   Number(0.),
                   ScalarNumber(2.) * phi_p_1 / denominator_1);
 
     auto t_2 =
-        p_2 - dealii::compare_and_apply_mask<dealii::SIMDComparison::less_than>(
+        p_2 - ryujin::compare_and_apply_mask<dealii::SIMDComparison::less_than>(
                   std::abs(denominator_2),
                   Number(eps),
                   Number(0.),

--- a/source/simd.h
+++ b/source/simd.h
@@ -143,7 +143,7 @@ namespace ryujin
    * @ingroup SIMD
    */
   template <typename Number>
-  inline DEAL_II_ALWAYS_INLINE Number positive_part(const Number number)
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE Number positive_part(const Number number)
   {
     return std::max(Number(0.), number);
   }
@@ -155,9 +155,62 @@ namespace ryujin
    * @ingroup SIMD
    */
   template <typename Number>
-  inline DEAL_II_ALWAYS_INLINE Number negative_part(const Number number)
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE Number negative_part(const Number number)
   {
     return -std::min(Number(0.), number);
+  }
+
+
+  /**
+   * A wrapper around dealii::compare_and_apply_mask() for scalar number
+   * types that is annotated with DEAL_II_HOST_DEVICE so that it can be
+   * used in device code.
+   *
+   * @ingroup SIMD
+   */
+  template <dealii::SIMDComparison predicate, typename Number>
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE Number
+  compare_and_apply_mask(const Number &left,
+                         const Number &right,
+                         const Number &true_value,
+                         const Number &false_value)
+  {
+    static_assert(std::is_floating_point_v<Number>,
+                  "Only scalar number types are allowed");
+
+    bool mask = false;
+    if constexpr (predicate == dealii::SIMDComparison::equal)
+      mask = (left == right);
+    else if constexpr (predicate == dealii::SIMDComparison::not_equal)
+      mask = (left != right);
+    else if constexpr (predicate == dealii::SIMDComparison::less_than)
+      mask = (left < right);
+    else if constexpr (predicate == dealii::SIMDComparison::less_than_or_equal)
+      mask = (left <= right);
+    else if constexpr (predicate == dealii::SIMDComparison::greater_than)
+      mask = (left > right);
+    else
+      mask = (left >= right);
+
+    return mask ? true_value : false_value;
+  }
+
+
+  /**
+   * Variant of above function for VectorizedArray that simply forwards to
+   * the dealii::compare_and_apply_mask() implementation. (Host only.)
+   *
+   * @ingroup SIMD
+   */
+  template <dealii::SIMDComparison predicate, typename T, std::size_t width>
+  DEAL_II_ALWAYS_INLINE inline dealii::VectorizedArray<T, width>
+  compare_and_apply_mask(const dealii::VectorizedArray<T, width> &left,
+                         const dealii::VectorizedArray<T, width> &right,
+                         const dealii::VectorizedArray<T, width> &true_value,
+                         const dealii::VectorizedArray<T, width> &false_value)
+  {
+    return dealii::compare_and_apply_mask<predicate>(
+        left, right, true_value, false_value);
   }
 
 
@@ -169,7 +222,7 @@ namespace ryujin
    * @ingroup SIMD
    */
   template <int N, typename T>
-  inline T fixed_power(const T x)
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE T fixed_power(const T x)
   {
     return dealii::Utilities::fixed_power<N, T>(x);
   }

--- a/source/simd.h
+++ b/source/simd.h
@@ -11,6 +11,8 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/vectorization.h>
 
+#include <cmath>
+
 
 /**
  * @name Exception handling in SIMD context
@@ -234,7 +236,7 @@ namespace ryujin
    * @ingroup SIMD
    */
   template <typename T>
-  T pow(const T x, const T b);
+  DEAL_II_HOST_DEVICE T pow(const T x, const T b);
 
 
   /**
@@ -259,6 +261,40 @@ namespace ryujin
       const dealii::VectorizedArray<T, width> b);
 
 
+  template <>
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE float pow(const float x, const float b)
+  {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) ||               \
+    defined(__SYCL_DEVICE_ONLY__)
+    /* Call generic std::pow() implementation: */
+    return std::pow(x, b);
+#elif DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
+    /* Use a custom pow implementation instead of std::pow(): */
+    return pow(dealii::VectorizedArray<float, 4>(x), b)[0];
+#else
+    /* Call generic std::pow() implementation: */
+    return std::pow(x, b);
+#endif
+  }
+
+
+  template <>
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE double pow(const double x, const double b)
+  {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) ||               \
+    defined(__SYCL_DEVICE_ONLY__)
+    /* Call generic std::pow() implementation */
+    return std::pow(x, b);
+#elif DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
+    /* Use a custom pow implementation instead of std::pow(): */
+    return pow(dealii::VectorizedArray<double, 2>(x), b)[0];
+#else
+    /* Call generic std::pow() implementation */
+    return std::pow(x, b);
+#endif
+  }
+
+
   /**
    * Controls the bias of the fast_pow() functions.
    */
@@ -269,14 +305,12 @@ namespace ryujin
     none,
 
     /**
-     * Guarantee an upper bound, i.e., fast_pow(x,b) >= pow(x,b) provided
-     * that FIXME
+     * Guarantee an upper bound, i.e., fast_pow(x,b) >= pow(x,b).
      */
     max,
 
     /**
-     * Guarantee a lower bound, i.e., fast_pow(x,b) >= pow(x,b) provided
-     * that FIXME
+     * Guarantee a lower bound, i.e., fast_pow(x,b) >= pow(x,b).
      */
     min
   };

--- a/source/simd.h
+++ b/source/simd.h
@@ -322,7 +322,9 @@ namespace ryujin
    * @ingroup SIMD
    */
   template <typename T>
-  T fast_pow(const T x, const T b, const Bias bias = Bias::none);
+  DEAL_II_HOST_DEVICE T fast_pow(const T x,
+                                 const T b,
+                                 const Bias bias = Bias::none);
 
 
   /**
@@ -348,6 +350,42 @@ namespace ryujin
   fast_pow(const dealii::VectorizedArray<T, width> x,
            const dealii::VectorizedArray<T, width> b,
            const Bias bias = Bias::none);
+
+
+  template <>
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE float
+  fast_pow(const float x, const float b, [[maybe_unused]] const Bias bias)
+  {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) ||               \
+    defined(__SYCL_DEVICE_ONLY__)
+    /* Call generic std::pow() implementation */
+    return std::pow(x, b);
+#elif DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
+    /* Use a custom fast_pow implementation instead of std::pow(): */
+    return fast_pow(dealii::VectorizedArray<float, 4>(x), b, bias)[0];
+#else
+    /* Call generic std::pow() implementation */
+    return std::pow(x, b);
+#endif
+  }
+
+
+  template <>
+  DEAL_II_HOST_DEVICE_ALWAYS_INLINE double
+  fast_pow(const double x, const double b, [[maybe_unused]] const Bias bias)
+  {
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) ||               \
+    defined(__SYCL_DEVICE_ONLY__)
+    /* Call generic std::pow() implementation (in single precision) */
+    return std::pow(static_cast<float>(x), static_cast<float>(b));
+#elif DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
+    /* Use a custom fast_pow implementation instead of std::pow(): */
+    return fast_pow(dealii::VectorizedArray<double, 2>(x), b, bias)[0];
+#else
+    /* Call generic std::pow() implementation (in single precision) */
+    return std::pow(static_cast<float>(x), static_cast<float>(b));
+#endif
+  }
 
   //@}
   /**

--- a/source/simd.template.h
+++ b/source/simd.template.h
@@ -194,24 +194,6 @@ namespace ryujin
    ****************************************************************************/
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
-  template <>
-  // DEAL_II_ALWAYS_INLINE inline
-  float pow(const float x, const float b)
-  {
-    /* Use a custom pow implementation instead of std::pow(): */
-    return vcl::pow(vcl::Vec4f(x), b).extract(0);
-  }
-
-
-  template <>
-  // DEAL_II_ALWAYS_INLINE inline
-  double pow(const double x, const double b)
-  {
-    /* Use a custom pow implementation instead of std::pow(): */
-    return vcl::pow(vcl::Vec2d(x), b).extract(0);
-  }
-
-
   template <typename T, std::size_t width>
   // DEAL_II_ALWAYS_INLINE inline
   dealii::VectorizedArray<T, width>
@@ -231,24 +213,6 @@ namespace ryujin
   }
 
 #else
-
-  template <>
-  // DEAL_II_ALWAYS_INLINE inline
-  float pow(const float x, const float b)
-  {
-    // Call generic std::pow() implementation
-    return std::pow(x, b);
-  }
-
-
-  template <>
-  // DEAL_II_ALWAYS_INLINE inline
-  double pow(const double x, const double b)
-  {
-    // Call generic std::pow() implementation
-    return std::pow(x, b);
-  }
-
 
   template <typename T, std::size_t width>
   // DEAL_II_ALWAYS_INLINE inline

--- a/source/simd.template.h
+++ b/source/simd.template.h
@@ -241,24 +241,6 @@ namespace ryujin
    ****************************************************************************/
 
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)
-  template <>
-  // DEAL_II_ALWAYS_INLINE inline
-  float fast_pow(const float x, const float b, const Bias bias)
-  {
-    /* Use a custom pow implementation instead of std::pow(): */
-    return fast_pow_impl(vcl::Vec4f(x), vcl::Vec4f(b), bias).extract(0);
-  }
-
-
-  template <>
-  // DEAL_II_ALWAYS_INLINE inline
-  double fast_pow(const double x, const double b, const Bias bias)
-  {
-    /* Use a custom pow implementation instead of std::pow(): */
-    return fast_pow_impl(vcl::Vec4f(x), vcl::Vec4f(b), bias).extract(0);
-  }
-
-
   template <typename T, std::size_t width>
   // DEAL_II_ALWAYS_INLINE inline
   dealii::VectorizedArray<T, width> fast_pow(
@@ -284,24 +266,6 @@ namespace ryujin
   }
 
 #else
-
-  template <>
-  // DEAL_II_ALWAYS_INLINE inline
-  float fast_pow(const float x, const float b, const Bias)
-  {
-    // Call generic std::pow() implementation
-    return std::pow(x, b);
-  }
-
-
-  template <>
-  // DEAL_II_ALWAYS_INLINE inline
-  double fast_pow(const double x, const double b, const Bias)
-  {
-    // Call generic std::pow() implementation
-    return std::pow(static_cast<float>(x), static_cast<float>(b));
-  }
-
 
   template <typename T, std::size_t width>
   // DEAL_II_ALWAYS_INLINE inline


### PR DESCRIPTION
This pull request makes most of the helper functions such as
`ryujin::positive_part`, `ryujin::pow`, `ryujin::fast_pow` available and
callable in device code.

Extracted and refactored from #332
